### PR TITLE
Use MSVC17 (instead of MSVC15) on Windows buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -251,10 +251,10 @@ def get_cmake_generator(os):
     return 'MSYS Makefiles'
   elif os.startswith('win'):
     if '-32' in os:
-      return 'Visual Studio 15'
+      return 'Visual Studio 17'
     else:
       assert '-64' in os
-      return 'Visual Studio 15 Win64'
+      return 'Visual Studio 17 Win64'
   else:
     return 'Unix Makefiles'
 


### PR DESCRIPTION
Since MSVC19 is now current, we should move our testing baseline forward to MSVC17.

(We already have it installed on both buildbots, but the master config is still using MSVC15.)