### PR TITLE
Re-enable D3D12 testing on Windows

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -399,12 +399,11 @@ def get_targets(os, llvm):
                     ('test_generator', 'host-metal'),
                     ('test_apps', 'host-metal')])
 
-  # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
-  # if os.startswith('mingw-64') or os.startswith('win-64'):
-  #   # test d3d12 on windows
-  #   targets.extend([('test_correctness', 'host-d3d12compute'),
-  #                   ('test_generator', 'host-d3d12compute'),
-  #                   ('test_apps', 'host-d3d12compute')])
+  if os.startswith('mingw-64') or os.startswith('win-64'):
+    # test d3d12 on windows
+    targets.extend([('test_correctness', 'host-d3d12compute'),
+                    ('test_generator', 'host-d3d12compute'),
+                    ('test_apps', 'host-d3d12compute')])
 
   if os.startswith('linux-64-gcc53') and llvm == 'trunk':
     # Also test hexagon using the simulator
@@ -638,9 +637,8 @@ def create_win_factory(os, llvm):
     env = {}
 
     targets = ['host', 'host-opencl', 'host-cuda']
-    # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
-    # if '-64' in os:
-    #   targets.append('host-d3d12compute')
+    if '-64' in os:
+      targets.append('host-d3d12compute')
 
     for hl_target in targets:
       target_env = env.copy()


### PR DESCRIPTION
Was disabled due to https://github.com/halide/Halide/issues/3909, but that is believed to be fixed now.