### PR TITLE
Revert winbots back to 1-task/4-threads

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -53,7 +53,7 @@ for sfx in worker_suffixes:
     workers.append(Worker('mac-worker' + sfx,       password, max_builds=2))
     workers.append(Worker('arm32-linux-worker' + sfx, password, max_builds=1))
     workers.append(Worker('arm64-linux-worker' + sfx, password, max_builds=1))
-    workers.append(Worker('win-worker' + sfx,       password, max_builds=2))
+    workers.append(Worker('win-worker' + sfx,       password, max_builds=1))
 
 c['workers'] = workers
 
@@ -370,9 +370,8 @@ def get_build_parallelism(os):
         # once so set threads = (12/2)+2 == 8
         return 8
     elif os.startswith('win'):
-        # WinBots have 6/12 cores but are very slow, and we're trying two simultaneous
-        # builds per machine; let's try 2 threads to minimize thrashing
-        return 2
+        # WinBots have 6/12 cores but are very slow.
+        return 4
     elif os.startswith('arm'):
         return 2
     else:


### PR DESCRIPTION
two tasks at once is indeed too thrashy for our hardware, alas; now that winbot1 is running again let's go back to one-at-a-time