### PR TITLE
Drop mac-32 support on buildbot

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -257,10 +257,6 @@ def get_llvm_cmake_definitions(os, config):
     definitions['CMAKE_FIND_ROOT_PATH'] = '/usr/lib/i386-linux-gnu'
     definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = 'ONLY'
 
-  if os.startswith('mac-32'):
-    definitions['CMAKE_FIND_ROOT_PATH'] = '/usr/lib'
-    definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = 'ONLY'
-
   return definitions
 
 
@@ -345,7 +341,7 @@ def get_targets(os, llvm):
     # mingw's timers appear to be very low-resolution
     targets.append(('test_performance', 'host'))
 
-  if os.startswith('linux-32-gcc53') or os.startswith('mac-32'):
+  if os.startswith('linux-32-gcc53'):
     # Also test without sse 4.1
     targets.append(('test_correctness', 'x86-32'))
 
@@ -722,9 +718,6 @@ create_builder('linux-32-gcc53', '500')
 create_builder('linux-64-gcc53', '600')
 create_builder('linux-64-gcc53', '500')
 
-create_builder('mac-32', 'trunk')
-create_builder('mac-32', '600')
-create_builder('mac-32', '500')
 create_builder('mac-64', 'trunk')
 create_builder('mac-64', '600')
 create_builder('mac-64', '500')
@@ -738,7 +731,6 @@ create_builder('mingw-64', 'trunk')
 create_builder('win-64-testbranch', '500')
 create_builder('win-32-testbranch', '500')
 create_builder('mac-64-testbranch', '500')
-create_builder('mac-32-testbranch', '500')
 create_builder('linux-64-gcc53-testbranch', '500')
 create_builder('linux-32-gcc53-testbranch', '500')
 create_builder('mingw-64-testbranch', '500')


### PR DESCRIPTION
macOS 10.14 SDK has dropped support for 32-bit OSX; we should save resources on the Mac buildbot by not bothering to build and test it any more. (We have plenty of 32-bit coverage for other targets that will remain for the forseeable future.)