### PR TITLE
Enable d3d12compute on windows build bot

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -366,7 +366,7 @@ def get_targets(os, llvm):
                     ('test_generator', 'host-metal'),
                     ('test_apps', 'host-metal')])
 
-  if os.startswith('mingw-64'):
+  if os.startswith('mingw-64') or os.startswith('win-64'):
     # test d3d12 on windows
     targets.extend([('test_correctness', 'host-d3d12compute'),
                     ('test_generator', 'host-d3d12compute'),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -366,6 +366,12 @@ def get_targets(os, llvm):
                     ('test_generator', 'host-metal'),
                     ('test_apps', 'host-metal')])
 
+  if os.startswith('mingw-64'):
+    # test d3d12 on windows
+    targets.extend([('test_correctness', 'host-d3d12compute'),
+                    ('test_generator', 'host-d3d12compute'),
+                    ('test_apps', 'host-d3d12compute')]
+
   if os.startswith('linux-64-gcc53') and llvm == 'trunk':
     # Also test hexagon using the simulator
     for t in ['host-hvx_128', 'host-hvx_64']:


### PR DESCRIPTION
This should not be added to master until https://github.com/halide/Halide/pull/2755 is accepted, but opening a PR so it can go smoothly once the d3d12compute backend is enabled.