### PR TITLE
Rework CMake support in buildbot

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -9,6 +9,7 @@ from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.trysched import Try_Userpass
 from buildbot.plugins import util
+from collections import defaultdict
 from functools import partial
 from os.path import isfile
 from twisted.internet import defer
@@ -169,6 +170,30 @@ from buildbot.process.properties import renderer
 from buildbot.process.properties import Interpolate
 
 
+def get_builddir_subpath(subpath):
+    return util.Interpolate('%(prop:builddir)s/' + subpath)
+
+
+def get_llvm_source_path(*subpaths):
+    return get_builddir_subpath(os.path.join('llvm-project', *subpaths))
+
+
+def get_llvm_build_path(config, *subpaths):
+    return get_builddir_subpath(os.path.join('llvm-build-%s' % config, *subpaths))
+
+
+def get_llvm_install_path(config, *subpaths):
+    return get_builddir_subpath(os.path.join('llvm-install-%s' % config, *subpaths))
+
+
+def get_halide_source_path(*subpaths):
+    return get_builddir_subpath(os.path.join('halide', *subpaths))
+
+
+def get_halide_build_path(config, *subpaths):
+    return get_builddir_subpath(os.path.join('halide-%s' % config, *subpaths))
+
+
 def add_get_source_steps(factory, llvm_branch):
 
     assert llvm_branch in [LLVM_TRUNK_BRANCH, LLVM_RELEASE_BRANCH, LLVM_OLD_BRANCH]
@@ -176,7 +201,7 @@ def add_get_source_steps(factory, llvm_branch):
     factory.addStep(Git(name='Get Halide master',
                         locks=[performance_lock.access('counting')],
                         codebase='halide',
-                        workdir='halide',
+                        workdir=get_halide_source_path(),
                         repourl='git://github.com/halide/Halide.git',
                         branch='master',
                         mode='incremental'))
@@ -184,7 +209,7 @@ def add_get_source_steps(factory, llvm_branch):
     factory.addStep(Git(name='Get LLVM ' + to_name(llvm_branch),
                         locks=[performance_lock.access('counting')],
                         codebase='llvm',
-                        workdir='llvm-project',
+                        workdir=get_llvm_source_path(),
                         repourl='https://github.com/llvm/llvm-project.git',
                         branch=llvm_branch,
                         mode='incremental'))
@@ -205,40 +230,77 @@ def get_distrib_name(props):
 
 def get_cmake_generator(os):
     if os.startswith('win'):
-        if '-32' in os:
-            return 'Visual Studio 15'
-        else:
-            assert '-64' in os
-            return 'Visual Studio 15 Win64'
+        # if '-32' in os:    # VS2017
+        #     return 'Visual Studio 15'
+        # else:
+        #     assert '-64' in os
+        #     return 'Visual Studio 15 Win64'
+        return 'Visual Studio 16 2019'
     else:
-        return 'Unix Makefiles'
+        return 'Ninja'
 
 
 def get_cmake_options(os):
     options = []
     if os.startswith('win'):
-        options.append('-Thost=x64')
+        # options.append('-Thost=x64')   # VS2017
+        options.extend(['-T', 'host=x64'])
+        if '-32' in os:
+            options.extend(['-A', 'Win32'])
+        else:
+            options.extend(['-A', 'x64'])
     return options
 
 
-def get_cmake_definitions(os, config):
+def get_halide_cmake_definitions(os, config, hl_target='host'):
     cmake_definitions = {
+        'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
         'CMAKE_BUILD_TYPE': config,
-        'LLVM_DIR': Interpolate('%(prop:builddir)s/llvm-install-' + config + '/lib/cmake/llvm'),
+        'HL_TARGET': hl_target,
+        'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm'),
     }
+
+    # The linux and arm linux buildbots have ccache installed
+    # (TODO: can install on mac if we update XCode there)
+    if 'linux' in os:
+        cmake_definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
+        cmake_definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
 
     if os.startswith('win-32'):
         cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
 
+    if os.startswith('win'):
+        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = r'C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
+
+    # Armbots don't have Python configured, so python bindings won't build
+    if os.startswith('arm'):
+        cmake_definitions['WITH_PYTHON_BINDINGS'] = 'OFF'
+
+    # TODO: buildbots + config need love to make 32-bit Python work properly,
+    # just disable the testing for now
+    if os.startswith('linux-32'):
+        cmake_definitions['WITH_PYTHON_BINDINGS'] = 'OFF'
+
     return cmake_definitions
