### PR TITLE
Add LLVM8 to buildbot

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -126,8 +126,10 @@ all_repositories = {
     u'https://github.com/halide/Halide.git' : 'halide',
     r'http://llvm.org/svn/llvm-project/llvm/trunk' : 'llvm-trunk',
     r'http://llvm.org/svn/llvm-project/cfe/trunk' : 'clang-trunk',
-    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_700/final' : 'llvm-700',
-    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_700/final' : 'clang-700',
+    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_800/final' : 'llvm-800',
+    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_800/final' : 'clang-800',
+    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_701/final' : 'llvm-701',
+    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_701/final' : 'clang-701',
     r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_601/final' : 'llvm-601',
     r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_601/final' : 'clang-601',
     r'git://github.com/pybind/pybind11.git' : 'pybind11',
@@ -715,29 +717,33 @@ for gcc in ['gcc53']:
     create_builder('linux-32-' + gcc, 'trunk')
     create_builder('linux-64-' + gcc, 'trunk')
 
-create_builder('linux-32-gcc53', '700')
+create_builder('linux-32-gcc53', '800')
+create_builder('linux-32-gcc53', '701')
 create_builder('linux-32-gcc53', '601')
-create_builder('linux-64-gcc53', '700')
+create_builder('linux-64-gcc53', '800')
+create_builder('linux-64-gcc53', '701')
 create_builder('linux-64-gcc53', '601')
 
 create_builder('mac-64', 'trunk')
-create_builder('mac-64', '700')
+create_builder('mac-64', '800')
+create_builder('mac-64', '701')
 create_builder('mac-64', '601')
 create_builder('win-32', 'trunk')
 create_builder('win-64', 'trunk')
-create_builder('win-32-distro', '700')
-create_builder('win-64-distro', '700')
-create_builder('mingw-64', '700')
+create_builder('win-32-distro', '800')
+create_builder('win-64-distro', '800')
+create_builder('mingw-64', '800')
 
 # Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.
-create_builder('win-64-testbranch', '700')
-create_builder('win-32-testbranch', '700')
-create_builder('mac-64-testbranch', '700')
-create_builder('linux-64-gcc53-testbranch', '700')
-create_builder('linux-32-gcc53-testbranch', '700')
-create_builder('mingw-64-testbranch', '700')
-create_builder('arm64-linux-64-testbranch', '700')
-create_builder('arm32-linux-32-testbranch', '700')
+create_builder('win-64-testbranch',         '800')
+create_builder('win-32-testbranch',         '800')
+create_builder('mac-64-testbranch',         '800')
+create_builder('linux-64-gcc53-testbranch', '800')
+create_builder('linux-32-gcc53-testbranch', '800')
+create_builder('mingw-64-testbranch',       '800')
+create_builder('arm64-linux-64-testbranch', '800')
+create_builder('arm32-linux-32-testbranch', '800')
+
 # Check for build breakages against other llvm versions too
 create_builder('linux-64-gcc53-testbranch', '601')
 create_builder('linux-64-gcc53-testbranch', 'trunk')
@@ -745,7 +751,8 @@ create_builder('linux-64-gcc53-testbranch', 'trunk')
 c['schedulers'] = []
 create_scheduler('trunk')
 create_scheduler('601')
-create_scheduler('700')
+create_scheduler('701')
+create_scheduler('800')
 
 # Create a scheduler to force a test of a branch
 builders = [str(b.name) for b in c['builders'] if 'testbranch' in b.name]
@@ -756,8 +763,10 @@ scheduler = ForceScheduler(
                'pybind11',
                'llvm-601',
                'clang-601',
-               'llvm-700',
-               'clang-700',
+               'llvm-701',
+               'clang-701',
+               'llvm-800',
+               'clang-800',
                'llvm-trunk',
                'clang-trunk'])
 c['schedulers'].append(scheduler)
@@ -767,16 +776,20 @@ def prioritize_builders(master, builders):
   def importance(builder):
     # These builders are equal highest priority, so check against this first.
     if 'testbranch' in builder.name: return 0
+
     # gccs other than 5.3 are just for making distros. They don't need
     # frequent testing.
     if 'gcc' in builder.name and 'gcc53' not in builder.name: return 6
+
     # Similarly deprioritize the windows distro-builders
     if '-distro' in builder.name: return 6
+
     # 32-bit is also less important than getting immediate feedback on 64-bit.
     if '-32' in builder.name: return 5
     # Order llvm versions by age
-    if '601' in builder.name: return 3
-    if '700' in builder.name: return 2
+    if '601' in builder.name: return 4
+    if '701' in builder.name: return 3
+    if '800' in builder.name: return 2
     return 1
 
   builders.sort(key = importance)


### PR DESCRIPTION
- Add LLVM8 to test matrix
- use 8 for testbranches (instead of 7)
- upgrade existing 7.0.0 usage to 7.0.1