### PR TITLE
Drop LLVM8, Add LLVM10

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -689,20 +689,19 @@ create_builder('mac-64', LLVM_10_BRANCH)
 
 create_builder('win-32', LLVM_TRUNK_BRANCH)
 create_builder('win-64', LLVM_TRUNK_BRANCH)
-create_builder('win-32-distro', LLVM_TRUNK_BRANCH)
-create_builder('win-64-distro', LLVM_TRUNK_BRANCH)
+create_builder('win-32-distro', LLVM_10_BRANCH)
+create_builder('win-64-distro', LLVM_10_BRANCH)
 
-# Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.
-create_builder('win-64-testbranch',         LLVM_9_BRANCH)
-create_builder('win-32-testbranch',         LLVM_9_BRANCH)
-create_builder('mac-64-testbranch',         LLVM_9_BRANCH)
-create_builder('linux-64-gcc53-testbranch', LLVM_9_BRANCH)
-create_builder('linux-32-gcc53-testbranch', LLVM_9_BRANCH)
-create_builder('arm64-linux-64-testbranch', LLVM_9_BRANCH)
-create_builder('arm32-linux-32-testbranch', LLVM_9_BRANCH)
+# Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround. Usually the most recent 'released' (non-trunk) version is the best choice.
+create_builder('win-64-testbranch',         LLVM_10_BRANCH)
+create_builder('win-32-testbranch',         LLVM_10_BRANCH)
+create_builder('mac-64-testbranch',         LLVM_10_BRANCH)
+create_builder('linux-64-gcc53-testbranch', LLVM_10_BRANCH)
+create_builder('linux-32-gcc53-testbranch', LLVM_10_BRANCH)
+create_builder('arm64-linux-64-testbranch', LLVM_10_BRANCH)
+create_builder('arm32-linux-32-testbranch', LLVM_10_BRANCH)
 
 # Check for build breakages against other llvm versions too
-create_builder('linux-64-gcc53-testbranch', LLVM_10_BRANCH)
 create_builder('linux-64-gcc53-testbranch', LLVM_9_BRANCH)
 
 c['schedulers'] = []

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -689,8 +689,8 @@ create_builder('mac-64', LLVM_10_BRANCH)
 
 create_builder('win-32', LLVM_TRUNK_BRANCH)
 create_builder('win-64', LLVM_TRUNK_BRANCH)
-create_builder('win-32-distro', LLVM_9_BRANCH)
-create_builder('win-64-distro', LLVM_9_BRANCH)
+create_builder('win-32-distro', LLVM_TRUNK_BRANCH)
+create_builder('win-64-distro', LLVM_TRUNK_BRANCH)
 
 # Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.
 create_builder('win-64-testbranch',         LLVM_9_BRANCH)
@@ -703,7 +703,7 @@ create_builder('arm32-linux-32-testbranch', LLVM_9_BRANCH)
 
 # Check for build breakages against other llvm versions too
 create_builder('linux-64-gcc53-testbranch', LLVM_10_BRANCH)
-create_builder('linux-64-gcc53-testbranch', LLVM_TRUNK_BRANCH)
+create_builder('linux-64-gcc53-testbranch', LLVM_9_BRANCH)
 
 c['schedulers'] = []
 create_scheduler(LLVM_TRUNK_BRANCH)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -14,14 +14,14 @@ from os.path import isfile
 from twisted.internet import defer
 
 LLVM_TRUNK_BRANCH = 'master'
+LLVM_10_BRANCH = 'release/10.x'
 LLVM_9_BRANCH = 'release/9.x'
-LLVM_8_BRANCH = 'release/8.x'
 
 # Map the branchnames to the "old" naming style, for continuity
 _TO_NAME = {
   LLVM_TRUNK_BRANCH: 'trunk',
+  LLVM_10_BRANCH = '1000'
   LLVM_9_BRANCH: '900',
-  LLVM_8_BRANCH: '800',
 }
 
 def to_name(llvm_branch):
@@ -153,7 +153,7 @@ from buildbot.process.properties import Interpolate
 
 def add_get_source_steps(factory, llvm_branch):
 