+
+
+def get_cmake_build_command(os, config, build_dir, target=None):
+    cmd = ['cmake',
+           '--build', build_dir,
+           '--config', config,
+           '-j', get_build_parallelism(os)]
+    if target:
+        cmd.extend(['--target', target])
+    return cmd
 
 
 def get_llvm_cmake_definitions(os, config, llvm_branch):
     definitions = {
         'CMAKE_BUILD_TYPE': config,
-        'CMAKE_INSTALL_PREFIX': '../llvm-install-%s' % config,
+        'CMAKE_INSTALL_PREFIX': get_llvm_install_path(config),
         'LLVM_BUILD_32_BITS': ('ON' if '-32' in os else 'OFF'),
         'LLVM_ENABLE_ASSERTIONS': 'ON',
+        'LLVM_ENABLE_LIBXML2': 'OFF',
         'LLVM_ENABLE_PROJECTS': 'clang;lld',
         'LLVM_ENABLE_RTTI': 'ON',
         'LLVM_ENABLE_TERMINFO': 'OFF',
@@ -260,7 +322,7 @@ def get_llvm_cmake_definitions(os, config, llvm_branch):
 
 
 def get_env(os, config):
-    env = {'LLVM_CONFIG': '../llvm-build-%s/bin/llvm-config' % config}
+    env = {'LLVM_CONFIG': get_llvm_build_path(config, 'bin/llvm-config')}
 
     cxx = 'c++'
     cc = 'cc'
@@ -284,6 +346,7 @@ def get_env(os, config):
             cc += ' -m32'
 
     # The linux and arm linux buildbots have ccache installed
+    # (TODO: can install on mac if we update XCode there)
     if 'linux' in os:
         cxx = 'ccache ' + cxx
         cc = 'ccache ' + cc
@@ -308,73 +371,22 @@ def get_env(os, config):
     return env
 
 
-def get_make_threads(os):
+def get_build_parallelism(os):
     # Standard wisdom is (nproc+2)
     if os.startswith('linux'):
         # TODO: our Linux bots also have 12 cores; this seems maybe too high?
-        return 16
+        return 8
     elif os.startswith('mac'):
         # MacBot has 32GB and 6/12 core Xeon. We allow two builds at
         # once so set threads = (12/2)+2 == 8
         return 8
-    elif os.startswith('arm'):
+    elif os.startswith('win'):
+        # WinBots have 6/12 cores but are very slow; let's try half the Mac
         return 4
+    elif os.startswith('arm'):
+        return 2
     else:
         return 1
-
-
-def get_targets(os, llvm_branch):
-    targets = [('distrib', 'host'),
-               ('build_tests', 'host'),
-               ('test_correctness', 'host'),
-               ('test_generator', 'host'),
-               ('test_performance', 'host')]
-
-    if os.startswith('linux-32-gcc53'):
-        # Also test without sse 4.1
-        targets.append(('test_correctness', 'x86-32'))
-
-    if os.startswith('linux-64-gcc53') or os.startswith('mac-64'):
-        # extended cpu/gpu tests
-        targets.extend([('test_correctness', 'x86-64'),
-                        ('test_correctness', 'x86-64-sse41'),
-                        ('test_python', 'host')])
-
-    if os.startswith('linux-64-gcc53') or os.startswith('mac-64'):
-        targets.extend([('test_apps', 'host'),
-                        ('test_tutorial', 'host')])
-
-    if os.startswith('linux-64-gcc53'):
-        # The linux build-bots have an nvidia card
-        targets.extend([('test_correctness', 'host-cuda'),
-                        ('test_generator', 'host-cuda'),
-                        ('test_apps', 'host-cuda'),
-                        ('test_correctness', 'host-opencl'),
-                        ('test_generator', 'host-opencl'),
-                        ('test_apps', 'host-opencl'),
-                        ('correctness_gpu_multi_device', 'host-cuda-opencl')])
-
-    if os.startswith('mac-64'):
-        # test metal on OS X
-        targets.extend([('test_correctness', 'host-metal'),
-                        ('test_generator', 'host-metal'),
-                        ('test_apps', 'host-metal')])
-
-    # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
-    # if os.startswith('win-64'):
-    #   # test d3d12 on windows
-    #   targets.extend([('test_correctness', 'host-d3d12compute'),
-    #                   ('test_generator', 'host-d3d12compute'),
-    #                   ('test_apps', 'host-d3d12compute')])
-
-    if os.startswith('linux-64-gcc53') and llvm_branch == LLVM_TRUNK_BRANCH:
-        # Also test hexagon using the simulator
-        for t in ['host-hvx_128', 'host-hvx_64']:
-            targets.extend([('test_correctness', t),
-                            ('test_generator', t),
-                            ('test_apps', t)])
-
-    return targets
 
 
 def get_workers(os):
@@ -390,260 +402,413 @@ def get_workers(os):
         return ['arm64-linux-worker' + sfx for sfx in worker_suffixes]
 
 
-def create_factory(os, llvm_branch):
-
-    if os.startswith('win'):
-        return create_win_factory(os, llvm_branch)
-
-    config = 'release'
-    env = get_env(os, config)
-    targets = get_targets(os, llvm_branch)
-    make_threads = get_make_threads(os)
-
-    factory = BuildFactory()
-
-    add_get_source_steps(factory, llvm_branch)
-
-    factory.addStep(CMake(name='Configure LLVM',
-                          description='Configure LLVM',
-                          locks=[performance_lock.access('counting')],
-                          haltOnFailure=True,
-                          env=env,
-                          workdir='llvm-build-%s' % config,
-                          path='../llvm-project/llvm/',
-                          generator=get_cmake_generator(os),
-                          definitions=get_llvm_cmake_definitions(os, config, llvm_branch),
-                          options=get_cmake_options(os)))
-
-    factory.addStep(ShellCommand(name='Build LLVM',
-                                 description='Build LLVM',
-                                 locks=[performance_lock.access('counting')],
-                                 workdir='llvm-build-%s' % config,
-                                 env=env,
-                                 haltOnFailure=True,
-                                 command=['make', '-j%s' % make_threads]))
-
-    # Force a full rebuild of Halide every time
-    factory.addStep(RemoveDirectory(dir='halide-build'))
-
-    for (target, hl_target) in targets:
-        target_env = env.copy()
-        target_env['HL_TARGET'] = hl_target
-        target_env['HL_JIT_TARGET'] = hl_target
-
-        p = make_threads
-        lock_mode = 'counting'
-        if target == 'test_performance' or target == 'test_tutorial':
-            p = 1
-            lock_mode = 'exclusive'
-        factory.addStep(ShellCommand(name='make ' + target,
-                                     description=target + ' ' + hl_target,
-                                     locks=[performance_lock.access(lock_mode)],
-                                     workdir='halide-build',
-                                     env=target_env,
-                                     haltOnFailure=(target == 'distrib'),
-                                     command=['make', '-f', '../halide/Makefile', '-j%s' %
-                                              p, target],
-                                     timeout=3600))
-        if target == 'distrib' and 'testbranch' not in os:
-            factory.addStep(
-                FileUpload(workersrc='distrib/halide.tgz',
-                           workdir='halide-build',
-                           mode=0644,
-                           masterdest=get_distrib_name))
-
-            factory.addStep(MasterShellCommand(
-                workdir='/home/abadams/artifacts',
-                command=['bash', '/home/abadams/build_bot_new/clean_artifacts.sh']))
-
-    return factory
-
-
-def create_win_factory(os, llvm_branch):
-    assert os.startswith('win')
-
-    factory = BuildFactory()
-    add_get_source_steps(factory, llvm_branch)
-
-    make_distro = '-distro' in os
-
-    if make_distro:
-        configs = ['Release', 'Debug']
-    else:
-        configs = ['Release']
-
-    # Build llvm and Halide in release and debug modes
+def add_llvm_steps(factory, llvm_branch, os, configs, clean_rebuild):
     for config in configs:
+        env = get_env(os, config)
 
-        factory.addStep(RemoveDirectory(dir='halide-build-' + config, haltOnFailure=False))
-        factory.addStep(MakeDirectory(dir='halide-build-' + config, haltOnFailure=False))
+        build_dir = get_llvm_build_path(config)
+        install_dir = get_llvm_install_path(config)
 
-        if llvm_branch == LLVM_TRUNK_BRANCH:
-            # Only do clean rebuilds of llvm on trunk
-            factory.addStep(RemoveDirectory(dir='llvm-build-' + config, haltOnFailure=False))
-            factory.addStep(RemoveDirectory(dir='llvm-install-' + config, haltOnFailure=False))
+        if clean_rebuild:
+            factory.addStep(RemoveDirectory(dir=build_dir, haltOnFailure=False))
+            factory.addStep(RemoveDirectory(dir=install_dir, haltOnFailure=False))
 
-        factory.addStep(MakeDirectory(dir='llvm-build-' + config, haltOnFailure=False))
-        factory.addStep(MakeDirectory(dir='llvm-install-' + config, haltOnFailure=False))
-
-        factory.addStep(CMake(name='Configure LLVM',
-                              description='Configure LLVM',
-                              locks=[performance_lock.access('counting')],
-                              haltOnFailure=True,
-                              workdir='llvm-build-%s' % config,
-                              path='../llvm-project/llvm/',
-                              generator=get_cmake_generator(os),
-                              definitions=get_llvm_cmake_definitions(os, config, llvm_branch),
-                              options=get_cmake_options(os)))
+        factory.addStep(MakeDirectory(dir=build_dir, haltOnFailure=False))
+        factory.addStep(MakeDirectory(dir=install_dir, haltOnFailure=False))
 
         factory.addStep(
-            ShellCommand(workdir='llvm-build-' + config,
+            CMake(name='Configure LLVM %s' % config,
+                  description='Configure LLVM %s' % config,
+                  locks=[performance_lock.access('counting')],
+                  haltOnFailure=True,
+                  env=env,
+                  workdir=build_dir,
+                  path=get_llvm_source_path('llvm'),
+                  generator=get_cmake_generator(os),
+                  definitions=get_llvm_cmake_definitions(os, config, llvm_branch),
+                  options=get_cmake_options(os)))
+
+        factory.addStep(
+            ShellCommand(name='Build LLVM %s' % config,
+                         description='Build LLVM %s' % config,
                          locks=[performance_lock.access('counting')],
-                         name='Build LLVM ' + config,
-                         description='Build LLVM ' + config,
                          haltOnFailure=True,
-                         command=['MSBuild.exe',
-                                  '/m:16',
-                                  '/t:Build',
-                                  '/p:Configuration=' + config,
-                                  '/v:m',
-                                  '.\\INSTALL.vcxproj']))
+                         workdir=build_dir,
+                         env=env,
+                         command=get_cmake_build_command(os, config, build_dir, target='install')))
+
+
+def add_halide_cmake_build_steps(factory, llvm_branch, os, configs):
+    for config in configs:
+        env = get_env(os, config)
+
+        # Always do a clean build for Halide
+        source_dir = get_halide_source_path()
+        build_dir = get_halide_build_path(config)
+        factory.addStep(RemoveDirectory(dir=build_dir, haltOnFailure=False))
+        factory.addStep(MakeDirectory(dir=build_dir, haltOnFailure=False))
 
         factory.addStep(CMake(name='Configure Halide %s' % config,
                               description='Configure Halide %s' % config,
                               locks=[performance_lock.access('counting')],
                               haltOnFailure=True,
-                              workdir='halide-build-' + config,
-                              path='..\\halide',
+                              workdir=build_dir,
+                              env=env,
+                              path=source_dir,
                               generator=get_cmake_generator(os),
-                              definitions=get_cmake_definitions(os, config),
+                              definitions=get_halide_cmake_definitions(os, config),
                               options=get_cmake_options(os)))
 
         factory.addStep(
-            ShellCommand(name='Build Halide ' + config,
-                         description='Build Halide ' + config,
+            ShellCommand(name='Build Halide %s' % config,
+                         description='Build Halide %s' % config,
                          locks=[performance_lock.access('counting')],
-                         workdir='halide-build-' + config,
                          haltOnFailure=True,
-                         command=['MSBuild.exe',
-                                  '/m:16',
-                                  '/t:Build',
-                                  '/p:Configuration=' + config,
-                                  '/v:m',
-                                  '.\\ALL_BUILD.vcxproj']))
+                         workdir=build_dir,
+                         env=env,
+                         command=get_cmake_build_command(os, config, build_dir)))
 
