### PR TITLE
Skip PRs labeled with 'skip_buildbots'

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -106,8 +106,14 @@ def pr_filter(pr):
     if reviewers is not None:
         for r in reviewers:
             result = result or (r['login'] == 'halidebuildbots')
+    # Any PR labeled with 'skip_buildbots' should be skipped
+    labels = pr['labels']
+    if labels is not None:
+        for l in labels:
+            if l['name'] == 'skip_buildbots':
+                result = False
     # print("Filter result: ", result)
-    print("PR: ", pr['title'], pr['html_url'], ' => ', result)
+    # print("PR: ", pr['title'], pr['html_url'], ' => ', result)
     return result
 
 c['change_source'].append(GitHubPullrequestPoller(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -778,6 +778,10 @@ def prioritize_builders(master, builders):
 
     builders.sort(key=importance)
 
+    print("prioritize_builders:")
+    for b in builders:
+        print("  PB: %s -> pri %d" % (b.name, importance(b)))
+
     return builders
 
 c['prioritizeBuilders'] = prioritize_builders


### PR DESCRIPTION
Short-term I want to avoid loading the 'old' buildbots while experimenting with the GHA builders, but this could also be useful for (e.g.) updating documentation only.