### PR TITLE
Re-enable D3D12 testing

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -364,14 +364,11 @@ def get_targets(os, llvm):
                     ('test_generator', 'host-metal'),
                     ('test_apps', 'host-metal')])
 
-  # Temporarily disabled: known failures with D3D12Compute feature
-  # are causing across-the-board Windows failures; disabling until
-  # they can be fixed
-  #if os.startswith('mingw-64') or os.startswith('win-64'):
-  #  # test d3d12 on windows
-  #  targets.extend([('test_correctness', 'host-d3d12compute'),
-  #                  ('test_generator', 'host-d3d12compute'),
-  #                  ('test_apps', 'host-d3d12compute')])
+  if os.startswith('mingw-64') or os.startswith('win-64'):
+    # test d3d12 on windows
+    targets.extend([('test_correctness', 'host-d3d12compute'),
+                    ('test_generator', 'host-d3d12compute'),
+                    ('test_apps', 'host-d3d12compute')])
 
   if os.startswith('linux-64-gcc53') and llvm == 'trunk':
     # Also test hexagon using the simulator


### PR DESCRIPTION
After fixes in Halide master, reenable D3D12 testing.  We believe all tests should now work on both mingw and msvc.