### PR TITLE
Buildbot: use CMake instrinsic instead of ShellCommand

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -538,7 +538,7 @@ def create_win_factory(os, llvm):
                           generator = get_cmake_generator(os),
                           definitions = {
                             'CMAKE_BUILD_TYPE': config,
-                            'LLVM_DIR': Interpolate('%(prop:builddir)s\\llvm-install-%s\\lib\\cmake\\llvm' % config),
+                            'LLVM_DIR': Interpolate('%(prop:builddir)s\\llvm-install-' + config + '\\lib\\cmake\\llvm'),
                           },
                           options = get_cmake_options(os)))
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -263,9 +263,9 @@ def get_llvm_cmake_definitions(os, config):
   return definitions
 
 
-def get_env(os):
-  env = {'LLVM_CONFIG': '../llvm-build/bin/llvm-config',
-         'CLANG': '../llvm-build/bin/clang',
+def get_env(os, config):
+  env = {'LLVM_CONFIG': '../llvm-build-%s/bin/llvm-config' % config,
+         'CLANG': '../llvm-build-%s/bin/clang' % config,
          'PYBIND11_PATH': '../pybind11'}
 
   cxx = 'c++'
@@ -410,7 +410,8 @@ def create_factory(os, llvm):
 
   if os.startswith('win'): return create_win_factory(os, llvm)
 
-  env           = get_env(os)
+  config        = 'release'
+  env           = get_env(os, config)
   targets       = get_targets(os, llvm)
   make_threads  = get_make_threads(os)
 
@@ -418,7 +419,6 @@ def create_factory(os, llvm):
 
   add_get_source_steps(factory, llvm)
 
-  config = 'Release'
   factory.addStep(CMake(name = 'Configure LLVM',
                         description = 'Configure LLVM',
                         locks = [performance_lock.access('counting')],

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -429,8 +429,7 @@ def create_factory(os, llvm):
                         path = '../llvm/',
                         generator = get_cmake_generator(os),
                         definitions = get_llvm_cmake_definitions(os, config),
-                        options = get_cmake_options(os),
-                        doStepIf=(lambda _: not isfile('llvm-build-%s/Makefile' % config))))
+                        options = get_cmake_options(os)))
 
   factory.addStep(ShellCommand(name = 'Build LLVM',
                                description = 'Build LLVM',

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -11,6 +11,7 @@ from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.trysched import Try_Userpass
 from buildbot.plugins import util
+from os.path import isfile
 from twisted.internet import defer
 
 # This is a sample buildmaster config file. It must be installed as
@@ -428,7 +429,8 @@ def create_factory(os, llvm):
                         path = '../llvm/',
                         generator = get_cmake_generator(os),
                         definitions = get_llvm_cmake_definitions(os, config),
-                        options = get_cmake_options(os)))
+                        options = get_cmake_options(os),
+                        doStepIf=(lambda _: not isfile('llvm-build-%s/Makefile' % config))))
 
   factory.addStep(ShellCommand(name = 'Build LLVM',
                                description = 'Build LLVM',

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -152,6 +152,7 @@ from buildbot.process.factory import BuildFactory
 from buildbot.steps.source.git import Git
 from buildbot.steps.source.svn import SVN
 from buildbot.steps.shell import ShellCommand
+from buildbot.steps.cmake import CMake
 from buildbot.steps.worker import RemoveDirectory
 from buildbot.steps.transfer import FileUpload
 from buildbot.steps.worker import MakeDirectory
@@ -221,38 +222,46 @@ def get_distrib_name(props):
   # since that's there the public-facing webpage looks
   return '/home/abadams/artifacts/halide-' + builder + '-' + rev + suffix
 
-def get_llvm_cmake_command(os):
-  llvm_cmake_command = [
-    'cmake',
-    '-DCMAKE_INSTALL_PREFIX=../llvm-install',
-    '-DLLVM_ENABLE_TERMINFO=OFF',
-    '-DLLVM_ENABLE_RTTI=ON',
-    '-DLLVM_TARGETS_TO_BUILD=X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC',
-    '-DCMAKE_BUILD_TYPE=Release']
-  if '-32' in os:
-    llvm_cmake_command.append('-DLLVM_BUILD_32_BITS=ON')
+def get_cmake_generator(os):
+  if os.startswith('mingw'):
+    return 'MSYS Makefiles'
+  elif os.startswith('win'):
+    if '-32' in os:
+      return 'Visual Studio 14'
+    else:
+      assert '-64' in os
+      return 'Visual Studio 14 Win64'
   else:
-    llvm_cmake_command.append('-DLLVM_BUILD_32_BITS=OFF')
+    return 'Unix Makefiles'
 
-  llvm_cmake_command.append('../llvm/')
+def get_cmake_options(os):
+  options = []
+  if os.startswith('win'):
+    options.append('-Thost=x64')
+  return options
+
+def get_llvm_cmake_definitions(os, config):
+  definitions = {
+    'CMAKE_BUILD_TYPE': config,
+    'CMAKE_INSTALL_PREFIX': '../llvm-install-%s' % config,
+    'LLVM_BUILD_32_BITS': ('ON' if '-32' in os else 'OFF'),
+    # mingw gcc 5.2 doesn't compile llvm correctly with assertions on
+    'LLVM_ENABLE_ASSERTIONS': ('OFF' if os.startswith('mingw') else 'ON'),
+    'LLVM_ENABLE_RTTI': 'ON',
+    'LLVM_ENABLE_TERMINFO': 'OFF',
+    'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC',
+  }
 
   if os.startswith('linux-32'):
-    llvm_cmake_command.append('-DCMAKE_FIND_ROOT_PATH=/usr/lib/i386-linux-gnu')
-    llvm_cmake_command.append('-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY')
+    definitions['CMAKE_FIND_ROOT_PATH'] = '/usr/lib/i386-linux-gnu'
+    definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = 'ONLY'
 
   if os.startswith('mac-32'):
-    llvm_cmake_command.append('-DCMAKE_FIND_ROOT_PATH=/usr/lib')
-    llvm_cmake_command.append('-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY')
+    definitions['CMAKE_FIND_ROOT_PATH'] = '/usr/lib'
+    definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = 'ONLY'
 
-  if os.startswith('mingw'):
-    llvm_cmake_command.append('-G')
-    llvm_cmake_command.append('MSYS Makefiles')
-    # mingw gcc 5.2 doesn't compile llvm correctly with assertions on
-    llvm_cmake_command.append('-DLLVM_ENABLE_ASSERTIONS=OFF')
-  else:
-    llvm_cmake_command.append('-DLLVM_ENABLE_ASSERTIONS=ON')
+  return definitions
 
-  return llvm_cmake_command
 
 def get_env(os):
   env = {'LLVM_CONFIG': '../llvm-build/bin/llvm-config',
@@ -401,7 +410,6 @@ def create_factory(os, llvm):
 
   if os.startswith('win'): return create_win_factory(os, llvm)
 
-  llvm_cmake_command = get_llvm_cmake_command(os)
   env           = get_env(os)
   targets       = get_targets(os, llvm)
   make_threads  = get_make_threads(os)
@@ -410,17 +418,22 @@ def create_factory(os, llvm):
 
   add_get_source_steps(factory, llvm)
 
-  factory.addStep(ShellCommand(name = 'Configure LLVM',
-                               description = 'Configure LLVM',
-                               locks = [performance_lock.access('counting')],
-                               workdir = 'llvm-build',
-                               env = env,
-                               haltOnFailure = True,
-                               command = llvm_cmake_command))
+  config = 'Release'
+  factory.addStep(CMake(name = 'Configure LLVM',
+                        description = 'Configure LLVM',
+                        locks = [performance_lock.access('counting')],
+                        haltOnFailure = True,
+                        env = env,
+                        workdir = 'llvm-build-%s' % config,
+                        path = '../llvm/',
+                        generator = get_cmake_generator(os),
+                        definitions = get_llvm_cmake_definitions(os, config),
+                        options = get_cmake_options(os)))
+
   factory.addStep(ShellCommand(name = 'Build LLVM',
                                description = 'Build LLVM',
                                locks = [performance_lock.access('counting')],
-                               workdir = 'llvm-build',
+                               workdir = 'llvm-build-%s' % config,
                                env = env,
                                haltOnFailure = True,
                                command = ['make', '-j%s' % make_threads]))
@@ -471,15 +484,6 @@ def create_win_factory(os, llvm):
   factory = BuildFactory()
   add_get_source_steps(factory, llvm)
 
-  # Configure llvm
-  if '-32' in os:
-    build_32_bits = 'ON'
-    project_type = 'Visual Studio 14'
-  else:
-    assert '-64' in os
-    build_32_bits = 'OFF'
-    project_type = 'Visual Studio 14 Win64'
-
   make_distro = '-distro' in os
 
   if make_distro:
@@ -502,24 +506,15 @@ def create_win_factory(os, llvm):
       factory.addStep(RemoveDirectory(dir = 'llvm-install-' + config, haltOnFailure = False))
     factory.addStep(MakeDirectory(dir = 'llvm-install-' + config, haltOnFailure = False))
 
-    factory.addStep(
-      ShellCommand(name = 'Configure LLVM',
-                   description = 'Configure LLVM',
-                   locks = [performance_lock.access('counting')],
-                   workdir = 'llvm-build-' + config,
-                   haltOnFailure = True,
-                   command = ['cmake',
-                              '-DCMAKE_INSTALL_PREFIX=../llvm-install-' + config,
-                              '-DLLVM_ENABLE_TERMINFO=OFF',
-                              '-DLLVM_ENABLE_RTTI=ON',
-                              '-DLLVM_TARGETS_TO_BUILD=X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC',
-                              '-DLLVM_ENABLE_ASSERTIONS=ON',
-                              '-DLLVM_BUILD_32_BITS=' + build_32_bits,
-                              '-Thost=x64',
-                              '-DCMAKE_BUILD_TYPE=' + config,
-                              '../llvm/',
-                              '-G',
-                              project_type]))
+    factory.addStep(CMake(name = 'Configure LLVM',
+                          description = 'Configure LLVM',
+                          locks = [performance_lock.access('counting')],
+                          haltOnFailure = True,
+                          workdir = 'llvm-build-%s' % config,
+                          path = '../llvm/',
+                          generator = get_cmake_generator(os),
+                          definitions = get_llvm_cmake_definitions(os, config),
+                          options = get_cmake_options(os)))
 
     factory.addStep(
       ShellCommand(workdir = 'llvm-build-' + config,
@@ -534,19 +529,20 @@ def create_win_factory(os, llvm):
                               '/v:m',
                               '.\\INSTALL.vcxproj']))
 
-    factory.addStep(
-      ShellCommand(name = 'Configure Halide ' + config,
-                   description = 'Configure Halide ' + config,
-                   locks = [performance_lock.access('counting')],
-                   workdir = 'halide-build-' + config,
-                   haltOnFailure = True,
-                   command = ['cmake',
-                               Interpolate('-DLLVM_DIR=%(prop:builddir)s\\llvm-install-' + config + '\\lib\\cmake\\llvm'),
-                               '-DCMAKE_BUILD_TYPE=' + config,
-                               '-Thost=x64',
-                               '-G',
-                               project_type,
-                               '..\\halide']))
+    factory.addStep(CMake(name = 'Configure Halide %s' % config,
+                          description = 'Configure Halide %s' % config,
+                          locks = [performance_lock.access('counting')],
+                          haltOnFailure = True,
+                          workdir = 'halide-build-' + config,
+                          path = '..\\halide',
+                          generator = get_cmake_generator(os),
+                          definitions = {
+                            'CMAKE_BUILD_TYPE': config,
+                            'LLVM_DIR': Interpolate('%(prop:builddir)s\\llvm-install-%s\\lib\\cmake\\llvm' % config),
+                          },
+                          options = get_cmake_options(os)))
+
+
     factory.addStep(
       ShellCommand(name = 'Build Halide ' + config,
                    description = 'Build Halide ' + config,


### PR DESCRIPTION
I'm hoping this will address some of the rogue unnecessary rebuilds; even if it doesn't, it consolidates some windows-vs-unix redundancy.

EDIT: just using the CMake step didn't change anything; added a `doStepIf` clause to try skipping the step if a `Makefile` is already present. Testing now.