### PR TITLE
Skip OpenCL test on Windows buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -324,8 +324,6 @@ def get_targets(os, llvm):
     targets.extend([('test_apps', 'host'),
                     ('test_tutorial', 'host')])
 
-    test_metal = os.startswith('mac')
-
     if os.startswith('linux-64-gcc53') or os.startswith('mingw'):
       # The linux and mingw build-bots have an nvidia card
       targets.extend([('test_correctness', 'host-cuda'),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -314,43 +314,43 @@ def get_targets(os, llvm):
     # Also test without sse 4.1
     targets.append(('test_correctness', 'x86-32'))
 
-  if os.startswith('linux-64-gcc53') or os.startswith('mingw-64') or os.startswith('mac-64'):
+  if os.startswith('linux-64-gcc53') or os.startswith('mac-64'):
     # extended cpu/gpu tests
-    if not os.startswith('mingw'):
-      targets.extend([('test_correctness', 'x86-64'),
-                      ('test_correctness', 'x86-64-sse41'),
-                      ('test_python', 'host')])
+    targets.extend([('test_correctness', 'x86-64'),
+                    ('test_correctness', 'x86-64-sse41'),
+                    ('test_python', 'host')])
 
+  if os.startswith('linux-64-gcc53') or os.startswith('mingw-64') or os.startswith('mac-64'):
     targets.extend([('test_apps', 'host'),
                     ('test_tutorial', 'host')])
 
-    if os.startswith('linux-64-gcc53') or os.startswith('mingw'):
-      # The linux and mingw build-bots have an nvidia card
-      targets.extend([('test_correctness', 'host-cuda'),
-                      ('test_generator', 'host-cuda'),
-                      ('test_apps', 'host-cuda')])
+  if os.startswith('linux-64-gcc53') or os.startswith('mingw-64'):
+    # The linux and mingw build-bots have an nvidia card
+    targets.extend([('test_correctness', 'host-cuda'),
+                    ('test_generator', 'host-cuda'),
+                    ('test_apps', 'host-cuda')])
 
-    if os.startswith('linux-64-gcc53'):
-      # OpenCL is extremely flaky on Windows buildbots, in part
-      # because Windows updates tend to break the driver (requiring
-      # manual reinstalls); only test on Linux for now.
-      targets.extend([('test_correctness', 'host-opencl'),
-                      ('test_generator', 'host-opencl'),
-                      ('test_apps', 'host-opencl'),
-                      ('correctness_gpu_multi_device', 'host-cuda-opencl')])
+  if os.startswith('linux-64-gcc53'):
+    # OpenCL is extremely flaky on Windows buildbots, in part
+    # because Windows updates tend to break the driver (requiring
+    # manual reinstalls); only test on Linux for now, not mingw.
+    targets.extend([('test_correctness', 'host-opencl'),
+                    ('test_generator', 'host-opencl'),
+                    ('test_apps', 'host-opencl'),
+                    ('correctness_gpu_multi_device', 'host-cuda-opencl')])
 
-    if os.startswith('mac'):
-      # test metal on OS X
-      targets.extend([('test_correctness', 'host-metal'),
-                      ('test_generator', 'host-metal'),
-                      ('test_apps', 'host-metal')])
+  if os.startswith('mac-64'):
+    # test metal on OS X
+    targets.extend([('test_correctness', 'host-metal'),
+                    ('test_generator', 'host-metal'),
+                    ('test_apps', 'host-metal')])
 
-    if os.startswith('linux-64-gcc53') and llvm == 'trunk':
-      # Also test hexagon using the simulator
-      for t in ['host-hvx_128', 'host-hvx_64']:
-        targets.extend([('test_correctness', t),
-                        ('test_generator', t),
-                        ('test_apps', t)])
+  if os.startswith('linux-64-gcc53') and llvm == 'trunk':
+    # Also test hexagon using the simulator
+    for t in ['host-hvx_128', 'host-hvx_64']:
+      targets.extend([('test_correctness', t),
+                      ('test_generator', t),
+                      ('test_apps', t)])
 
   # Also run Bazel tests, but only on linux-64 targets for now.
   # TODO: install & test Bazel on OSX and Windows builders in the future.

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -324,17 +324,24 @@ def get_targets(os, llvm):
     targets.extend([('test_apps', 'host'),
                     ('test_tutorial', 'host')])
 
-    if not os.startswith('mac'):
-      # The linux and mingw build-bot has an nvidia card
+    test_metal = os.startswith('mac')
+
+    if os.startswith('linux-64-gcc53') or os.startswith('mingw'):
+      # The linux and mingw build-bots have an nvidia card
       targets.extend([('test_correctness', 'host-cuda'),
                       ('test_generator', 'host-cuda'),
-                      ('test_apps', 'host-cuda'),
-                      ('test_correctness', 'host-opencl'),
+                      ('test_apps', 'host-cuda')])
+
+    if os.startswith('linux-64-gcc53'):
+      # OpenCL is extremely flaky on Windows buildbots, in part
+      # because Windows updates tend to break the driver (requiring
+      # manual reinstalls); only test on Linux for now.
+      targets.extend([('test_correctness', 'host-opencl'),
                       ('test_generator', 'host-opencl'),
                       ('test_apps', 'host-opencl'),
                       ('correctness_gpu_multi_device', 'host-cuda-opencl')])
 
-    else:
+    if os.startswith('mac'):
       # test metal on OS X
       targets.extend([('test_correctness', 'host-metal'),
                       ('test_generator', 'host-metal'),
@@ -570,7 +577,10 @@ def create_win_factory(os, llvm):
   else:
     # Run the tests
     env = {}
-    for hl_target in ['host', 'host-opencl', 'host-cuda']:
+    # OpenCL is extremely flaky on Windows buildbots, in part
+    # because Windows updates tend to break the driver (requiring
+    # manual reinstalls). Disabling for now.
+    for hl_target in ['host', 'host-cuda']:
       target_env = env.copy()
       target_env['HL_TARGET'] = hl_target
       target_env['HL_JIT_TARGET'] = hl_target


### PR DESCRIPTION
Windows updates like to break the OpenCL driver. Just skip OpenCL testing on Windows hardware for now to avoid misleading failures.