### PR TITLE
Revert "Use MSVC17 (instead of MSVC15) on Windows buildbots"

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -251,10 +251,10 @@ def get_cmake_generator(os):
     return 'MSYS Makefiles'
   elif os.startswith('win'):
     if '-32' in os:
-      return 'Visual Studio 17'
+      return 'Visual Studio 15'
     else:
       assert '-64' in os
-      return 'Visual Studio 17 Win64'
+      return 'Visual Studio 15 Win64'
   else:
     return 'Unix Makefiles'
 


### PR DESCRIPTION
As it turns out, "15" means "2017" in this world:

```
CMake Error: Could not create named generator Visual Studio 17 Win64
Generators
  Visual Studio 16 2019        = Generates Visual Studio 2019 project files.
                                 Use -A option to specify architecture.
* Visual Studio 15 2017 [arch] = Generates Visual Studio 2017 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 14 2015 [arch] = Generates Visual Studio 2015 project files.
                                 Optional [arch] can be "Win64" or "ARM".
```

Whether this nonsense is due to CMake, MSVC, or some combination of the two, is not clear to me, but we were already using VC2017.