-    if make_distro:
-        # Make and upload a distro
-        factory.addStep(RemoveDirectory(dir='distrib', haltOnFailure=False))
-        factory.addStep(MakeDirectory(dir='distrib', haltOnFailure=False))
-        factory.addStep(MakeDirectory(dir='distrib\\halide', haltOnFailure=False))
-        for d in ['Release', 'Debug', 'include', 'tools', 'tutorial', 'tutorial\\figures']:
-            factory.addStep(MakeDirectory(dir='distrib\\halide\\' + d, haltOnFailure=False))
 
-        file_pairs = [
-            ('..\\halide-build-Release\\bin\\Release\\Halide.dll', 'Release'),
-            ('..\\halide-build-Release\\lib\\Release\\Halide.lib', 'Release'),
-            ('..\\halide-build-Debug\\bin\\Debug\\Halide.dll', 'Debug'),
-            ('..\\halide-build-Debug\\lib\\Debug\\Halide.lib', 'Debug'),
-            ('..\\halide-build-Release\\include\\Halide.h', 'include'),
-            ('..\\halide\\src\\runtime\\HalideRuntim*.h', 'include'),
-            ('..\\halide\\src\\runtime\\HalideBuffer.h', 'include'),
-            ('..\\halide\\tools\\mex_halide.m', 'tools'),
-            ('..\\halide\\tools\\GenGen.cpp', 'tools'),
-            ('..\\halide\\tools\\RunGen.h', 'tools'),
-            ('..\\halide\\tools\\RunGenMain.cpp', 'tools'),
-            ('..\\halide\\tools\\halide_benchmark.h', 'tools'),
-            ('..\\halide\\tools\\halide_image.h', 'tools'),
-            ('..\\halide\\tools\\halide_image_io.h', 'tools'),
-            ('..\\halide\\tools\\halide_image_info.h', 'tools'),
-            ('..\\halide\\tools\\halide_malloc_trace.h', 'tools'),
-            ('..\\halide\\tools\\halide_trace_config.h', 'tools'),
-            ('..\\halide\\tutorial\\images\\*.png', 'tutorial\\figures'),
-            ('..\\halide\\tutorial\\figures\\*.gif', 'tutorial\\figures'),
-            ('..\\halide\\tutorial\\figures\\*.jpg', 'tutorial\\figures'),
-            ('..\\halide\\tutorial\\figures\\*.mp4', 'tutorial\\figures'),
-            ('..\\halide\\tutorial\\*.cpp', 'tutorial'),
-            ('..\\halide\\tutorial\\*.h', 'tutorial'),
-            ('..\\halide\\tutorial\\*.sh', 'tutorial'),
-            ('..\\halide-build-Release\\halide_config.*', '.'),
-            ('..\\halide\\halide.cmake', '.'),
-            ('..\\halide\\README*.md', '.')]
-        for (file, dir) in file_pairs:
-            factory.addStep(
-                ShellCommand(name='Copying ' + file,
-                             workdir='distrib',
-                             command=['copy', file, 'halide\\' + dir + '\\']))
+# Return a dict with halide-targets as the keys, and a list of test-labels for each value.
+def get_test_labels(os, llvm_branch):
+    targets = defaultdict(list)
 
