### PR TITLE
Reenable D3D12Compute testing

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -510,8 +510,7 @@ def get_test_labels(os, llvm_branch):
     if os.startswith('win-64'):
         targets['host-cuda'].extend(['correctness', 'generator', 'apps'])
         targets['host-opencl'].extend(['correctness', 'generator', 'apps'])
-        # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
-        # targets['host-d3d12compute'].extend(['correctness', 'generator', 'apps'])
+        targets['host-d3d12compute'].extend(['correctness', 'generator', 'apps'])
 
     if os.startswith('linux-64-gcc53') and llvm_branch == LLVM_TRUNK_BRANCH:
         # Also test hexagon using the simulator


### PR DESCRIPTION
Now that #4394 is merged into Halide master, this reenables testing D3D12Compute on the build bots.