### PR TITLE
Remove Bazel testing from buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -375,11 +375,6 @@ def get_targets(os, llvm):
                       ('test_generator', t),
                       ('test_apps', t)])
 
-  # Also run Bazel tests, but only on linux-64 targets for now.
-  # TODO: install & test Bazel on OSX and Windows builders in the future.
-  if os.startswith('linux-64'):
-      targets.append(('test_bazel', 'host'))
-
   return targets
 
 def get_workers(os):


### PR DESCRIPTION
It's clearly not in use by anyone; not proposing to remove the Bazel build code (yet) but it's not worth spending any buildbot time on verifying it.