### PR TITLE
Remove PyBind11 handling from buildbot

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -13,8 +13,6 @@ from functools import partial
 from os.path import isfile
 from twisted.internet import defer
 
-PYBIND11_BRANCH = 'v2.2'
-
 LLVM_TRUNK_BRANCH = 'master'
 LLVM_9_BRANCH = 'release/9.x'
 LLVM_8_BRANCH = 'release/8.x'
@@ -87,13 +85,6 @@ c['change_source'].append(GitPoller(
     pollInterval = 60*5,  # Check Halide master every five minutes
     pollAtLaunch = True))
 
-c['change_source'].append(GitPoller(
-    repourl = 'git://github.com/pybind/pybind11.git',
-    workdir = 'gitpoller-pybind11-workdir',
-    branch = PYBIND11_BRANCH,
-    pollInterval = 60*60*24, # Only check pybind11 once every 24 hours
-    pollAtLaunch = True))
-
 def pr_filter(pr):
     # Auto test anything in the halide master repo
     # print("Considering PR: ", pr['title'], pr['html_url'])
@@ -131,8 +122,6 @@ all_repositories = {
     u'https://github.com/halide/Halide.git' : 'halide',
     r'git://github.com/llvm/llvm-project.git' : 'llvm',
     u'https://github.com/llvm/llvm-project.git' : 'llvm',
-    r'git://github.com/pybind/pybind11.git' : 'pybind11',
-    u'https://github.com/pybind/pybind11.git' : 'pybind11',
 }
 
 def codebase_generator(chdict):
@@ -172,15 +161,6 @@ def add_get_source_steps(factory, llvm_branch):
                       workdir = 'halide',
                       repourl = 'git://github.com/halide/Halide.git',
                       branch = 'master',
-                      mode = 'incremental'))
-
-  # PyBind11 is a header-only library: we don't need to build it, we just need to pull it
-  factory.addStep(Git(name = 'Get PyBind11',
-                      locks = [performance_lock.access('counting')],
-                      codebase = 'pybind11',
-                      workdir = 'pybind11',
-                      repourl = 'git://github.com/pybind/pybind11.git',
-                      branch = PYBIND11_BRANCH,
                       mode = 'incremental'))
 
   factory.addStep(Git(name = 'Get LLVM ' + to_name(llvm_branch),
@@ -256,8 +236,7 @@ def get_llvm_cmake_definitions(os, config, llvm_branch):
 
 
 def get_env(os, config):
-  env = {'LLVM_CONFIG': '../llvm-build-%s/bin/llvm-config' % config,
-         'PYBIND11_PATH': '../pybind11'}
+  env = {'LLVM_CONFIG': '../llvm-build-%s/bin/llvm-config' % config}
 
   cxx = 'c++'
   cc = 'cc'
@@ -663,17 +642,11 @@ def create_builder(os, llvm_branch):
 def create_scheduler(llvm_branch):
 
   def master_only(change, llvm_branch):
-    # For PyBind11, ignore branches and always accept the change
-    if 'pybind11' in change.repository:
-      return True
     if 'llvm' in change.repository:
       return change.branch == llvm_branch
     return change.branch == 'master' or change.branch is None
 
   def not_master(change, llvm_branch):
-    # For PyBind11, ignore branches and always accept the change
-    if 'pybind11' in change.repository:
-      return True
     if 'llvm' in change.repository:
       return change.branch == llvm_branch
     return not master_only(change, llvm_branch)
@@ -681,7 +654,7 @@ def create_scheduler(llvm_branch):
   builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch and 'testbranch' not in b.name]
   scheduler = SingleBranchScheduler(
       name = 'halide-' + to_name(llvm_branch),
-      codebases = ['halide', 'pybind11', 'llvm'],
+      codebases = ['halide', 'llvm'],
       change_filter = util.ChangeFilter(filter_fn = partial(master_only, llvm_branch=llvm_branch)),
       treeStableTimer = 60*5, # seconds
       builderNames = builders)
@@ -692,7 +665,7 @@ def create_scheduler(llvm_branch):
   if builders:
       scheduler = SingleBranchScheduler(
           name = 'halide-testbranch-' + to_name(llvm_branch),
-          codebases = ['halide', 'pybind11', 'llvm'],
+          codebases = ['halide', 'llvm'],
           change_filter = util.ChangeFilter(filter_fn = partial(not_master, llvm_branch=llvm_branch)),
           treeStableTimer = 60*5, # seconds
           builderNames = builders)
@@ -703,7 +676,7 @@ def create_scheduler(llvm_branch):
   scheduler = ForceScheduler(
     name = 'force-' + to_name(llvm_branch),
     builderNames = builders,
-    codebases = ['halide', 'pybind11', 'llvm'])
+    codebases = ['halide', 'llvm'])
 
   c['schedulers'].append(scheduler)
 
@@ -762,7 +735,6 @@ scheduler = ForceScheduler(
   name = 'testbranch',
   builderNames = builders,
   codebases = ['halide',
-               'pybind11',
                'llvm'])
 c['schedulers'].append(scheduler)
 


### PR DESCRIPTION
If/when we land https://github.com/halide/Halide/pull/4608, this change removes no-longer-necessary cruft related to PyBind11 from the buildbot script.

(Don't land until that other one lands; just putting it out there for early review.)