### PR TITLE
Disable d3d12compute testing

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -398,11 +398,12 @@ def get_targets(os, llvm):
                     ('test_generator', 'host-metal'),
                     ('test_apps', 'host-metal')])
 
-  if os.startswith('mingw-64') or os.startswith('win-64'):
-    # test d3d12 on windows
-    targets.extend([('test_correctness', 'host-d3d12compute'),
-                    ('test_generator', 'host-d3d12compute'),
-                    ('test_apps', 'host-d3d12compute')])
+  # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
+  # if os.startswith('mingw-64') or os.startswith('win-64'):
+  #   # test d3d12 on windows
+  #   targets.extend([('test_correctness', 'host-d3d12compute'),
+  #                   ('test_generator', 'host-d3d12compute'),
+  #                   ('test_apps', 'host-d3d12compute')])
 
   if os.startswith('linux-64-gcc53') and llvm == 'trunk':
     # Also test hexagon using the simulator
@@ -620,8 +621,9 @@ def create_win_factory(os, llvm):
     env = {}
 
     targets = ['host', 'host-opencl', 'host-cuda']
-    if '-64' in os:
-      targets.append('host-d3d12compute')
+    # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
+    # if '-64' in os:
+    #   targets.append('host-d3d12compute')
 
     for hl_target in targets:
       target_env = env.copy()


### PR DESCRIPTION
Disabling testing until https://github.com/halide/Halide/issues/3909 is addressed, to avoid buildbot failure noise