### PR TITLE
Add -Thost=x64 for MSVC builders

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -464,6 +464,10 @@ def create_win_factory(os, llvm):
       factory.addStep(RemoveDirectory(dir = 'llvm-install-' + config, haltOnFailure = False))
     factory.addStep(MakeDirectory(dir = 'llvm-install-' + config, haltOnFailure = False))
 
+    # '-Thost=x64' means 'Use 64-bit host compilers', which generally provides
+    # better compile/link times (esp. for LLVM); be aware that in addition to
+    # 64-bit OS + MSVC install, it requires CMake 3.8+ (earlier versions will
+    # fail with obscure and misleading errors if you specify this flag).
     factory.addStep(
       ShellCommand(name = 'Configure LLVM',
                    description = 'Configure LLVM',
@@ -471,6 +475,7 @@ def create_win_factory(os, llvm):
                    workdir = 'llvm-build-' + config,
                    haltOnFailure = True,
                    command = ['cmake',
+                              '-Thost=x64',
                               '-DCMAKE_INSTALL_PREFIX=../llvm-install-' + config,
                               '-DLLVM_ENABLE_TERMINFO=OFF',
                               '-DLLVM_TARGETS_TO_BUILD=X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC',
@@ -500,6 +505,7 @@ def create_win_factory(os, llvm):
                    workdir = 'halide-build-' + config,
                    haltOnFailure = True,
                    command = ['cmake',
+                              '-Thost=x64',
                                Interpolate('-DLLVM_DIR=%(prop:builddir)s\\llvm-install-' + config + '\\lib\\cmake\\llvm'),
                                '-DLLVM_VERSION=' + llvm_version,
                                '-DCMAKE_BUILD_TYPE=' + config,


### PR DESCRIPTION
This forces the use of 64-bit tools for compile/link, which improves compile/link times (esp for LLVM). Requires CMake 3.8+ to be installed to work properly.

Please note that I have tested this flag locally but have not tested this buildbot change.