-        factory.addStep(
-            ShellCommand(name='Zipping distribution',
-                         workdir='distrib',
-                         command=['C:\\Program Files\\7-Zip\\7z.exe',
-                                  'a',
-                                  'halide.zip',
-                                  'halide']))
+    targets['host'].extend(['internal', 'correctness', 'generator',
+                            'error', 'warning', 'apps', 'performance'])
 
-        factory.addStep(
-            FileUpload(workersrc='halide.zip',
-                       workdir='distrib',
-                       mode=0644,
-                       masterdest=get_distrib_name))
-    else:
-        # Run the tests
-        env = {}
+    # TODO: some JIT+generator tests are failing on arm32; disable for now
+    # pending fixes (see https://github.com/halide/Halide/issues/4940)
+    if os.startswith('arm32'):
+        targets['host'].remove('internal')
+        targets['host'].remove('generator')
 
-        targets = ['host', 'host-opencl', 'host-cuda']
+    # The armbots aren't equipped to use python.
+    # TODO: buildbots + config need love to make 32-bit Python work properly,
+    # just disable the testing for now
+    if not os.startswith('arm') and not os.startswith('linux-32'):
+        targets['host'].extend(['python'])
+
+    if os.startswith('linux-32-gcc53'):
+        # Also test without sse 4.1
+        targets['x86-32'].extend(['correctness'])
+
+    if os.startswith('linux-64-gcc53') or os.startswith('mac-64'):
+        # extended cpu/gpu tests
+        targets['x86-64'].extend(['correctness'])
+        targets['x86-64-sse41'].extend(['correctness'])
+
+    if os.startswith('linux-64-gcc53'):
+        # The linux build-bots have an nvidia card
+        targets['host-cuda'].extend(['correctness', 'generator', 'apps'])
+        targets['host-opencl'].extend(['correctness', 'generator', 'apps'])
+        targets['host-cuda-opencl'].extend(['correctness_multi_gpu'])
+
+    if os.startswith('mac-64'):
+        # test metal on OS X
+        targets['host-metal'].extend(['correctness', 'generator', 'apps'])
+
+    if os.startswith('win-64'):
+        targets['host-cuda'].extend(['correctness', 'generator', 'apps'])
+        targets['host-opencl'].extend(['correctness', 'generator', 'apps'])
         # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
