### PR TITLE
The buildbot 'testbranch' scheduler should not listen for llvm changes

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -632,6 +632,8 @@ def ctest_command_line(testgroup, cfg='', parallel=0):
 def create_builder(os, llvm_branch):
     factory = create_factory(os, llvm_branch)
 
+    # TODO: are these tags used for anything?
+    # Are they possible to inspect in the Buildbot UI?
     tags = os.split('-')
     tags.append('llvm-' + to_name(llvm_branch))
     if 'testbranch' not in tags:
@@ -651,40 +653,50 @@ def create_builder(os, llvm_branch):
 
 def create_scheduler(llvm_branch):
 
-    def master_only(change, llvm_branch):
+    # Find the builders that are for Halide master (ie, not testbranch)
+    # and schedule them to run anytime we see a change in llvm-master or halide-master
+    # (checked every five minutes)
+    builders = [str(b.name) for b in c['builders'] if b.llvm_branch ==
+                llvm_branch and 'testbranch' not in b.name]
+
+    def is_halide_master(change, llvm_branch):
         if 'llvm' in change.repository:
             return change.branch == llvm_branch
         return change.branch == 'master' or change.branch is None
 
-    def not_master(change, llvm_branch):
-        if 'llvm' in change.repository:
-            return change.branch == llvm_branch
-        return not master_only(change, llvm_branch)
-
-    builders = [str(b.name) for b in c['builders'] if b.llvm_branch ==
-                llvm_branch and 'testbranch' not in b.name]
     scheduler = SingleBranchScheduler(
         name='halide-' + to_name(llvm_branch),
         codebases=['halide', 'llvm'],
-        change_filter=util.ChangeFilter(filter_fn=partial(master_only, llvm_branch=llvm_branch)),
+        change_filter=util.ChangeFilter(filter_fn=partial(is_halide_master, llvm_branch=llvm_branch)),
         treeStableTimer=60 * 5,  # seconds
         builderNames=builders)
 
     c['schedulers'].append(scheduler)
 
+    # Find the builders that are for Halide pull requests (ie, not master)
+    # and schedule them to run anytime we see a change in the pull-request branch
+    # (but *not* for changes in llvm -- we don't want arbitrary changes in llvm trunk
+    # to trigger rebuilds for a PR)
     builders = [str(b.name) for b in c['builders'] if b.llvm_branch ==
                 llvm_branch and 'testbranch' in b.name]
+
+    def is_halide_testbranch(change):
+        if 'llvm' in change.repository:
+            print('is_halide_testbranch should never see llvm changes')
+            return True
+        return change.branch is not None and change.branch != 'master'
+
     if builders:
         scheduler = SingleBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
-            codebases=['halide', 'llvm'],
-            change_filter=util.ChangeFilter(
-                filter_fn=partial(not_master, llvm_branch=llvm_branch)),
+            codebases=['halide'],
+            change_filter=util.ChangeFilter(filter_fn=is_halide_testbranch),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 
         c['schedulers'].append(scheduler)
 
+    # Finally, add the 'schedulers' that allow us to force a build
     builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch]
     scheduler = ForceScheduler(
         name='force-' + to_name(llvm_branch),
@@ -749,8 +761,7 @@ builders = [str(b.name) for b in c['builders'] if 'testbranch' in b.name]
 scheduler = ForceScheduler(
     name='testbranch',
     builderNames=builders,
-    codebases=['halide',
-               'llvm'])
+    codebases=['halide', 'llvm'])
 c['schedulers'].append(scheduler)
 
 # Set the builder priorities


### PR DESCRIPTION
We want to listen for llvm changes to do halide-master changes, but not for any other branches (eg pull requests) -- doing so means that arbitrary changes in upstream llvm-trunk can force rebuilds for existing PRs.