### PR TITLE
Ensure all buildsteps acquire performance_lock

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -506,16 +506,20 @@ def add_llvm_steps(factory, llvm_branch, os, configs, clean_rebuild):
 
         if clean_rebuild:
             factory.addStep(RemoveDirectory(name="Remove LLVM Build Dir",
+                                            locks=[performance_lock.access('counting')],
                                             dir=build_dir,
                                             haltOnFailure=False))
             factory.addStep(RemoveDirectory(name="Remove LLVM Install Dir",
+                                            locks=[performance_lock.access('counting')],
                                             dir=install_dir,
                                             haltOnFailure=False))
 
         factory.addStep(MakeDirectory(name="Make LLVM Build Dir",
+                                      locks=[performance_lock.access('counting')],
                                       dir=build_dir,
                                       haltOnFailure=False))
         factory.addStep(MakeDirectory(name="Make LLVM Install Dir",
+                                      locks=[performance_lock.access('counting')],
                                       dir=install_dir,
                                       haltOnFailure=False))
 
@@ -549,9 +553,11 @@ def add_halide_cmake_build_steps(factory, llvm_branch, os, configs):
         source_dir = get_halide_source_path()
         build_dir = get_halide_build_path(config)
         factory.addStep(RemoveDirectory(name="Remove Halide Build Dir",
+                                        locks=[performance_lock.access('counting')],
                                         dir=build_dir,
                                         haltOnFailure=False))
         factory.addStep(MakeDirectory(name="Make Halide Build Dir",
+                                      locks=[performance_lock.access('counting')],
                                       dir=build_dir,
                                       haltOnFailure=False))
 
@@ -761,6 +767,7 @@ def create_make_factory(os, llvm_branch):
 
         # Force a full rebuild of Halide every time
         factory.addStep(RemoveDirectory(name="Remove Halide Build Dir",
+                                        locks=[performance_lock.access('counting')],
                                         dir=build_dir))
 
         targets = [('distrib', 'host'),
@@ -809,11 +816,13 @@ def create_make_factory(os, llvm_branch):
                 factory.addStep(
                     FileUpload(workersrc='distrib/halide.tgz',
                                workdir=build_dir,
+                               locks=[performance_lock.access('counting')],
                                mode=0o644,
                                masterdest=get_distrib_name))
 
                 factory.addStep(MasterShellCommand(
                     workdir='/home/abadams/artifacts',
+                    locks=[performance_lock.access('counting')],
                     command=['bash', '/home/abadams/build_bot_new/clean_artifacts.sh']))
 
     return factory
@@ -838,15 +847,19 @@ def create_win_distro_factory(os, llvm_branch):
 
     # Make and upload a distro
     factory.addStep(RemoveDirectory(name="Remove Halide Distrib Dir",
+                                    locks=[performance_lock.access('counting')],
                                     dir='distrib',
                                     haltOnFailure=False))
     factory.addStep(MakeDirectory(name="Make Halide Distrib Dir",
+                                  locks=[performance_lock.access('counting')],
                                   dir='distrib',
                                   haltOnFailure=False))
     factory.addStep(MakeDirectory(dir='distrib\\halide',
+                                  locks=[performance_lock.access('counting')],
                                   haltOnFailure=False))
     for d in ['Release', 'Debug', 'include', 'tools', 'tutorial', 'tutorial\\figures']:
         factory.addStep(MakeDirectory(dir='distrib\\halide\\' + d,
+                                      locks=[performance_lock.access('counting')],
                                       haltOnFailure=False))
 
     file_pairs = [
@@ -880,11 +893,13 @@ def create_win_distro_factory(os, llvm_branch):
     for (file, dir) in file_pairs:
         factory.addStep(
             ShellCommand(name='Copying ' + file,
+                         locks=[performance_lock.access('counting')],
                          workdir='distrib',
                          command=['copy', file, 'halide\\' + dir + '\\']))
 
     factory.addStep(
         ShellCommand(name='Zipping distribution',
+                     locks=[performance_lock.access('counting')],
                      workdir='distrib',
                      command=['C:\\Program Files\\7-Zip\\7z.exe',
                               'a',
@@ -893,6 +908,7 @@ def create_win_distro_factory(os, llvm_branch):
 
     factory.addStep(
         FileUpload(workersrc='halide.zip',
+                   locks=[performance_lock.access('counting')],
                    workdir='distrib',
                    mode=0o644,
                    masterdest=get_distrib_name))


### PR DESCRIPTION
This ismostly hygiene; I don't know of a specific case where this is mattering, but all steps should explicitly acquire the lock one way or another