### PR TITLE
Skip building OpenGL tests on arm32.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -436,6 +436,9 @@ def create_factory(os, llvm_branch):
         if target == 'test_performance' or target == 'test_tutorial':
             p = 1
             lock_mode = 'exclusive'
+        make_vars = []
+        if 'arm32' in os and target == 'build_tests':
+            make_vars = ['WITH_OPENGL=']
         factory.addStep(ShellCommand(name='make ' + target,
                                      description=target + ' ' + hl_target,
                                      locks=[performance_lock.access(lock_mode)],
@@ -443,7 +446,7 @@ def create_factory(os, llvm_branch):
                                      env=target_env,
                                      haltOnFailure=(target == 'distrib'),
                                      command=['make', '-f', '../halide/Makefile', '-j%s' %
-                                              p, target],
+                                              p, target] + make_vars,
                                      timeout=3600))
         if target == 'distrib' and 'testbranch' not in os:
             factory.addStep(


### PR DESCRIPTION
They aren't run anyway and don't work with system paths since OpenGL isn't installed on those buildbots.