### PR TITLE
Add LLD to the LLVM buildbot script

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -267,7 +267,7 @@ def get_cmake_options(os):
     options.append('-Thost=x64')
   return options
 
-def get_llvm_cmake_definitions(os, config):
+def get_llvm_cmake_definitions(os, config, llvm):
   definitions = {
     'CMAKE_BUILD_TYPE': config,
     'CMAKE_INSTALL_PREFIX': '../llvm-install-%s' % config,
@@ -276,7 +276,7 @@ def get_llvm_cmake_definitions(os, config):
     'LLVM_ENABLE_ASSERTIONS': ('OFF' if os.startswith('mingw') else 'ON'),
     'LLVM_ENABLE_RTTI': 'ON',
     'LLVM_ENABLE_TERMINFO': 'OFF',
-    'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC',
+    'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC' + (';WebAssembly' if llvm == 'trunk' else ''),
   }
 
   if os.startswith('linux-32'):
@@ -449,7 +449,7 @@ def create_factory(os, llvm):
                         workdir = 'llvm-build-%s' % config,
                         path = '../llvm/',
                         generator = get_cmake_generator(os),
-                        definitions = get_llvm_cmake_definitions(os, config),
+                        definitions = get_llvm_cmake_definitions(os, config, llvm),
                         options = get_cmake_options(os)))
 
   factory.addStep(ShellCommand(name = 'Build LLVM',
@@ -535,7 +535,7 @@ def create_win_factory(os, llvm):
                           workdir = 'llvm-build-%s' % config,
                           path = '../llvm/',
                           generator = get_cmake_generator(os),
-                          definitions = get_llvm_cmake_definitions(os, config),
+                          definitions = get_llvm_cmake_definitions(os, config, llvm),
                           options = get_cmake_options(os)))
 
     factory.addStep(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -119,6 +119,12 @@ c['change_source'].append(SVNPoller(
     pollInterval = 60*60*24, # Only check llvm once every 24 hours
     pollAtLaunch = True))
 
+c['change_source'].append(SVNPoller(
+    repourl = 'http://llvm.org/svn/llvm-project/lld/trunk',
+    split_file = split_file_alwaystrunk,
+    pollInterval = 60*60*24, # Only check llvm once every 24 hours
+    pollAtLaunch = True))
+
 ####### CODEBASES
 
 all_repositories = {
@@ -126,12 +132,16 @@ all_repositories = {
     u'https://github.com/halide/Halide.git' : 'halide',
     r'http://llvm.org/svn/llvm-project/llvm/trunk' : 'llvm-trunk',
     r'http://llvm.org/svn/llvm-project/cfe/trunk' : 'clang-trunk',
+    r'http://llvm.org/svn/llvm-project/lld/trunk' : 'lld-trunk',
     r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_800/final' : 'llvm-800',
     r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_800/final' : 'clang-800',
+    r'http://llvm.org/svn/llvm-project/lld/tags/RELEASE_800/final' : 'lld-800',
     r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_701/final' : 'llvm-701',
     r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_701/final' : 'clang-701',
+    r'http://llvm.org/svn/llvm-project/lld/tags/RELEASE_701/final' : 'lld-701',
     r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_601/final' : 'llvm-601',
     r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_601/final' : 'clang-601',
+    r'http://llvm.org/svn/llvm-project/lld/tags/RELEASE_601/final' : 'lld-601',
     r'git://github.com/pybind/pybind11.git' : 'pybind11',
     u'https://github.com/pybind/pybind11.git' : 'pybind11',
 }
@@ -168,6 +178,7 @@ def add_get_source_steps(factory, llvm):
 
   llvm_codebase  = 'llvm-' + llvm
   clang_codebase = 'clang-' + llvm
+  lld_codebase = 'lld-' + llvm
   if llvm == 'trunk':
     llvm_svn_path = 'trunk'
   else:
@@ -201,6 +212,12 @@ def add_get_source_steps(factory, llvm):
                                workdir = 'llvm/tools/clang',
                                command = ['svn', 'cleanup']))
 
+  factory.addStep(ShellCommand(name = 'svn cleanup',
+                               locks = [performance_lock.access('counting')],
+                               flunkOnFailure = False,
+                               workdir = 'llvm/tools/lld',
+                               command = ['svn', 'cleanup']))
+
   factory.addStep(SVN(name = 'Get LLVM source',
                       locks = [performance_lock.access('counting')],
                       codebase = llvm_codebase,
@@ -213,6 +230,13 @@ def add_get_source_steps(factory, llvm):
                       codebase = clang_codebase,
                       workdir = 'llvm/tools/clang',
                       repourl = r'http://llvm.org/svn/llvm-project/cfe/%s' % llvm_svn_path,
+                      mode = 'incremental'))
+
+  factory.addStep(SVN(name = 'Get LLD source',
+                      locks = [performance_lock.access('counting')],
+                      codebase = lld_codebase,
+                      workdir = 'llvm/tools/lld',
+                      repourl = r'http://llvm.org/svn/llvm-project/lld/%s' % llvm_svn_path,
                       mode = 'incremental'))
 
 @renderer
@@ -684,7 +708,7 @@ def create_scheduler(llvm):
   builders = [str(b.name) for b in c['builders'] if b.llvm == llvm and 'testbranch' not in b.name]
   scheduler = SingleBranchScheduler(
       name = 'halide-' + llvm,
-      codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm],
+      codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm, 'lld-' + llvm],
       change_filter = util.ChangeFilter(filter_fn = master_only),
       treeStableTimer = 60*5, # seconds
       builderNames = builders)
@@ -695,7 +719,7 @@ def create_scheduler(llvm):
   if builders:
       scheduler = SingleBranchScheduler(
           name = 'halide-testbranch-' + llvm,
-          codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm],
+          codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm, 'lld-' + llvm],
           change_filter = util.ChangeFilter(filter_fn = not_master),
           treeStableTimer = 60*5, # seconds
           builderNames = builders)
@@ -706,7 +730,7 @@ def create_scheduler(llvm):
   scheduler = ForceScheduler(
     name = 'force-' + llvm,
     builderNames = builders,
-    codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm])
+    codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm, 'lld-' + llvm])
 
   c['schedulers'].append(scheduler)
 
@@ -763,12 +787,16 @@ scheduler = ForceScheduler(
                'pybind11',
                'llvm-601',
                'clang-601',
+               'lld-601',
                'llvm-701',
                'clang-701',
+               'lld-701',
                'llvm-800',
                'clang-800',
+               'lld-800',
                'llvm-trunk',
-               'clang-trunk'])
+               'clang-trunk',
+               'lld-trunk'])
 c['schedulers'].append(scheduler)
 
 # Set the builder priorities


### PR DESCRIPTION
This is part 1 of enabling WebAssembly testing on the buildbots; LLD is needed for our JIT tests. (Note that this change adds LLD pull-and-build for all versions of LLVM; we'll likely only need it for trunk, but it's much simpler to enable it for all versions, and for non-trunk builds it should be built and cached.)