### PR TITLE
Enable metal validation on mac buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -285,6 +285,10 @@ def get_env(os):
       env['HL_HEXAGON_TOOLS'] = '/usr/local/hexagon'
       env['HL_HEXAGON_SIM_REMOTE'] = '${PWD}/worker/' + os + '-trunk/halide/src/runtime/hexagon_remote/bin/v60/hexagon_sim_remote'
       env['HL_HEXAGON_SIM_CYCLES'] = '1'
+  elif os.startswith('mac'):
+      # Environment variable for turning on Metal API validation
+      # This will have no effect on CPU testing, just Metal testing
+      env['METAL_DEVICE_WRAPPER_TYPE'] = '1'
 
   return env
 


### PR DESCRIPTION
This should catch subtle correctness bugs with our use of Metal.