### PR TITLE
Drop linux-{32,64}-gcc{48,51,52} builders

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -274,18 +274,9 @@ def get_env(os, config):
   ld = 'ld'
 
   if os.startswith('linux'):
-    if '-gcc48' in os:
-      cc = 'gcc-4.8'
-      cxx = 'g++-4.8'
-    elif '-gcc49' in os:
+    if '-gcc49' in os:
       cc = 'gcc-4.9'
       cxx = 'g++-4.9'
-    elif '-gcc51' in os:
-      cc = 'gcc-5.1'
-      cxx = 'g++-5.1'
-    elif '-gcc52' in os:
-      cc = 'gcc-5.2'
-      cxx = 'g++-5.2'
     elif '-gcc53' in os:
       cc = 'gcc-5.3'
       cxx = 'g++-5.3'
@@ -713,7 +704,7 @@ def create_scheduler(llvm):
 c['builders'] = []
 create_builder('arm32-linux-32', 'trunk')
 create_builder('arm64-linux-64', 'trunk')
-for gcc in ['gcc48', 'gcc49', 'gcc51', 'gcc52', 'gcc53']:
+for gcc in ['gcc49', 'gcc53']:
     create_builder('linux-32-' + gcc, 'trunk')
     create_builder('linux-64-' + gcc, 'trunk')
 


### PR DESCRIPTION
Quoth Andrew: "They're not branch testers, but dropping them should lighten the load on the linux boxes. Plus they all build against llvm trunk"