### PR TITLE
 Add PyBind11 support to buildbot

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -444,11 +444,6 @@ def create_win_factory(os, llvm):
   factory = BuildFactory()
   add_get_source_steps(factory, llvm)
 
-  if llvm == 'trunk':
-    llvm_version = '50'
-  else:
-    llvm_version = llvm[0:2]
-
   # Configure llvm
   if '-32' in os:
     build_32_bits = 'ON'
@@ -519,7 +514,6 @@ def create_win_factory(os, llvm):
                    haltOnFailure = True,
                    command = ['cmake',
                                Interpolate('-DLLVM_DIR=%(prop:builddir)s\\llvm-install-' + config + '\\lib\\cmake\\llvm'),
-                               '-DLLVM_VERSION=' + llvm_version,
                                '-DCMAKE_BUILD_TYPE=' + config,
                                '-Thost=x64',
                                '-G',

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -192,6 +192,15 @@ def add_get_source_steps(factory, llvm):
                       repourl = r'http://llvm.org/svn/llvm-project/cfe/%s' % llvm_svn_path,
                       mode = 'incremental'))
 
+  # PyBind11 is a header-only library: we don't need to build it, we just need to pull it
+  factory.addStep(Git(name = 'Get PyBind11',
+                      locks = [performance_lock.access('counting')],
+                      codebase = 'pybind11',
+                      workdir = 'pybind11',
+                      repourl = 'git://github.com/pybind/pybind11.git',
+                      branch = 'v2.2',
+                      mode = 'incremental'))
+
 @renderer
 def get_distrib_name(props):
   rev = props.getProperty('got_revision')['halide']
@@ -236,7 +245,8 @@ def get_llvm_cmake_command(os):
 
 def get_env(os):
   env = {'LLVM_CONFIG': '../llvm-build/bin/llvm-config',
-         'CLANG': '../llvm-build/bin/clang'}
+         'CLANG': '../llvm-build/bin/clang',
+         'PYBIND11_PATH': '../pybind11'}
 
   cxx = 'c++'
   cc = 'cc'


### PR DESCRIPTION
Some upcoming changes need PyBind11 to be available for python-binding testing; this modifies the buildbot to install PyBind11 on the build machine and point the PYBIND11_PATH env var at it. (Note that PyBind11 is a header-only template library, so no build step is necessary.)

Also, drive-by removal of long-unnecessary LLVM_VERSION cruft.