-  assert llvm_branch in [LLVM_TRUNK_BRANCH, LLVM_9_BRANCH, LLVM_8_BRANCH]
+  assert llvm_branch in [LLVM_TRUNK_BRANCH, LLVM_10_BRANCH, LLVM_9_BRANCH]
 
   factory.addStep(Git(name = 'Get Halide master',
                       locks = [performance_lock.access('counting')],
@@ -673,42 +673,42 @@ c['builders'] = []
 # breakages on various platforms if they are discovered late.
 create_builder('arm32-linux-32', LLVM_TRUNK_BRANCH)
 create_builder('arm64-linux-64', LLVM_TRUNK_BRANCH)
-create_builder('arm32-linux-32', LLVM_8_BRANCH)
-create_builder('arm64-linux-64', LLVM_8_BRANCH)
+create_builder('arm32-linux-32', LLVM_9_BRANCH)
+create_builder('arm64-linux-64', LLVM_9_BRANCH)
 
 create_builder('linux-32-gcc53', LLVM_TRUNK_BRANCH)
 create_builder('linux-64-gcc53', LLVM_TRUNK_BRANCH)
-create_builder('linux-32-gcc53', LLVM_8_BRANCH)
 create_builder('linux-32-gcc53', LLVM_9_BRANCH)
-create_builder('linux-64-gcc53', LLVM_8_BRANCH)
+create_builder('linux-32-gcc53', LLVM_10_BRANCH)
 create_builder('linux-64-gcc53', LLVM_9_BRANCH)
+create_builder('linux-64-gcc53', LLVM_10_BRANCH)
 
 create_builder('mac-64', LLVM_TRUNK_BRANCH)
-create_builder('mac-64', LLVM_8_BRANCH)
 create_builder('mac-64', LLVM_9_BRANCH)
+create_builder('mac-64', LLVM_10_BRANCH)
 
 create_builder('win-32', LLVM_TRUNK_BRANCH)
 create_builder('win-64', LLVM_TRUNK_BRANCH)
-create_builder('win-32-distro', LLVM_8_BRANCH)
-create_builder('win-64-distro', LLVM_8_BRANCH)
+create_builder('win-32-distro', LLVM_9_BRANCH)
+create_builder('win-64-distro', LLVM_9_BRANCH)
 
 # Make some builders just for testing branches. Picking a fixed llvm version will avoid LLVM rebuilds for the best turnaround.
-create_builder('win-64-testbranch',         LLVM_8_BRANCH)
-create_builder('win-32-testbranch',         LLVM_8_BRANCH)
-create_builder('mac-64-testbranch',         LLVM_8_BRANCH)
-create_builder('linux-64-gcc53-testbranch', LLVM_8_BRANCH)
-create_builder('linux-32-gcc53-testbranch', LLVM_8_BRANCH)
-create_builder('arm64-linux-64-testbranch', LLVM_8_BRANCH)
-create_builder('arm32-linux-32-testbranch', LLVM_8_BRANCH)
+create_builder('win-64-testbranch',         LLVM_9_BRANCH)
+create_builder('win-32-testbranch',         LLVM_9_BRANCH)
+create_builder('mac-64-testbranch',         LLVM_9_BRANCH)
+create_builder('linux-64-gcc53-testbranch', LLVM_9_BRANCH)
+create_builder('linux-32-gcc53-testbranch', LLVM_9_BRANCH)
+create_builder('arm64-linux-64-testbranch', LLVM_9_BRANCH)
+create_builder('arm32-linux-32-testbranch', LLVM_9_BRANCH)
 
 # Check for build breakages against other llvm versions too
-create_builder('linux-64-gcc53-testbranch', LLVM_9_BRANCH)
+create_builder('linux-64-gcc53-testbranch', LLVM_10_BRANCH)
 create_builder('linux-64-gcc53-testbranch', LLVM_TRUNK_BRANCH)
 
 c['schedulers'] = []
 create_scheduler(LLVM_TRUNK_BRANCH)
+create_scheduler(LLVM_10_BRANCH)
 create_scheduler(LLVM_9_BRANCH)
-create_scheduler(LLVM_8_BRANCH)
 
 # Create a scheduler to force a test of a branch
 builders = [str(b.name) for b in c['builders'] if 'testbranch' in b.name]
@@ -731,9 +731,9 @@ def prioritize_builders(master, builders):
     # releases. We care most about the most recently-released llvm so
     # that we have a full set of builds for releases, then llvm trunk
     # for bisection, then older llvm versions.
-    if to_name(LLVM_9_BRANCH) in builder.name: return 1
+    if to_name(LLVM_10_BRANCH) in builder.name: return 1
     if to_name(LLVM_TRUNK_BRANCH) in builder.name: return 2
-    if to_name(LLVM_8_BRANCH) in builder.name: return 3
+    if to_name(LLVM_9_BRANCH) in builder.name: return 3
     return 4
 
   builders.sort(key = importance)


### PR DESCRIPTION
Drop LLVM8 testing from buildbots, add LLVM10.

Targets formerly using LLVM8 -> LLVM9, and LLVM9 -> LLVM 10.

(Don't land yet, this is in anticipation of LLVM10 being release-tagged soon)

See https://github.com/halide/Halide/issues/4560