### PR TITLE
Use 'minimal' verbosity in MSVC builds to cut down on MSVC build log …

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -497,6 +497,7 @@ def create_win_factory(os, llvm):
                               '/m:16',
                               '/t:Build',
                               '/p:Configuration=' + config,
+                              '/v:m',
                               '.\\INSTALL.vcxproj']))
 
     factory.addStep(
@@ -523,6 +524,7 @@ def create_win_factory(os, llvm):
                               '/m:16',
                               '/t:Build',
                               '/p:Configuration=' + config,
+                              '/v:m',
                               '.\\ALL_BUILD.vcxproj']))
 
 
@@ -584,6 +586,7 @@ def create_win_factory(os, llvm):
                                   '/m:16',
                                   '/t:Build',
                                   '/p:Configuration=Release',
+                                  '/v:m',
                                   '.\\test_' + testgroup + '.vcxproj']))
 
       # TODO: add 'tutorial' to this testgroup (requires libjpeg, libpng, etc)
@@ -598,6 +601,7 @@ def create_win_factory(os, llvm):
                        command = ['MSBuild.exe',
                                   '/t:Build',
                                   '/p:Configuration=Release',
+                                  '/v:m',
                                   '.\\test_' + testgroup + '.vcxproj']))
 
   return factory


### PR DESCRIPTION
…size

Default verbosity includes a lot of noise, most of which isn't useful for actual debugging of problems.