-        # if '-64' in os:
-        #   targets.append('host-d3d12compute')
+        # targets['host-d3d12compute'].extend(['correctness', 'generator', 'apps'])
 
-        for hl_target in targets:
+    if os.startswith('linux-64-gcc53') and llvm_branch == LLVM_TRUNK_BRANCH:
+        # Also test hexagon using the simulator
+        targets['host-hvx_128'].extend(['correctness', 'generator', 'apps'])
+        targets['host-hvx_64'].extend(['correctness', 'generator', 'apps'])
+
+    return targets
+
+# Return true if the test label (or single-test name) is 'time critical' and must
+# be run with an exclusive lock on the buildbot (typically, performance tests)
+
+
+def is_time_critical_test(test):
+    return test in ['performance']
+
+
+def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
+    base_env = {
+        # Current NVidia drivers on our Windows buildbots can corrupt their own
+        # cache, leading to many spurious failures. Disable the cache
+        # for now, pending NVidia investigation.
+        'CUDA_CACHE_DISABLE': '1',
+
+        # We don't ever want an Abort, Rerty, Ignore dialog in our tests
+        'HL_DISABLE_WINDOWS_ABORT_DIALOG': '1'
+    }
+
+    parallelism = get_build_parallelism(os)
+
+    labels = get_test_labels(os, llvm_branch)
+
+    for config in configs:
+        source_dir = get_halide_source_path()
+        build_dir = get_halide_build_path(config)
+
+        # Since we need to do at least a partial rebuild for each different target,
+        # we want to group things by target. Do host first, followed by a key-sorted
+        # order, to ensure predictability.
+        keys = labels.keys()
+        keys.remove('host')
+        keys.sort()
+        keys.insert(0, 'host')
+
+        for hl_target in keys:
+            env = base_env.copy()
+            env['HL_TARGET'] = hl_target
+            env['HL_JIT_TARGET'] = hl_target
+
+            factory.addStep(
+                CMake(name='Reconfigure for HL_TARGET=%s' % hl_target,
+                      description='Reconfigure for HL_TARGET=%s' % hl_target,
+                      locks=[performance_lock.access('counting')],
+                      haltOnFailure=True,
+                      env=env,
+                      workdir=build_dir,
+                      path=source_dir,
+                      generator=get_cmake_generator(os),
+                      definitions=get_halide_cmake_definitions(os, config, hl_target=hl_target),
+                      options=get_cmake_options(os)))
+
+            factory.addStep(
+                ShellCommand(name='Rebuild for HL_TARGET=%s' % hl_target,
+                             description='Rebuild Halide for HL_TARGET=%s' % hl_target,
+                             locks=[performance_lock.access('counting')],
+                             haltOnFailure=True,
+                             workdir=build_dir,
+                             env=env,
+                             command=get_cmake_build_command(os, config, build_dir)))
+
+            test_labels = labels[hl_target]
+
+            # TODO: buildbots + config need love to make 32-bit Python work properly,
+            # just disable the testing for now
+            if os.startswith('arm') or os.startswith('linux-32'):
+                if 'python' in test_labels:
+                    test_labels.remove('python')
+
+                # TODO: some of the apps require python, so we must skip them for now also
+                if 'apps' in test_labels:
+                    test_labels.remove('apps')
+
+            parallel_test_labels = [
+                test for test in test_labels if not is_time_critical_test(test)]
+            exclusive_test_labels = [test for test in test_labels if is_time_critical_test(test)]
+
+            if len(parallel_test_labels):
+                test_set = '|'.join(parallel_test_labels)
+                # Note that we pass cmd as a single string deliberately,
+                # to avoid buildbot escaping issues with the | char
+                cmd = ' '.join(['ctest',
+                                '--build-config', config,
+                                '--output-on-failure',
+                                '--label-regex', '"%s"' % test_set,
+                                '--parallel', '%d' % parallelism])
+                factory.addStep(
+                    ShellCommand(name='Test %s HL_TARGET=%s' % (test_set, hl_target),
+                                 description='Test %s HL_TARGET=%s' % (test_set, hl_target),
+                                 locks=[performance_lock.access('counting')],
+                                 workdir=build_dir,
+                                 env=env,
+                                 timeout=3600,
+                                 command=cmd))
+
+            if len(exclusive_test_labels):
+                test_set = '|'.join(exclusive_test_labels)
+                # Note that we pass cmd as a single string deliberately,
+                # to avoid buildbot escaping issues with the | char
+                cmd = ' '.join(['ctest',
+                                '--build-config', config,
+                                '--output-on-failure',
+                                '--label-regex', '"%s"' % test_set])
+                factory.addStep(
+                    ShellCommand(name='Test %s HL_TARGET=%s' % (test_set, hl_target),
+                                 description='Test %s HL_TARGET=%s' % (test_set, hl_target),
+                                 locks=[performance_lock.access('exclusive')],
+                                 workdir=build_dir,
+                                 env=env,
+                                 timeout=3600,
+                                 command=cmd))
+
+
+def create_make_factory(os, llvm_branch):
+    assert not os.startswith('win')
+
+    configs = ['Release']
+    for config in configs:
+        env = get_env(os, config)
+        make_threads = get_build_parallelism(os)
+        build_dir = get_halide_build_path(config)
+
+        factory = BuildFactory()
+
+        add_get_source_steps(factory, llvm_branch)
+
+        # TODO: we shouldn't need a clean rebuild anymore
+        clean_llvm_rebuild = False  # (llvm_branch == LLVM_TRUNK_BRANCH)
+        add_llvm_steps(factory, llvm_branch, os, configs, clean_llvm_rebuild)
+
+        # Force a full rebuild of Halide every time
+        factory.addStep(RemoveDirectory(dir=build_dir))
+
+        targets = [('distrib', 'host'),
+                   ('build_tests', 'host')]
+
+        labels = get_test_labels(os, llvm_branch)
+        for hl_target in labels.keys():
+            for label in labels[hl_target]:
+                # TODO: buildbots + config need love to make 32-bit Python work properly,
+                # just disable the testing for now
+                if os.startswith('arm') or os.startswith('linux-32'):
+                    if 'python' in label:
+                        continue
+                    # TODO: some of the apps require python, so we must skip them for now also
+                    if 'apps' in label:
+                        continue
+                targets.append((label, hl_target))
+
+        for (target, hl_target) in targets:
             target_env = env.copy()
             target_env['HL_TARGET'] = hl_target
             target_env['HL_JIT_TARGET'] = hl_target
 
