### PR TITLE
Revise BuildBot to pull LLVM from GitHub

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -5,12 +5,11 @@ from buildbot.worker import Worker
 from buildbot.config import BuilderConfig
 from buildbot.changes.gitpoller import GitPoller
 from buildbot.changes.github import GitHubPullrequestPoller
-from buildbot.changes.svnpoller import SVNPoller
-from buildbot.changes.svnpoller import split_file_alwaystrunk
 from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.trysched import Try_Userpass
 from buildbot.plugins import util
+from from functools import partial
 from os.path import isfile
 from twisted.internet import defer
 
@@ -66,6 +65,10 @@ performance_lock = util.WorkerLock("performance_lock",
 
 PYBIND11_BRANCH = 'v2.2'
 
+LLVM_TRUNK_BRANCH = 'master'
+LLVM_9_BRANCH = 'release/9.x'
+LLVM_8_BRANCH = 'release/8.x'
+
 c['change_source'] = []
 
 token = open('github_token.txt').read().strip()
@@ -107,21 +110,10 @@ c['change_source'].append(GitHubPullrequestPoller(
     pollInterval = 60*5,  # Check Halide PRs every five minutes
     pollAtLaunch = True))
 
-c['change_source'].append(SVNPoller(
-    repourl = 'http://llvm.org/svn/llvm-project/llvm/trunk',
-    split_file = split_file_alwaystrunk,
-    pollInterval = 60*60*24, # Only check llvm once every 24 hours
-    pollAtLaunch = True))
-
-c['change_source'].append(SVNPoller(
-    repourl = 'http://llvm.org/svn/llvm-project/cfe/trunk',
-    split_file = split_file_alwaystrunk,
-    pollInterval = 60*60*24, # Only check llvm once every 24 hours
-    pollAtLaunch = True))
-
-c['change_source'].append(SVNPoller(
-    repourl = 'http://llvm.org/svn/llvm-project/lld/trunk',
-    split_file = split_file_alwaystrunk,
+c['change_source'].append(GitPoller(
+    repourl = 'https://github.com/llvm/llvm-project.git',
+    workdir = 'gitpoller-llvm-workdir',
+    branch = LLVM_TRUNK_BRANCH,
     pollInterval = 60*60*24, # Only check llvm once every 24 hours
     pollAtLaunch = True))
 
@@ -130,15 +122,8 @@ c['change_source'].append(SVNPoller(
 all_repositories = {
     r'git://github.com/halide/Halide.git' : 'halide',
     u'https://github.com/halide/Halide.git' : 'halide',
-    r'http://llvm.org/svn/llvm-project/llvm/trunk' : 'llvm-trunk',
-    r'http://llvm.org/svn/llvm-project/cfe/trunk' : 'clang-trunk',
-    r'http://llvm.org/svn/llvm-project/lld/trunk' : 'lld-trunk',
-    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_800/final' : 'llvm-800',
-    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_800/final' : 'clang-800',
-    r'http://llvm.org/svn/llvm-project/lld/tags/RELEASE_800/final' : 'lld-800',
-    r'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_900/final' : 'llvm-900',
-    r'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_900/final' : 'clang-900',
-    r'http://llvm.org/svn/llvm-project/lld/tags/RELEASE_900/final' : 'lld-900',
+    r'git://github.com/llvm/llvm-project.git' : 'llvm',
+    u'https://github.com/llvm/llvm-project.git' : 'llvm',
     r'git://github.com/pybind/pybind11.git' : 'pybind11',
     u'https://github.com/pybind/pybind11.git' : 'pybind11',
 }
@@ -160,7 +145,6 @@ c['codebaseGenerator'] = codebase_generator
 
 from buildbot.process.factory import BuildFactory
 from buildbot.steps.source.git import Git
-from buildbot.steps.source.svn import SVN
 from buildbot.steps.shell import ShellCommand
 from buildbot.steps.cmake import CMake
 from buildbot.steps.worker import RemoveDirectory
@@ -171,21 +155,16 @@ from buildbot.process.properties import Property
 from buildbot.process.properties import renderer
 from buildbot.process.properties import Interpolate
 
-def add_get_source_steps(factory, llvm):
+def add_get_source_steps(factory, llvm_branch):
 
-  llvm_codebase  = 'llvm-' + llvm
-  clang_codebase = 'clang-' + llvm
-  lld_codebase = 'lld-' + llvm
-  if llvm == 'trunk':
-    llvm_svn_path = 'trunk'
-  else:
-    llvm_svn_path = 'tags/RELEASE_' + llvm + '/final'
+  assert llvm_branch in [LLVM_TRUNK_BRANCH, LLVM_9_BRANCH, LLVM_8_BRANCH]
 
   factory.addStep(Git(name = 'Get Halide master',
                       locks = [performance_lock.access('counting')],
                       codebase = 'halide',
                       workdir = 'halide',
                       repourl = 'git://github.com/halide/Halide.git',
+                      branch = 'master',
                       mode = 'incremental'))
 
   # PyBind11 is a header-only library: we don't need to build it, we just need to pull it
@@ -197,43 +176,12 @@ def add_get_source_steps(factory, llvm):
                       branch = PYBIND11_BRANCH,
                       mode = 'incremental'))
 
-  factory.addStep(ShellCommand(name = 'svn cleanup',
-                               locks = [performance_lock.access('counting')],
-                               flunkOnFailure = False,
-                               workdir = 'llvm',
-                               command = ['svn', 'cleanup']))
-
-  factory.addStep(ShellCommand(name = 'svn cleanup',
-                               locks = [performance_lock.access('counting')],
-                               flunkOnFailure = False,
-                               workdir = 'llvm/tools/clang',
-                               command = ['svn', 'cleanup']))
-
-  factory.addStep(ShellCommand(name = 'svn cleanup',
-                               locks = [performance_lock.access('counting')],
-                               flunkOnFailure = False,
-                               workdir = 'llvm/tools/lld',
-                               command = ['svn', 'cleanup']))
-
-  factory.addStep(SVN(name = 'Get LLVM source',
+  factory.addStep(Git(name = 'Get LLVM ' + llvm_branch,
                       locks = [performance_lock.access('counting')],
-                      codebase = llvm_codebase,
-                      workdir = 'llvm',
-                      repourl = r'http://llvm.org/svn/llvm-project/llvm/%s' % llvm_svn_path,
-                      mode = 'incremental'))
-
-  factory.addStep(SVN(name = 'Get Clang source',
-                      locks = [performance_lock.access('counting')],
-                      codebase = clang_codebase,
-                      workdir = 'llvm/tools/clang',
-                      repourl = r'http://llvm.org/svn/llvm-project/cfe/%s' % llvm_svn_path,
-                      mode = 'incremental'))
-
-  factory.addStep(SVN(name = 'Get LLD source',
-                      locks = [performance_lock.access('counting')],
-                      codebase = lld_codebase,
-                      workdir = 'llvm/tools/lld',
-                      repourl = r'http://llvm.org/svn/llvm-project/lld/%s' % llvm_svn_path,
+                      codebase = 'llvm',
+                      workdir = 'llvm-project',
+                      repourl = 'https://github.com/llvm/llvm-project.git',
+                      branch = llvm_branch,
                       mode = 'incremental'))
 
 @renderer
@@ -264,16 +212,17 @@ def get_cmake_options(os):
     options.append('-Thost=x64')
   return options
 
-def get_llvm_cmake_definitions(os, config, llvm):
+def get_llvm_cmake_definitions(os, config, llvm_branch):
   definitions = {
     'CMAKE_BUILD_TYPE': config,
     'CMAKE_INSTALL_PREFIX': '../llvm-install-%s' % config,
     'LLVM_BUILD_32_BITS': ('ON' if '-32' in os else 'OFF'),
     # mingw gcc 5.2 doesn't compile llvm correctly with assertions on
     'LLVM_ENABLE_ASSERTIONS': ('OFF' if os.startswith('mingw') else 'ON'),
+    'LLVM_ENABLE_PROJECTS': 'clang;lld',
     'LLVM_ENABLE_RTTI': 'ON',
     'LLVM_ENABLE_TERMINFO': 'OFF',
-    'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC' + (';WebAssembly' if llvm == 'trunk' else ''),
+    'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC' + (';WebAssembly' if llvm_branch == LLVM_TRUNK_BRANCH else ''),
   }
 
   if os.startswith('linux-32'):
@@ -301,7 +250,6 @@ def get_llvm_cmake_definitions(os, config, llvm):
 
 def get_env(os, config):
   env = {'LLVM_CONFIG': '../llvm-build-%s/bin/llvm-config' % config,
-         'CLANG': '../llvm-build-%s/bin/clang' % config,
          'PYBIND11_PATH': '../pybind11'}
 
   cxx = 'c++'
@@ -359,7 +307,7 @@ def get_make_threads(os):
   else:
     return 1
 
-def get_targets(os, llvm):
+def get_targets(os, llvm_branch):
   targets = [('distrib', 'host'),
              ('build_tests', 'host'),
              ('test_correctness', 'host'),
@@ -406,7 +354,7 @@ def get_targets(os, llvm):
   #                   ('test_generator', 'host-d3d12compute'),
   #                   ('test_apps', 'host-d3d12compute')])
 
-  if os.startswith('linux-64-gcc53') and llvm == 'trunk':
+  if os.startswith('linux-64-gcc53') and llvm_branch == LLVM_TRUNK_BRANCH:
     # Also test hexagon using the simulator
     for t in ['host-hvx_128', 'host-hvx_64']:
       targets.extend([('test_correctness', t),
@@ -427,18 +375,19 @@ def get_workers(os):
   elif os.startswith('arm64-linux'):
     return ['arm64-linux-worker' + sfx for sfx in worker_suffixes]
 
-def create_factory(os, llvm):
+def create_factory(os, llvm_branch):
 
-  if os.startswith('win'): return create_win_factory(os, llvm)
+  if os.startswith('win'):
+    return create_win_factory(os, llvm_branch)
 
   config        = 'release'
   env           = get_env(os, config)
-  targets       = get_targets(os, llvm)
+  targets       = get_targets(os, llvm_branch)
   make_threads  = get_make_threads(os)
 
   factory = BuildFactory()
 
-  add_get_source_steps(factory, llvm)
+  add_get_source_steps(factory, llvm_branch)
 
   factory.addStep(CMake(name = 'Configure LLVM',
                         description = 'Configure LLVM',
@@ -446,9 +395,9 @@ def create_factory(os, llvm):
                         haltOnFailure = True,
                         env = env,
                         workdir = 'llvm-build-%s' % config,
-                        path = '../llvm/',
+                        path = '../llvm-project/llvm/',
                         generator = get_cmake_generator(os),
-                        definitions = get_llvm_cmake_definitions(os, config, llvm),
+                        definitions = get_llvm_cmake_definitions(os, config, llvm_branch),
                         options = get_cmake_options(os)))
 
   factory.addStep(ShellCommand(name = 'Build LLVM',
@@ -499,11 +448,11 @@ def create_factory(os, llvm):
 
   return factory
 
-def create_win_factory(os, llvm):
+def create_win_factory(os, llvm_branch):
   assert os.startswith('win')
 
   factory = BuildFactory()
-  add_get_source_steps(factory, llvm)
+  add_get_source_steps(factory, llvm_branch)
 
   make_distro = '-distro' in os
 
@@ -518,13 +467,12 @@ def create_win_factory(os, llvm):
     factory.addStep(RemoveDirectory(dir = 'halide-build-' + config, haltOnFailure = False))
     factory.addStep(MakeDirectory(dir = 'halide-build-' + config, haltOnFailure = False))
 
-    if llvm == 'trunk':
+    if llvm_branch == LLVM_TRUNK_BRANCH:
       # Only do clean rebuilds of llvm on trunk
       factory.addStep(RemoveDirectory(dir = 'llvm-build-' + config, haltOnFailure = False))
-    factory.addStep(MakeDirectory(dir = 'llvm-build-' + config, haltOnFailure = False))
-
-    if llvm == 'trunk':
       factory.addStep(RemoveDirectory(dir = 'llvm-install-' + config, haltOnFailure = False))
+
+    factory.addStep(MakeDirectory(dir = 'llvm-build-' + config, haltOnFailure = False))
     factory.addStep(MakeDirectory(dir = 'llvm-install-' + config, haltOnFailure = False))
 
     factory.addStep(CMake(name = 'Configure LLVM',
@@ -532,9 +480,9 @@ def create_win_factory(os, llvm):
                           locks = [performance_lock.access('counting')],
                           haltOnFailure = True,
                           workdir = 'llvm-build-%s' % config,
-                          path = '../llvm/',
+                          path = '../llvm-project/llvm/',
                           generator = get_cmake_generator(os),
-                          definitions = get_llvm_cmake_definitions(os, config, llvm),
+                          definitions = get_llvm_cmake_definitions(os, config, llvm_branch),
                           options = get_cmake_options(os)))
 
     factory.addStep(
@@ -688,65 +636,69 @@ def create_win_factory(os, llvm):
   return factory
 
 
-def create_builder(os, llvm):
-  factory = create_factory(os, llvm)
+def create_builder(os, llvm_branch):
+  factory = create_factory(os, llvm_branch)
 
   tags = os.split('-')
-  tags.append('llvm-' + llvm)
+  tags.append('llvm-' + llvm_branch)
   if 'testbranch' not in tags:
     tags.append('master')
 
-  builder = BuilderConfig(name = os + '-' + llvm,
+  builder = BuilderConfig(name = os + '-' + llvm_branch,
                           workernames = get_workers(os),
                           factory = factory,
                           collapseRequests = True,
                           tags = tags)
 
-  builder.llvm = llvm
+  builder.llvm_branch = llvm_branch
   builder.os = os
 
   c['builders'].append(builder)
 
-def create_scheduler(llvm):
+def create_scheduler(llvm_branch):
 
-  def master_only(change):
+  def master_only(change, llvm_branch):
     # For PyBind11, ignore branches and always accept the change
     if 'pybind11' in change.repository:
       return True
+    if 'llvm' in change.repository:
+      return change.branch == llvm_branch
     return change.branch == 'master' or change.branch is None
 
-  def not_master(change):
+  def not_master(change, llvm_branch):
     # For PyBind11, ignore branches and always accept the change
     if 'pybind11' in change.repository:
       return True
-    return not master_only(change)
+    if 'llvm' in change.repository:
+      return change.branch == llvm_branch
+    return not master_only(change, llvm_branch)
 
-  builders = [str(b.name) for b in c['builders'] if b.llvm == llvm and 'testbranch' not in b.name]
+  builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch and 'testbranch' not in b.name]
   scheduler = SingleBranchScheduler(
-      name = 'halide-' + llvm,
-      codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm, 'lld-' + llvm],
-      change_filter = util.ChangeFilter(filter_fn = master_only),
+      name = 'halide-' + llvm_branch,
+      codebases = ['halide', 'pybind11', 'llvm'],
+      change_filter = util.ChangeFilter(filter_fn = partial(master_only, llvm_branch=llvm_branch)),
       treeStableTimer = 60*5, # seconds
       builderNames = builders)
 
   c['schedulers'].append(scheduler)
 
-  builders = [str(b.name) for b in c['builders'] if b.llvm == llvm and 'testbranch' in b.name]
+  builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch and 'testbranch' in b.name]
   if builders:
       scheduler = SingleBranchScheduler(
-          name = 'halide-testbranch-' + llvm,
-          codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm, 'lld-' + llvm],
-          change_filter = util.ChangeFilter(filter_fn = not_master),
+          name = 'halide-testbranch-' + llvm_branch,
+          codebases = ['halide', 'pybind11', 'llvm'],
+          change_filter = util.ChangeFilter(filter_fn = partial(not_master, llvm_branch=llvm_branch)),
           treeStableTimer = 60*5, # seconds
           builderNames = builders)
 
       c['schedulers'].append(scheduler)
 
-  builders = [str(b.name) for b in c['builders'] if b.llvm == llvm]
+  builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch]
   scheduler = ForceScheduler(
-    name = 'force-' + llvm,
+    name = 'force-' + llvm_branch,
     builderNames = builders,
-    codebases = ['halide', 'pybind11', 'llvm-' + llvm, 'clang-' + llvm, 'lld-' + llvm])
+    codebases = ['halide', 'pybind11', 'llvm'])
 
   c['schedulers'].append(scheduler)
 
@@ -757,47 +709,47 @@ c['builders'] = []
 # distributions with a uniform llvm version. We also test against llvm
 # trunk, with lower priority, so that we can bisect llvm trunk
 # breakages on various platforms if they are discovered late.
-create_builder('arm32-linux-32', 'trunk')
-create_builder('arm64-linux-64', 'trunk')
-create_builder('arm32-linux-32', '800')
-create_builder('arm64-linux-64', '800')
+create_builder('arm32-linux-32', LLVM_TRUNK_BRANCH)
+create_builder('arm64-linux-64', LLVM_TRUNK_BRANCH)
+create_builder('arm32-linux-32', LLVM_8_BRANCH)
+create_builder('arm64-linux-64', LLVM_8_BRANCH)
 
-create_builder('linux-32-gcc53', 'trunk')
-create_builder('linux-64-gcc53', 'trunk')
-create_builder('linux-32-gcc53', '800')
-create_builder('linux-32-gcc53', '900')
-create_builder('linux-64-gcc53', '800')
-create_builder('linux-64-gcc53', '900')
+create_builder('linux-32-gcc53', LLVM_TRUNK_BRANCH)
+create_builder('linux-64-gcc53', LLVM_TRUNK_BRANCH)
+create_builder('linux-32-gcc53', LLVM_8_BRANCH)
+create_builder('linux-32-gcc53', LLVM_9_BRANCH)
+create_builder('linux-64-gcc53', LLVM_8_BRANCH)
+create_builder('linux-64-gcc53', LLVM_9_BRANCH)
 
-create_builder('mac-64', 'trunk')
-create_builder('mac-64', '800')
-create_builder('mac-64', '900')
+create_builder('mac-64', LLVM_TRUNK_BRANCH)
+create_builder('mac-64', LLVM_8_BRANCH)
+create_builder('mac-64', LLVM_9_BRANCH)
 
-create_builder('win-32', 'trunk')
-create_builder('win-64', 'trunk')
-create_builder('win-32-distro', '800')
-create_builder('win-64-distro', '800')
+create_builder('win-32', LLVM_TRUNK_BRANCH)
+create_builder('win-64', LLVM_TRUNK_BRANCH)
+create_builder('win-32-distro', LLVM_8_BRANCH)
+create_builder('win-64-distro', LLVM_8_BRANCH)
 
-create_builder('mingw-64', '800')
+create_builder('mingw-64', LLVM_8_BRANCH)
 
 # Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.
-create_builder('win-64-testbranch',         '800')
-create_builder('win-32-testbranch',         '800')
-create_builder('mac-64-testbranch',         '800')
-create_builder('linux-64-gcc53-testbranch', '800')
-create_builder('linux-32-gcc53-testbranch', '800')
-create_builder('mingw-64-testbranch',       '800')
-create_builder('arm64-linux-64-testbranch', '800')
-create_builder('arm32-linux-32-testbranch', '800')
+create_builder('win-64-testbranch',         LLVM_8_BRANCH)
+create_builder('win-32-testbranch',         LLVM_8_BRANCH)
+create_builder('mac-64-testbranch',         LLVM_8_BRANCH)
+create_builder('linux-64-gcc53-testbranch', LLVM_8_BRANCH)
+create_builder('linux-32-gcc53-testbranch', LLVM_8_BRANCH)
+create_builder('mingw-64-testbranch',       LLVM_8_BRANCH)
+create_builder('arm64-linux-64-testbranch', LLVM_8_BRANCH)
+create_builder('arm32-linux-32-testbranch', LLVM_8_BRANCH)
 
 # Check for build breakages against other llvm versions too
-create_builder('linux-64-gcc53-testbranch', '900')
-create_builder('linux-64-gcc53-testbranch', 'trunk')
+create_builder('linux-64-gcc53-testbranch', LLVM_9_BRANCH)
+create_builder('linux-64-gcc53-testbranch', LLVM_TRUNK_BRANCH)
 
 c['schedulers'] = []
-create_scheduler('trunk')
-create_scheduler('900')
-create_scheduler('800')
+create_scheduler(LLVM_TRUNK_BRANCH)
+create_scheduler(LLVM_9_BRANCH)
+create_scheduler(LLVM_8_BRANCH)
 
 # Create a scheduler to force a test of a branch
 builders = [str(b.name) for b in c['builders'] if 'testbranch' in b.name]
@@ -806,15 +758,7 @@ scheduler = ForceScheduler(
   builderNames = builders,
   codebases = ['halide',
                'pybind11',
-               'llvm-900',
-               'clang-900',
-               'lld-900',
-               'llvm-800',
-               'clang-800',
-               'lld-800',
-               'llvm-trunk',
-               'clang-trunk',
-               'lld-trunk'])
+               'llvm'])
 c['schedulers'].append(scheduler)
 
 # Set the builder priorities
@@ -829,9 +773,9 @@ def prioritize_builders(master, builders):
     # releases. We care most about the most recently-released llvm so
     # that we have a full set of builds for releases, then llvm trunk
     # for bisection, then older llvm versions.
-    if '900' in builder.name: return 1
-    if 'trunk' in builder.name: return 2
-    if '800' in builder.name: return 3
+    if LLVM_9_BRANCH in builder.name: return 1
+    if LLVM_TRUNK_BRANCH in builder.name: return 2
+    if LLVM_8_BRANCH in builder.name: return 3
     return 4
 
   builders.sort(key = importance)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -13,8 +13,14 @@ from functools import partial
 from os.path import isfile
 from twisted.internet import defer
 
-# This is a sample buildmaster config file. It must be installed as
-# 'master.cfg' in your buildmaster's base directory.
+PYBIND11_BRANCH = 'v2.2'
+
+LLVM_TRUNK_BRANCH = 'master'
+LLVM_9_BRANCH = 'release/9.x'
+LLVM_8_BRANCH = 'release/8.x'
+
+def _clean_name(n):
+  return n.replace('/', '_').replace('.', '_')
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -62,12 +68,6 @@ performance_lock = util.WorkerLock("performance_lock",
 
 # the 'change_source' setting tells the buildmaster how it should find out
 # about source code changes.  Here we point to the buildbot clone of halide.
-
-PYBIND11_BRANCH = 'v2.2'
-
-LLVM_TRUNK_BRANCH = 'master'
-LLVM_9_BRANCH = 'release/9.x'
-LLVM_8_BRANCH = 'release/8.x'
 
 c['change_source'] = []
 
@@ -640,11 +640,11 @@ def create_builder(os, llvm_branch):
   factory = create_factory(os, llvm_branch)
 
   tags = os.split('-')
-  tags.append('llvm-' + llvm_branch)
+  tags.append('llvm-' + _clean_name(llvm_branch))
   if 'testbranch' not in tags:
     tags.append('master')
 
-  builder = BuilderConfig(name = os + '-' + llvm_branch,
+  builder = BuilderConfig(name = os + '-' + _clean_name(llvm_branch),
                           workernames = get_workers(os),
                           factory = factory,
                           collapseRequests = True,
@@ -675,7 +675,7 @@ def create_scheduler(llvm_branch):
 
   builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch and 'testbranch' not in b.name]
   scheduler = SingleBranchScheduler(
-      name = 'halide-' + llvm_branch,
+      name = 'halide-' + _clean_name(llvm_branch),
       codebases = ['halide', 'pybind11', 'llvm'],
       change_filter = util.ChangeFilter(filter_fn = partial(master_only, llvm_branch=llvm_branch)),
       treeStableTimer = 60*5, # seconds
@@ -686,7 +686,7 @@ def create_scheduler(llvm_branch):
   builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch and 'testbranch' in b.name]
   if builders:
       scheduler = SingleBranchScheduler(
-          name = 'halide-testbranch-' + llvm_branch,
+          name = 'halide-testbranch-' + _clean_name(llvm_branch),
           codebases = ['halide', 'pybind11', 'llvm'],
           change_filter = util.ChangeFilter(filter_fn = partial(not_master, llvm_branch=llvm_branch)),
           treeStableTimer = 60*5, # seconds
@@ -696,7 +696,7 @@ def create_scheduler(llvm_branch):
 
   builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch]
   scheduler = ForceScheduler(
-    name = 'force-' + llvm_branch,
+    name = 'force-' + _clean_name(llvm_branch),
     builderNames = builders,
     codebases = ['halide', 'pybind11', 'llvm'])
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -9,7 +9,7 @@ from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.trysched import Try_Userpass
 from buildbot.plugins import util
-from from functools import partial
+from functools import partial
 from os.path import isfile
 from twisted.internet import defer
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -19,8 +19,15 @@ LLVM_TRUNK_BRANCH = 'master'
 LLVM_9_BRANCH = 'release/9.x'
 LLVM_8_BRANCH = 'release/8.x'
 
-def _clean_name(n):
-  return n.replace('/', '_').replace('.', '_')
+# Map the branchnames to the "old" naming style, for continuity
+_TO_NAME = {
+  LLVM_TRUNK_BRANCH: 'trunk',
+  LLVM_9_BRANCH: '900',
+  LLVM_8_BRANCH: '800',
+}
+
+def to_name(llvm_branch):
+  return _TO_NAME[llvm_branch]
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -176,7 +183,7 @@ def add_get_source_steps(factory, llvm_branch):
                       branch = PYBIND11_BRANCH,
                       mode = 'incremental'))
 
-  factory.addStep(Git(name = 'Get LLVM ' + llvm_branch,
+  factory.addStep(Git(name = 'Get LLVM ' + to_name(llvm_branch),
                       locks = [performance_lock.access('counting')],
                       codebase = 'llvm',
                       workdir = 'llvm-project',
@@ -640,11 +647,11 @@ def create_builder(os, llvm_branch):
   factory = create_factory(os, llvm_branch)
 
   tags = os.split('-')
-  tags.append('llvm-' + _clean_name(llvm_branch))
+  tags.append('llvm-' + to_name(llvm_branch))
   if 'testbranch' not in tags:
     tags.append('master')
 
-  builder = BuilderConfig(name = os + '-' + _clean_name(llvm_branch),
+  builder = BuilderConfig(name = os + '-' + to_name(llvm_branch),
                           workernames = get_workers(os),
                           factory = factory,
                           collapseRequests = True,
@@ -675,7 +682,7 @@ def create_scheduler(llvm_branch):
 
   builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch and 'testbranch' not in b.name]
   scheduler = SingleBranchScheduler(
-      name = 'halide-' + _clean_name(llvm_branch),
+      name = 'halide-' + to_name(llvm_branch),
       codebases = ['halide', 'pybind11', 'llvm'],
       change_filter = util.ChangeFilter(filter_fn = partial(master_only, llvm_branch=llvm_branch)),
       treeStableTimer = 60*5, # seconds
@@ -686,7 +693,7 @@ def create_scheduler(llvm_branch):
   builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch and 'testbranch' in b.name]
   if builders:
       scheduler = SingleBranchScheduler(
-          name = 'halide-testbranch-' + _clean_name(llvm_branch),
+          name = 'halide-testbranch-' + to_name(llvm_branch),
           codebases = ['halide', 'pybind11', 'llvm'],
           change_filter = util.ChangeFilter(filter_fn = partial(not_master, llvm_branch=llvm_branch)),
           treeStableTimer = 60*5, # seconds
@@ -696,7 +703,7 @@ def create_scheduler(llvm_branch):
 
   builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch]
   scheduler = ForceScheduler(
-    name = 'force-' + _clean_name(llvm_branch),
+    name = 'force-' + to_name(llvm_branch),
     builderNames = builders,
     codebases = ['halide', 'pybind11', 'llvm'])
 
@@ -773,9 +780,9 @@ def prioritize_builders(master, builders):
     # releases. We care most about the most recently-released llvm so
     # that we have a full set of builds for releases, then llvm trunk
     # for bisection, then older llvm versions.
-    if LLVM_9_BRANCH in builder.name: return 1
-    if LLVM_TRUNK_BRANCH in builder.name: return 2
-    if LLVM_8_BRANCH in builder.name: return 3
+    if to_name(LLVM_9_BRANCH) in builder.name: return 1
+    if to_name(LLVM_TRUNK_BRANCH) in builder.name: return 2
+    if to_name(LLVM_8_BRANCH) in builder.name: return 3
     return 4
 
   builders.sort(key = importance)


### PR DESCRIPTION
See https://github.com/halide/Halide/issues/4394 and https://llvm.org/docs/Proposals/GitHubMove.html for more info.

This is a work in progress that needs some testing, but initial feedback welcome.

The basic changes:
- The Git repo now includes all the tools we need (including clang and lld) as subprojects
- It includes the old releases we need as branches

(Note that you can still pull the subprojects individually, but I checked and just pulling the entire repo is only trivially larger than what we do now; pulling the whole thing simplifies the world)