### PR TITLE
Update buildbots for LLVM12

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -18,14 +18,14 @@ from functools import partial
 # are released, but the underlying test logic should not need changing
 
 LLVM_TRUNK_BRANCH = 'master'
-LLVM_RELEASE_BRANCH = 'release/10.x'
-LLVM_OLD_BRANCH = 'release/9.x'
+LLVM_RELEASE_BRANCH = 'release/11.x'
+LLVM_OLD_BRANCH = 'release/10.x'
 
 # Map the branchnames to the "old" naming style, for continuity
 _TO_NAME = {
     LLVM_TRUNK_BRANCH: 'trunk',
-    LLVM_RELEASE_BRANCH: '1000',
-    LLVM_OLD_BRANCH: '900',
+    LLVM_RELEASE_BRANCH: '1100',
+    LLVM_OLD_BRANCH: '1000',
 }
 
 


### PR DESCRIPTION
trunk is now LLVM12, so update 'release' -> 11, 'old' -> 10, and drop testing of LLVM9 entirely.