### PR TITLE
Try increasing max_builds=2 for win workers

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -53,7 +53,7 @@ for sfx in worker_suffixes:
     workers.append(Worker('mac-worker' + sfx,       password, max_builds=2))
     workers.append(Worker('arm32-linux-worker' + sfx, password, max_builds=1))
     workers.append(Worker('arm64-linux-worker' + sfx, password, max_builds=1))
-    workers.append(Worker('win-worker' + sfx,       password, max_builds=1))
+    workers.append(Worker('win-worker' + sfx,       password, max_builds=2))
 
 c['workers'] = workers
 


### PR DESCRIPTION
We have only one winbot for the short-term future; let's try increasing the load on WinBot2 to two simultaneous builds and see if it can handle it.