### PR TITLE
Stop setting PYTHON_EXECUTABLE for windows buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -231,13 +231,6 @@ def get_llvm_cmake_definitions(os, config, llvm_branch):
         definitions['CMAKE_FIND_ROOT_PATH'] = '/usr/lib/i386-linux-gnu'
         definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = 'ONLY'
 
-    # CMake is infamously flaky about finding the 'right' version of Python
-    # reliably, and configuring your system to change its preferences
-    # is apparently not a thing. On Windows this can be catastrophic;
-    # ensure that CMake is explicitly pointed at Windows Python 2.7 for now.
-    if os.startswith('win'):
-        definitions['PYTHON_EXECUTABLE'] = 'c:/Python27/python'
-
     # This disables an XCode setting that can get enabled by default
     # when assertions are enabled, but only if your XCode install has
     # certain frameworks installed; we want it disabled, as it prevents


### PR DESCRIPTION
This was especially important back in the mingw days, but we will need to be upgrading the winbots to use Python3 (for python-bindings build and test), so we should just stop setting this and rely on a correct path. (I'll fix the buildbots as appropriate.)