### PR TITLE
Try dialing winbots down to 2 threads, not 4

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -370,8 +370,9 @@ def get_build_parallelism(os):
         # once so set threads = (12/2)+2 == 8
         return 8
     elif os.startswith('win'):
-        # WinBots have 6/12 cores but are very slow; let's try half the Mac
-        return 4
+        # WinBots have 6/12 cores but are very slow, and we're trying two simultaneous
+        # builds per machine; let's try 2 threads to minimize thrashing
+        return 2
     elif os.startswith('arm'):
         return 2
     else:


### PR DESCRIPTION
Upping to two simultaneous builds is causing a more dramatic slowdown than I thought. Before we revert to a single build at a time, let's try two builds but with fewer threads and see how that goes.