### PR TITLE
Run test_python2 as well as test_python

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -342,7 +342,8 @@ def get_targets(os, llvm):
     # extended cpu/gpu tests
     targets.extend([('test_correctness', 'x86-64'),
                     ('test_correctness', 'x86-64-sse41'),
-                    ('test_python', 'host')])
+                    ('test_python', 'host'),
+                    ('test_python2', 'host')])
 
   if os.startswith('linux-64-gcc53') or os.startswith('mingw-64') or os.startswith('mac-64'):
     targets.extend([('test_apps', 'host'),


### PR DESCRIPTION
Ensures that both python 2.x and python 3.x builds are tested