### PR TITLE
Use / instead of \ in paths on all platforms (in Interpolate-safe way)

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -345,12 +345,10 @@ def get_cmake_options(os):
 
 def get_halide_cmake_definitions(os, config, halide_target='host'):
     cmake_definitions = {
-        # todo: remove Clang_DIR line when halide/Halide#5135 lands         'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
-        # Use "CMake paths" which always use forward slashes, even on Windows.
-        'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm').replace('\\', '/'),
-        'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang').replace('\\', '/'),           'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
+        'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
         'CMAKE_BUILD_TYPE': config,
         'Halide_TARGET': halide_target,
+        'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm'),
     }
 
     # The linux and arm linux buildbots have ccache installed

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -165,9 +165,35 @@ from buildbot.process.properties import Property
 from buildbot.process.properties import renderer
 from buildbot.process.properties import Interpolate
 
+from buildbot.process.properties import Interpolate
+
+
+class InterpolateAndFixSlashes(Interpolate):
+    """Interpolate followed by replacing \\ with /
+    """
+
+    def __init__(self, fmtstring, *args, **kwargs):
+        Interpolate.__init__(self, fmtstring, *args, **kwargs)
+
+    def _sub(self, s):
+        return s.replace('\\', '/')
+
+    def getRenderingFor(self, props):
+        props = props.getProperties()
+        if self.args:
+            d = props.render(self.args)
+            d.addCallback(lambda args:
+                          self._sub(self.fmtstring % tuple(args)))
+            return d
+        else:
+            d = props.render(self.interpolations)
+            d.addCallback(lambda res:
+                          self._sub(self.fmtstring % res))
+            return d
+
 
 def get_builddir_subpath(subpath):
-    return util.Interpolate('%(prop:builddir)s/' + subpath)
+    return InterpolateAndFixSlashes('%(prop:builddir)s/' + subpath)
 
 
 def get_llvm_source_path(*subpaths):
@@ -319,10 +345,12 @@ def get_cmake_options(os):
 
 def get_halide_cmake_definitions(os, config, halide_target='host'):
     cmake_definitions = {
-        'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
+        # todo: remove Clang_DIR line when halide/Halide#5135 lands         'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
+        # Use "CMake paths" which always use forward slashes, even on Windows.
+        'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm').replace('\\', '/'),
+        'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang').replace('\\', '/'),           'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
         'CMAKE_BUILD_TYPE': config,
         'Halide_TARGET': halide_target,
-        'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm'),
     }
 
     # The linux and arm linux buildbots have ccache installed


### PR DESCRIPTION
attn @alexreinking 