### PR TITLE
Revert "Use / instead of \ in LLVM_DIR on all platforms"

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -319,12 +319,10 @@ def get_cmake_options(os):
 
 def get_halide_cmake_definitions(os, config, halide_target='host'):
     cmake_definitions = {
-        # todo: remove Clang_DIR line when halide/Halide#5135 lands
-        # Use "CMake paths" which always use forward slashes, even on Windows.
-        'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm').replace('\\', '/'),
-        'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang').replace('\\', '/'),
+        'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
         'CMAKE_BUILD_TYPE': config,
         'Halide_TARGET': halide_target,
+        'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm'),
     }
 
     # The linux and arm linux buildbots have ccache installed


### PR DESCRIPTION
Reverts halide/build_bot#78