### PR TITLE
Revert "Re-enable D3D12 testing on Windows"

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -399,11 +399,12 @@ def get_targets(os, llvm):
                     ('test_generator', 'host-metal'),
                     ('test_apps', 'host-metal')])
 
-  if os.startswith('mingw-64') or os.startswith('win-64'):
-    # test d3d12 on windows
-    targets.extend([('test_correctness', 'host-d3d12compute'),
-                    ('test_generator', 'host-d3d12compute'),
-                    ('test_apps', 'host-d3d12compute')])
+  # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
+  # if os.startswith('mingw-64') or os.startswith('win-64'):
+  #   # test d3d12 on windows
+  #   targets.extend([('test_correctness', 'host-d3d12compute'),
+  #                   ('test_generator', 'host-d3d12compute'),
+  #                   ('test_apps', 'host-d3d12compute')])
 
   if os.startswith('linux-64-gcc53') and llvm == 'trunk':
     # Also test hexagon using the simulator
@@ -637,8 +638,9 @@ def create_win_factory(os, llvm):
     env = {}
 
     targets = ['host', 'host-opencl', 'host-cuda']
-    if '-64' in os:
-      targets.append('host-d3d12compute')
+    # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
+    # if '-64' in os:
+    #   targets.append('host-d3d12compute')
 
     for hl_target in targets:
       target_env = env.copy()


### PR DESCRIPTION
Reverts halide/build_bot#44

It appears that the D3D12 backend has some bugs that need fixing:
- correctness_gpu_allocation_cache can run for 30+ minutes
- correctness_math can fail with small accuracy errors

These need to be investigated and fixed offline; disabling them (again) for now to avoid false-positive for unrelated builds on Windows.

attn @slomp, @shoaibkamil 