-            # Current NVidia drivers on our Windows buildbots can corrupt their own
-            # cache, leading to many spurious failures. Disable the cache
-            # for now, pending NVidia investigation.
-            target_env['CUDA_CACHE_DISABLE'] = '1'
+            if is_time_critical_test(target):
+                p = 1
+                lock_mode = 'exclusive'
+            else:
+                p = make_threads
+                lock_mode = 'counting'
 
-            # We don't ever want an Abort, Rerty, Ignore dialog in our tests
-            target_env['HL_DISABLE_WINDOWS_ABORT_DIALOG'] = '1'
+            if target != 'distrib' and target != 'build_tests':
+                target = 'test_%s' % target
 
-            for testgroup in ['correctness', 'generator']:
+            factory.addStep(ShellCommand(name='make ' + target,
+                                         description=target + ' ' + hl_target,
+                                         locks=[performance_lock.access(lock_mode)],
+                                         workdir=build_dir,
+                                         env=target_env,
+                                         haltOnFailure=(target == 'distrib'),
+                                         command=['make',
+                                                  '-f', get_halide_source_path('Makefile'),
+                                                  '-j', p,
+                                                  target],
+                                         timeout=3600))
+            if target == 'distrib' and 'testbranch' not in os:
                 factory.addStep(
-                    ShellCommand(name=testgroup,
-                                 description=testgroup,
-                                 locks=[performance_lock.access('counting')],
-                                 workdir='halide-build-Release',
-                                 env=target_env,
-                                 timeout=3600,
-                                 command=ctest_command_line(testgroup, cfg='Release', parallel=16)))
+                    FileUpload(workersrc='distrib/halide.tgz',
+                               workdir=build_dir,
+                               mode=0644,
+                               masterdest=get_distrib_name))
 
