### PR TITLE
Switch buildbots to use mostly CMake

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1025,6 +1025,9 @@ c['builders'] = []
 # distributions with a uniform llvm version. We also test against llvm
 # trunk, with lower priority, so that we can bisect llvm trunk
 # breakages on various platforms if they are discovered late.
+#
+# TODO(srj): we should probably move most (~all) of these to using CMake rather
+# than Make, but distrib builds in CMake aren't fully baked yet for all platforms.
 create_builder('arm32-linux-32', LLVM_TRUNK_BRANCH)
 create_builder('arm32-linux-32', LLVM_OLD_BRANCH)
 
@@ -1052,24 +1055,20 @@ create_builder('win-64-distro', LLVM_RELEASE_BRANCH)
 # Make some builders just for testing branches. Picking a fixed llvm
 # version will avoid LLVM rebuilds for the best turnaround. Usually the
 # most recent 'released' (non-trunk) version is the best choice.
-create_builder('win-64-testbranch',         LLVM_RELEASE_BRANCH)
-create_builder('win-32-testbranch',         LLVM_RELEASE_BRANCH)
-create_builder('mac-64-testbranch',         LLVM_RELEASE_BRANCH)
-create_builder('linux-64-gcc7-testbranch', LLVM_RELEASE_BRANCH)
-create_builder('linux-32-gcc7-testbranch', LLVM_RELEASE_BRANCH)
-create_builder('arm64-linux-64-testbranch', LLVM_RELEASE_BRANCH)
-create_builder('arm32-linux-32-testbranch', LLVM_RELEASE_BRANCH)
-
-# And some CMake testing
+create_builder('win-64-testbranch-cmake',         LLVM_RELEASE_BRANCH, use_cmake=True)
+create_builder('win-32-testbranch-cmake',         LLVM_RELEASE_BRANCH, use_cmake=True)
 create_builder('mac-64-testbranch-cmake',         LLVM_RELEASE_BRANCH, use_cmake=True)
-create_builder('linux-64-gcc7-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
-create_builder('linux-32-gcc7-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
+create_builder('linux-64-gcc7-testbranch-cmake',  LLVM_RELEASE_BRANCH, use_cmake=True)
+create_builder('linux-32-gcc7-testbranch-cmake',  LLVM_RELEASE_BRANCH, use_cmake=True)
 create_builder('arm64-linux-64-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
 create_builder('arm32-linux-32-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
 
+# Add at least one testbranch test using Make rather than CMake
+create_builder('linux-64-gcc7-testbranch-make', LLVM_RELEASE_BRANCH, use_cmake=False)
+
 # Check for build breakages against other llvm versions too
-create_builder('linux-64-gcc7-testbranch', LLVM_OLD_BRANCH)
-create_builder('linux-64-gcc7-testbranch', LLVM_TRUNK_BRANCH)
+create_builder('linux-64-gcc7-testbranch', LLVM_OLD_BRANCH, use_cmake=True)
+create_builder('linux-64-gcc7-testbranch', LLVM_TRUNK_BRANCH, use_cmake=True)
 
 c['schedulers'] = []
 create_scheduler(LLVM_TRUNK_BRANCH)


### PR DESCRIPTION
Since the CMake rewrite, we've been doing a fair amount of redundant testing on the CMake/Make builds on the buildbots; this proposes to move almost all of the testbranch testing on the buildbots to use CMake instead of Make.

This is more of a proposal than a real PR; it assumes that we want to start considering CMake to be our 'primary' build system everywhere, with Make supported on a best-effort basis, which is not somethere there is consensus on; this is an effort to start the dialog.

Note also that we still have to use Make for distrib builds (CMake has some open issues with this on Windows IIRC), so, again, this is more an open-for-discussion thing.