### PR TITLE
Don't test python2 bindings

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -343,8 +343,7 @@ def get_targets(os, llvm):
     # extended cpu/gpu tests
     targets.extend([('test_correctness', 'x86-64'),
                     ('test_correctness', 'x86-64-sse41'),
-                    ('test_python', 'host'),
-                    ('test_python2', 'host')])
+                    ('test_python', 'host')])
 
   if os.startswith('linux-64-gcc53') or os.startswith('mingw-64') or os.startswith('mac-64'):
     targets.extend([('test_apps', 'host'),


### PR DESCRIPTION
- Building and testing the python bindings isn't cheap
- Very few of python-related failures are v2 vs v3 at this point (PyBind handles most of the issues for us)
- If python2 breaks, we can still fix it