### PR TITLE
Update buildbots for HL_TARGET -> Halide_TARGET change

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -317,11 +317,11 @@ def get_cmake_options(os):
     return options
 
 
-def get_halide_cmake_definitions(os, config, hl_target='host'):
+def get_halide_cmake_definitions(os, config, halide_target='host'):
     cmake_definitions = {
         'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
         'CMAKE_BUILD_TYPE': config,
-        'HL_TARGET': hl_target,
+        'Halide_TARGET': halide_target,
         'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm'),
     }
 
@@ -657,33 +657,36 @@ def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
         keys.sort()
         keys.insert(0, 'host')
 
-        for hl_target in keys:
+        for halide_target in keys:
             env = get_env(os, config)
-            env['HL_TARGET'] = hl_target
-            env['HL_JIT_TARGET'] = hl_target
+            # HL_TARGET is now ignored by CMake builds, no need to set
+            # (must specify -DHalide_TARGET to CMake instead)
+            # env['HL_TARGET'] = halide_target
+            env['HL_JIT_TARGET'] = halide_target
 
             factory.addStep(
-                CMake(name='Reconfigure for HL_TARGET=%s' % hl_target,
-                      description='Reconfigure for HL_TARGET=%s' % hl_target,
+                CMake(name='Reconfigure for Halide_TARGET=%s' % halide_target,
+                      description='Reconfigure for Halide_TARGET=%s' % halide_target,
                       locks=[performance_lock.access('counting')],
                       haltOnFailure=True,
                       env=env,
                       workdir=build_dir,
                       path=source_dir,
                       generator=get_cmake_generator(os),
-                      definitions=get_halide_cmake_definitions(os, config, hl_target=hl_target),
+                      definitions=get_halide_cmake_definitions(
+                          os, config, halide_target=halide_target),
                       options=get_cmake_options(os)))
 
             factory.addStep(
-                ShellCommand(name='Rebuild for HL_TARGET=%s' % hl_target,
-                             description='Rebuild Halide for HL_TARGET=%s' % hl_target,
+                ShellCommand(name='Rebuild for Halide_TARGET=%s' % halide_target,
+                             description='Rebuild Halide for Halide_TARGET=%s' % halide_target,
                              locks=[performance_lock.access('counting')],
                              haltOnFailure=True,
                              workdir=build_dir,
                              env=env,
                              command=get_cmake_build_command(os, config, build_dir)))
 
-            test_labels = labels[hl_target]
+            test_labels = labels[halide_target]
 
             # TODO: buildbots + config need love to make 32-bit Python work properly,
             # just disable the testing for now
@@ -722,8 +725,9 @@ def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
                     cmd = cmd + ' --exclude-regex "lens_blur"'
 
                 factory.addStep(
-                    ShellCommand(name='Test %s HL_TARGET=%s' % (test_set, hl_target),
-                                 description='Test %s HL_TARGET=%s' % (test_set, hl_target),
+                    ShellCommand(name='Test %s Halide_TARGET=%s' % (test_set, halide_target),
+                                 description='Test %s Halide_TARGET=%s' % (
+                                     test_set, halide_target),
                                  locks=[performance_lock.access('counting')],
                                  workdir=build_dir,
                                  env=env,
@@ -739,8 +743,9 @@ def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
                                 '--output-on-failure',
                                 '--label-regex', '"%s"' % test_set])
                 factory.addStep(
-                    ShellCommand(name='Test %s HL_TARGET=%s' % (test_set, hl_target),
-                                 description='Test %s HL_TARGET=%s' % (test_set, hl_target),
+                    ShellCommand(name='Test %s Halide_TARGET=%s' % (test_set, halide_target),
+                                 description='Test %s Halide_TARGET=%s' % (
+                                     test_set, halide_target),
                                  locks=[performance_lock.access('exclusive')],
                                  workdir=build_dir,
                                  env=env,
@@ -777,8 +782,8 @@ def create_make_factory(os, llvm_branch):
                    ('build_tests', 'host')]
 
         labels = get_test_labels(os, llvm_branch)
-        for hl_target in list(labels.keys()):
-            for label in labels[hl_target]:
+        for halide_target in list(labels.keys()):
+            for label in labels[halide_target]:
                 # TODO: buildbots + config need love to make 32-bit Python work properly,
                 # just disable the testing for now
                 if os.startswith('arm') or os.startswith('linux-32'):
@@ -787,12 +792,12 @@ def create_make_factory(os, llvm_branch):
                     # TODO: some of the apps require python, so we must skip them for now also
                     if 'apps' in label:
                         continue
-                targets.append((label, hl_target))
+                targets.append((label, halide_target))
 
-        for (target, hl_target) in targets:
+        for (target, halide_target) in targets:
             target_env = env.copy()
-            target_env['HL_TARGET'] = hl_target
-            target_env['HL_JIT_TARGET'] = hl_target
+            target_env['HL_TARGET'] = halide_target
+            target_env['HL_JIT_TARGET'] = halide_target
 
             if is_time_critical_test(target):
                 p = 1
@@ -805,7 +810,7 @@ def create_make_factory(os, llvm_branch):
                 target = 'test_%s' % target
 
             factory.addStep(ShellCommand(name='make ' + target,
-                                         description=target + ' ' + hl_target,
+                                         description=target + ' ' + halide_target,
                                          locks=[performance_lock.access(lock_mode)],
                                          workdir=build_dir,
                                          env=target_env,


### PR DESCRIPTION
CMake builds recently changed how AOT targets are specified. This brings the buildbot script up to date.

attn @alexreinking 