-            # TODO: add 'tutorial' to this testgroup (requires libjpeg, libpng, etc)
-            for testgroup in ['performance']:
-                factory.addStep(
-                    ShellCommand(name=testgroup,
-                                 description=testgroup,
-                                 locks=[performance_lock.access('exclusive')],
-                                 workdir='halide-build-Release',
-                                 env=target_env,
-                                 timeout=3600,
-                                 command=ctest_command_line(testgroup, cfg='Release')))
+                factory.addStep(MasterShellCommand(
+                    workdir='/home/abadams/artifacts',
+                    command=['bash', '/home/abadams/build_bot_new/clean_artifacts.sh']))
+
+    return factory
+
+# TODO replace this with cmake package
+
+
+def create_win_distro_factory(os, llvm_branch):
+    assert os.startswith('win')
+
+    factory = BuildFactory()
+    add_get_source_steps(factory, llvm_branch)
+
+    configs = ['Release', 'Debug']
+
+    clean_llvm_rebuild = (llvm_branch == LLVM_TRUNK_BRANCH)
+    add_llvm_steps(factory, llvm_branch, os, configs, clean_llvm_rebuild)
+
+    add_halide_cmake_build_steps(factory, llvm_branch, os, configs)
+
+    # Make and upload a distro
+    factory.addStep(RemoveDirectory(dir='distrib', haltOnFailure=False))
+    factory.addStep(MakeDirectory(dir='distrib', haltOnFailure=False))
+    factory.addStep(MakeDirectory(dir='distrib\\halide', haltOnFailure=False))
+    for d in ['Release', 'Debug', 'include', 'tools', 'tutorial', 'tutorial\\figures']:
+        factory.addStep(MakeDirectory(dir='distrib\\halide\\' + d, haltOnFailure=False))
+
+    file_pairs = [
+        ('..\\halide-build-Release\\bin\\Release\\Halide.dll', 'Release'),
+        ('..\\halide-build-Release\\lib\\Release\\Halide.lib', 'Release'),
+        ('..\\halide-build-Debug\\bin\\Debug\\Halide.dll', 'Debug'),
+        ('..\\halide-build-Debug\\lib\\Debug\\Halide.lib', 'Debug'),
+        ('..\\halide-build-Release\\include\\Halide.h', 'include'),
+        ('..\\halide\\src\\runtime\\HalideRuntim*.h', 'include'),
+        ('..\\halide\\src\\runtime\\HalideBuffer.h', 'include'),
+        ('..\\halide\\tools\\mex_halide.m', 'tools'),
+        ('..\\halide\\tools\\GenGen.cpp', 'tools'),
+        ('..\\halide\\tools\\RunGen.h', 'tools'),
+        ('..\\halide\\tools\\RunGenMain.cpp', 'tools'),
+        ('..\\halide\\tools\\halide_benchmark.h', 'tools'),
+        ('..\\halide\\tools\\halide_image.h', 'tools'),
+        ('..\\halide\\tools\\halide_image_io.h', 'tools'),
+        ('..\\halide\\tools\\halide_image_info.h', 'tools'),
+        ('..\\halide\\tools\\halide_malloc_trace.h', 'tools'),
+        ('..\\halide\\tools\\halide_trace_config.h', 'tools'),
+        ('..\\halide\\tutorial\\images\\*.png', 'tutorial\\figures'),
+        ('..\\halide\\tutorial\\figures\\*.gif', 'tutorial\\figures'),
+        ('..\\halide\\tutorial\\figures\\*.jpg', 'tutorial\\figures'),
+        ('..\\halide\\tutorial\\figures\\*.mp4', 'tutorial\\figures'),
+        ('..\\halide\\tutorial\\*.cpp', 'tutorial'),
+        ('..\\halide\\tutorial\\*.h', 'tutorial'),
+        ('..\\halide\\tutorial\\*.sh', 'tutorial'),
+        ('..\\halide-build-Release\\halide_config.*', '.'),
+        ('..\\halide\\halide.cmake', '.'),
+        ('..\\halide\\README*.md', '.')]
+    for (file, dir) in file_pairs:
+        factory.addStep(
+            ShellCommand(name='Copying ' + file,
+                         workdir='distrib',
+                         command=['copy', file, 'halide\\' + dir + '\\']))
+
+    factory.addStep(
+        ShellCommand(name='Zipping distribution',
+                     workdir='distrib',
+                     command=['C:\\Program Files\\7-Zip\\7z.exe',
+                              'a',
+                              'halide.zip',
+                              'halide']))
+
+    factory.addStep(
+        FileUpload(workersrc='halide.zip',
+                   workdir='distrib',
+                   mode=0644,
+                   masterdest=get_distrib_name))
 
     return factory
 
 
