### PR TITLE
Drop LLVM 3.8, Add LLVM 5.0, update 4.00 -> 4.01

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -116,10 +116,10 @@ all_repositories = {
     r'http://llvm.org/svn/llvm-project/cfe/trunk' : 'clang-trunk',
     r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_391/final' : 'llvm-391',
     r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_391/final' : 'clang-391',
-    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_381/final' : 'llvm-381',
-    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_381/final' : 'clang-381',
-    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_400/final' : 'llvm-400',
-    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_400/final' : 'clang-400',
+    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_401/final' : 'llvm-401',
+    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_401/final' : 'clang-401',
+    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_500/final' : 'llvm-500',
+    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_500/final' : 'clang-500',
 }
 
 def codebase_generator(chdict):
@@ -659,20 +659,20 @@ for gcc in ['gcc48', 'gcc49', 'gcc51', 'gcc52', 'gcc53']:
     create_builder('linux-64-' + gcc, 'trunk')
 
 create_builder('linux-32-gcc53', '391')
-create_builder('linux-32-gcc53', '381')
-create_builder('linux-32-gcc53', '400')
+create_builder('linux-32-gcc53', '401')
+create_builder('linux-32-gcc53', '500')
 create_builder('linux-64-gcc53', '391')
-create_builder('linux-64-gcc53', '381')
-create_builder('linux-64-gcc53', '400')
+create_builder('linux-64-gcc53', '401')
+create_builder('linux-64-gcc53', '500')
 
 create_builder('mac-32', 'trunk')
 create_builder('mac-32', '391')
-create_builder('mac-32', '381')
-create_builder('mac-32', '400')
+create_builder('mac-32', '401')
+create_builder('mac-32', '500')
 create_builder('mac-64', 'trunk')
 create_builder('mac-64', '391')
-create_builder('mac-64', '381')
-create_builder('mac-64', '400')
+create_builder('mac-64', '401')
+create_builder('mac-64', '500')
 create_builder('win-32', 'trunk')
 create_builder('win-64', 'trunk')
 create_builder('win-32-distro', 'trunk')
@@ -680,17 +680,17 @@ create_builder('win-64-distro', 'trunk')
 create_builder('mingw-64', 'trunk')
 
 # Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.
-create_builder('win-64-testbranch', '400')
-create_builder('win-32-testbranch', '400')
-create_builder('mac-64-testbranch', '400')
-create_builder('mac-32-testbranch', '400')
-create_builder('linux-64-gcc53-testbranch', '400')
-create_builder('linux-32-gcc53-testbranch', '400')
-create_builder('mingw-64-testbranch', '400')
-create_builder('arm64-linux-64-testbranch', '400')
-create_builder('arm32-linux-32-testbranch', '400')
+create_builder('win-64-testbranch', '401')
+create_builder('win-32-testbranch', '401')
+create_builder('mac-64-testbranch', '401')
+create_builder('mac-32-testbranch', '401')
+create_builder('linux-64-gcc53-testbranch', '401')
+create_builder('linux-32-gcc53-testbranch', '401')
+create_builder('mingw-64-testbranch', '401')
+create_builder('arm64-linux-64-testbranch', '401')
+create_builder('arm32-linux-32-testbranch', '401')
 # Check for build breakages against other llvm versions too
-create_builder('linux-64-gcc53-testbranch', '381')
+create_builder('linux-64-gcc53-testbranch', '500')
 create_builder('linux-64-gcc53-testbranch', 'trunk')
 
 # Don't try to build every single commit
@@ -720,8 +720,8 @@ c['collapseRequests'] = collapseRequests
 
 c['schedulers'] = []
 create_scheduler('trunk')
-create_scheduler('400')
-create_scheduler('381')
+create_scheduler('500')
+create_scheduler('401')
 create_scheduler('391')
 
 # Create a scheduler to force a test of a branch
@@ -730,10 +730,10 @@ scheduler = ForceScheduler(
   name = 'testbranch',
   builderNames = builders,
   codebases = ['halide',
-               'llvm-381',
-               'clang-381',
-               'llvm-400',
-               'clang-400',
+               'llvm-500',
+               'clang-500',
+               'llvm-401',
+               'clang-401',
                'llvm-trunk',
                'clang-trunk'])
 c['schedulers'].append(scheduler)
@@ -749,9 +749,9 @@ def prioritize_builders(master, builders):
     # 32-bit is also less important than getting immediate feedback on 64-bit.
     if '-32' in builder.name: return 5
     # Order llvm versions by age
-    if '381' in builder.name: return 4
-    if '391' in builder.name: return 3
-    if '400' in builder.name: return 2
+    if '391' in builder.name: return 4
+    if '401' in builder.name: return 3
+    if '500' in builder.name: return 2
     # These builders are the highest priority
     if 'testbranch' in builder.name: return 0
     return 1


### PR DESCRIPTION
Buildbot should be testing against now-final 5.00, and shouldn't be testing against the soon-to-be-dropped-by-us 3.8. Also, update 4.00 to 4.01.