### PR TITLE
Windows -> VS2017, Linux -> GCC 5.3

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -228,10 +228,10 @@ def get_cmake_generator(os):
     return 'MSYS Makefiles'
   elif os.startswith('win'):
     if '-32' in os:
-      return 'Visual Studio 14'
+      return 'Visual Studio 15'
     else:
       assert '-64' in os
-      return 'Visual Studio 14 Win64'
+      return 'Visual Studio 15 Win64'
   else:
     return 'Unix Makefiles'
 
@@ -270,10 +270,7 @@ def get_env(os, config):
   ld = 'ld'
 
   if os.startswith('linux'):
-    if '-gcc49' in os:
-      cc = 'gcc-4.9'
-      cxx = 'g++-4.9'
-    elif '-gcc53' in os:
+    if '-gcc53' in os:
       cc = 'gcc-5.3'
       cxx = 'g++-5.3'
     else:
@@ -698,7 +695,7 @@ def create_scheduler(llvm):
 c['builders'] = []
 create_builder('arm32-linux-32', 'trunk')
 create_builder('arm64-linux-64', 'trunk')
-for gcc in ['gcc49', 'gcc53']:
+for gcc in ['gcc53']:
     create_builder('linux-32-' + gcc, 'trunk')
     create_builder('linux-64-' + gcc, 'trunk')
 


### PR DESCRIPTION
- Drop support for GCC 4.9, since trunk LLVM is dropping support. (Should we bother trying to keep supporting it for older llvm versions?)
- Bump MSVC usage to VS2017 (aka "v15")