### PR TITLE
Point win-32 to 32-bit Python installation.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -221,6 +221,18 @@ def get_cmake_options(os):
     return options
 
 
+def get_cmake_definitions(os, config):
+    cmake_definitions = {
+        'CMAKE_BUILD_TYPE': config,
+        'LLVM_DIR': Interpolate('%(prop:builddir)s/llvm-install-' + config + '/lib/cmake/llvm'),
+    }
+
+    if os.startswith('win-32'):
+        cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
+
+    return cmake_definitions
+
+
 def get_llvm_cmake_definitions(os, config, llvm_branch):
     definitions = {
         'CMAKE_BUILD_TYPE': config,
@@ -504,10 +516,7 @@ def create_win_factory(os, llvm_branch):
                               workdir='halide-build-' + config,
                               path='..\\halide',
                               generator=get_cmake_generator(os),
-                              definitions={
-                                  'CMAKE_BUILD_TYPE': config,
-                                  'LLVM_DIR': Interpolate('%(prop:builddir)s\\llvm-install-' + config + '\\lib\\cmake\\llvm'),
-                              },
+                              definitions=get_cmake_definitions(os, config),
                               options=get_cmake_options(os)))
 
         factory.addStep(


### PR DESCRIPTION
btw - CMake doesn't care if you use `/` as a path separator on Windows.