### PR TITLE
Band-aid for Win Distro Builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -583,7 +583,7 @@ def create_win_factory(os, llvm):
     factory.addStep(RemoveDirectory(dir = 'distrib', haltOnFailure = False))
     factory.addStep(MakeDirectory(dir = 'distrib', haltOnFailure = False))
     factory.addStep(MakeDirectory(dir = 'distrib\\halide', haltOnFailure = False))
-    for d in ['Release', 'Debug', 'include', 'tools']:
+    for d in ['Release', 'Debug', 'include', 'tools', 'tutorial', 'tutorial\\figures']:
       factory.addStep(MakeDirectory(dir = 'distrib\\halide\\' + d, haltOnFailure = False))
 
     file_pairs = [
@@ -595,9 +595,25 @@ def create_win_factory(os, llvm):
         ('..\\halide\\src\\runtime\\HalideRuntim*.h', 'include'),
         ('..\\halide\\src\\runtime\\HalideBuffer.h', 'include'),
         ('..\\halide\\tools\\mex_halide.m', 'tools'),
-        ('..\\halide\\tools\\halide_image_io.h', 'tools'),
         ('..\\halide\\tools\\GenGen.cpp', 'tools'),
-        ('..\\halide\\README.md', '.')]
+        ('..\\halide\\tools\\RunGen.h', 'tools'),
+        ('..\\halide\\tools\\RunGenMain.cpp', 'tools'),
+        ('..\\halide\\tools\\halide_benchmark.h', 'tools'),
+        ('..\\halide\\tools\\halide_image.h', 'tools'),
+        ('..\\halide\\tools\\halide_image_io.h', 'tools'),
+        ('..\\halide\\tools\\halide_image_info.h', 'tools'),
+        ('..\\halide\\tools\\halide_malloc_trace.h', 'tools'),
+        ('..\\halide\\tools\\halide_trace_config.h', 'tools'),
+        ('..\\halide\\tutorial\\images\\*.png', 'tutorial\\figures'),
+        ('..\\halide\\tutorial\\figures\\*.gif, 'tutorial\\figures'),
+        ('..\\halide\\tutorial\\figures\\*.jpg, 'tutorial\\figures'),
+        ('..\\halide\\tutorial\\figures\\*.mp4, 'tutorial\\figures'),
+        ('..\\halide\\tutorial\\*.cpp, 'tutorial'),
+        ('..\\halide\\tutorial\\*.h, 'tutorial'),
+        ('..\\halide\\tutorial\\*.sh, 'tutorial'),
+        ('..\\halide-build-Release\\halide_config.*', '.'),
+        ('..\\halide\\halide.cmake', '.'),
+        ('..\\halide\\README*.md', '.')]
     for (file, dir) in file_pairs:
       factory.addStep(
         ShellCommand(name = 'Copying ' + file,
@@ -753,6 +769,8 @@ create_builder('win-32', 'trunk')
 create_builder('win-64', 'trunk')
 create_builder('win-32-distro', '800')
 create_builder('win-64-distro', '800')
+create_builder('win-32-distro', 'trunk')
+create_builder('win-64-distro', 'trunk')
 create_builder('mingw-64', '800')
 
 # Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.


### PR DESCRIPTION
- build Windows distros for LLVM-trunk as well as LLVM-8
- Copy additional files that weren't being copied

(We really should use the CMake 'distrib' target for Windows, but it's not quite right, see https://github.com/halide/Halide/issues/3971 -- this is intended as a temporary fix to allow new binary releases)