### PR TITLE
Buildbot: drop LLVM4, add LLVM6

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -125,8 +125,8 @@ all_repositories = {
     u'https://github.com/halide/Halide.git' : 'halide',
     r'http://llvm.org/svn/llvm-project/llvm/trunk' : 'llvm-trunk',
     r'http://llvm.org/svn/llvm-project/cfe/trunk' : 'clang-trunk',
-    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_401/final' : 'llvm-401',
-    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_401/final' : 'clang-401',
+    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_600/final' : 'llvm-600',
+    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_600/final' : 'clang-600',
     r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_500/final' : 'llvm-500',
     r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_500/final' : 'clang-500',
     r'git://github.com/pybind/pybind11.git' : 'pybind11',
@@ -710,16 +710,16 @@ for gcc in ['gcc48', 'gcc49', 'gcc51', 'gcc52', 'gcc53']:
     create_builder('linux-32-' + gcc, 'trunk')
     create_builder('linux-64-' + gcc, 'trunk')
 
-create_builder('linux-32-gcc53', '401')
+create_builder('linux-32-gcc53', '600')
 create_builder('linux-32-gcc53', '500')
-create_builder('linux-64-gcc53', '401')
+create_builder('linux-64-gcc53', '600')
 create_builder('linux-64-gcc53', '500')
 
 create_builder('mac-32', 'trunk')
-create_builder('mac-32', '401')
+create_builder('mac-32', '600')
 create_builder('mac-32', '500')
 create_builder('mac-64', 'trunk')
-create_builder('mac-64', '401')
+create_builder('mac-64', '600')
 create_builder('mac-64', '500')
 create_builder('win-32', 'trunk')
 create_builder('win-64', 'trunk')
@@ -728,23 +728,23 @@ create_builder('win-64-distro', 'trunk')
 create_builder('mingw-64', 'trunk')
 
 # Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.
-create_builder('win-64-testbranch', '401')
-create_builder('win-32-testbranch', '401')
-create_builder('mac-64-testbranch', '401')
-create_builder('mac-32-testbranch', '401')
-create_builder('linux-64-gcc53-testbranch', '401')
-create_builder('linux-32-gcc53-testbranch', '401')
-create_builder('mingw-64-testbranch', '401')
-create_builder('arm64-linux-64-testbranch', '401')
-create_builder('arm32-linux-32-testbranch', '401')
-# Check for build breakages against other llvm versions too
+create_builder('win-64-testbranch', '500')
+create_builder('win-32-testbranch', '500')
+create_builder('mac-64-testbranch', '500')
+create_builder('mac-32-testbranch', '500')
 create_builder('linux-64-gcc53-testbranch', '500')
+create_builder('linux-32-gcc53-testbranch', '500')
+create_builder('mingw-64-testbranch', '500')
+create_builder('arm64-linux-64-testbranch', '500')
+create_builder('arm32-linux-32-testbranch', '500')
+# Check for build breakages against other llvm versions too
+create_builder('linux-64-gcc53-testbranch', '600')
 create_builder('linux-64-gcc53-testbranch', 'trunk')
 
 c['schedulers'] = []
 create_scheduler('trunk')
 create_scheduler('500')
-create_scheduler('401')
+create_scheduler('600')
 
 # Create a scheduler to force a test of a branch
 builders = [str(b.name) for b in c['builders'] if 'testbranch' in b.name]
@@ -755,8 +755,8 @@ scheduler = ForceScheduler(
                'pybind11',
                'llvm-500',
                'clang-500',
-               'llvm-401',
-               'clang-401',
+               'llvm-600',
+               'clang-600',
                'llvm-trunk',
                'clang-trunk'])
 c['schedulers'].append(scheduler)
@@ -774,8 +774,8 @@ def prioritize_builders(master, builders):
     # 32-bit is also less important than getting immediate feedback on 64-bit.
     if '-32' in builder.name: return 5
     # Order llvm versions by age
-    if '401' in builder.name: return 3
-    if '500' in builder.name: return 2
+    if '500' in builder.name: return 3
+    if '600' in builder.name: return 2
     return 1
 
   builders.sort(key = importance)


### PR DESCRIPTION
(Note that testbranch now uses LLVM5 instead of LLVM4)