### PR TITLE
Revert "Reenable D3D12Compute testing"

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -510,7 +510,8 @@ def get_test_labels(os, llvm_branch):
     if os.startswith('win-64'):
         targets['host-cuda'].extend(['correctness', 'generator', 'apps'])
         targets['host-opencl'].extend(['correctness', 'generator', 'apps'])
-        targets['host-d3d12compute'].extend(['correctness', 'generator', 'apps'])
+        # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
+        # targets['host-d3d12compute'].extend(['correctness', 'generator', 'apps'])
 
     if os.startswith('linux-64-gcc53') and llvm_branch == LLVM_TRUNK_BRANCH:
         # Also test hexagon using the simulator


### PR DESCRIPTION
Reverts halide/build_bot#63

Many failures on the buildbots, e.g. https://buildbot.halide-lang.org/master/#/builders/15/builds/15/steps/20/logs/stdio

Going to roll back pending investigation by you and Marcos.