-def ctest_command_line(testgroup, cfg='', parallel=0):
-    cmd = ['ctest', '-L', testgroup, '--output-on-failure']
-    if parallel:
-        cmd.extend(['-j', str(parallel)])
-    if cfg:
-        cmd.extend(['-C', cfg])
-    return cmd
+def create_cmake_factory(os, llvm_branch):
+    factory = BuildFactory()
+    add_get_source_steps(factory, llvm_branch)
+
+    configs = ['Release']
+
+    clean_llvm_rebuild = (llvm_branch == LLVM_TRUNK_BRANCH)
+    add_llvm_steps(factory, llvm_branch, os, configs, clean_llvm_rebuild)
+
+    add_halide_cmake_build_steps(factory, llvm_branch, os, configs)
+
+    add_halide_cmake_test_steps(factory, llvm_branch, os, configs)
+
+    return factory
 
 
-def create_builder(os, llvm_branch):
-    factory = create_factory(os, llvm_branch)
+def create_factory(os, llvm_branch, use_cmake):
+    if os.startswith('win') and '-distro' in os:
+        return create_win_distro_factory(os, llvm_branch)
+    elif os.startswith('win') or use_cmake:
+        return create_cmake_factory(os, llvm_branch)
+    else:
+        return create_make_factory(os, llvm_branch)
+
+
+def create_builder(os, llvm_branch, use_cmake=False):
+    factory = create_factory(os, llvm_branch, use_cmake)
 
     tags = os.split('-')
     tags.append('llvm-' + to_name(llvm_branch))
@@ -747,6 +912,13 @@ create_builder('linux-64-gcc53-testbranch', LLVM_RELEASE_BRANCH)
 create_builder('linux-32-gcc53-testbranch', LLVM_RELEASE_BRANCH)
 create_builder('arm64-linux-64-testbranch', LLVM_RELEASE_BRANCH)
 create_builder('arm32-linux-32-testbranch', LLVM_RELEASE_BRANCH)
+
+# And some CMake testing
+create_builder('mac-64-testbranch-cmake',         LLVM_RELEASE_BRANCH, use_cmake=True)
+create_builder('linux-64-gcc53-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
+create_builder('linux-32-gcc53-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
+create_builder('arm64-linux-64-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
+create_builder('arm32-linux-32-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
 
 # Check for build breakages against other llvm versions too
 create_builder('linux-64-gcc53-testbranch', LLVM_OLD_BRANCH)


### PR DESCRIPTION
In anticipation of https://github.com/halide/Halide/pull/4644 landing, we need better CMake coverage on our buildbots. This refactors to:

- Pull all the CMake support for building Halide into a non-windows-specific chunk
- Smarten up the use of CTest to more fully test everything we want to test
- Hopefully streamline the code some
- Use Ninja everywhere possible

I'm sure this will take a few tries to get right (we'll have to take down the buildbots to try it out, so scheduling suggestions welcomed) -- offering this up for initial review and comments.

(Note that I wrote this with an eye toward the code in the branch above; it's possible that it may have glitches with our current CMake code in addition to general errors...)

attn @alexreinking 