### PR TITLE
Reshuffle which builds we do to include most recent llvm release on arm

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -751,12 +751,19 @@ def create_scheduler(llvm):
   c['schedulers'].append(scheduler)
 
 c['builders'] = []
+
+# Builders that test master. We test the most recent official release
+# of llvm on everything, to make it possible to do binary
+# distributions with a uniform llvm version. We also test against llvm
+# trunk, with lower priority, so that we can bisect llvm trunk
+# breakages on various platforms if they are discovered late.
 create_builder('arm32-linux-32', 'trunk')
 create_builder('arm64-linux-64', 'trunk')
-for gcc in ['gcc53']:
-    create_builder('linux-32-' + gcc, 'trunk')
-    create_builder('linux-64-' + gcc, 'trunk')
+create_builder('arm32-linux-32', '800')
+create_builder('arm64-linux-64', '800')
 
+create_builder('linux-32-gcc53', 'trunk')
+create_builder('linux-64-gcc53', 'trunk')
 create_builder('linux-32-gcc53', '800')
 create_builder('linux-32-gcc53', '701')
 create_builder('linux-64-gcc53', '800')
@@ -765,12 +772,12 @@ create_builder('linux-64-gcc53', '701')
 create_builder('mac-64', 'trunk')
 create_builder('mac-64', '800')
 create_builder('mac-64', '701')
+
 create_builder('win-32', 'trunk')
 create_builder('win-64', 'trunk')
 create_builder('win-32-distro', '800')
 create_builder('win-64-distro', '800')
-create_builder('win-32-distro', 'trunk')
-create_builder('win-64-distro', 'trunk')
+
 create_builder('mingw-64', '800')
 
 # Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.
@@ -813,23 +820,19 @@ c['schedulers'].append(scheduler)
 # Set the builder priorities
 def prioritize_builders(master, builders):
   def importance(builder):
-    # These builders are equal highest priority, so check against this first.
+    # Branch testers all need to come back before we can merge a PR,
+    # so they all have equal highest priority.
     if 'testbranch' in builder.name: return 0
 
-    # gccs other than 5.3 are just for making distros. They don't need
-    # frequent testing.
-    if 'gcc' in builder.name and 'gcc53' not in builder.name: return 6
-
-    # Similarly deprioritize the windows distro-builders
-    if '-distro' in builder.name: return 6
-
-    # 32-bit is also less important than getting immediate feedback on 64-bit.
-    if '-32' in builder.name: return 5
-    # Order llvm versions by age
-    # 4: unused
+    # non-branch testers are mostly used for bisecting failures that
+    # didn't show up in the branch testers and doing binary
+    # releases. We care most about the most recently-released llvm so
+    # that we have a full set of builds for releases, then llvm trunk
+    # for bisection, then older llvm versions.
+    if '800' in builder.name: return 1
+    if 'trunk' in builder.name: return 2
     if '701' in builder.name: return 3
-    if '800' in builder.name: return 2
-    return 1
+    return 4
 
   builders.sort(key = importance)
 


### PR DESCRIPTION
Not going to let this stop me from doing a release, but in future it would be nice to do the arm releases against a released llvm