### PR TITLE
Enable WebAssembly unconditionally

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -380,7 +380,7 @@ def get_llvm_cmake_definitions(os, config, llvm_branch):
         'LLVM_ENABLE_PROJECTS': 'clang;lld',
         'LLVM_ENABLE_RTTI': 'ON',
         'LLVM_ENABLE_TERMINFO': 'OFF',
-        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC' + (';WebAssembly' if llvm_branch == LLVM_TRUNK_BRANCH else ''),
+        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC;WebAssembly',
     }
 
     if os.startswith('linux-32'):


### PR DESCRIPTION
LLVM 10+ all understand the target, and it's easier to build LLVM variants with the same targets