### PR TITLE
Add BuilderType

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -165,7 +165,86 @@ from buildbot.process.properties import Property
 from buildbot.process.properties import renderer
 from buildbot.process.properties import Interpolate
 
-from buildbot.process.properties import Interpolate
+
+class BuilderType:
+    """A class to encapsulate the settings for a specific Builder.
+       (Do not confuse with CMake's 'BUILD_TYPE', which is something else.)
+
+       It includes:
+       - Halide 'target' in the form of arch-bits-os
+       - LLVM branch to be used
+       - CMake vs Make
+
+       It doesn't currently include any 'features' because we don't currently
+       bake any in at build time.
+
+       It doesn't currently include the C++ compiler used (eg gcc7 vs gcc8 vs clang),
+       mainly because we currently never test with multiple compilers for a given
+       setup. (If we ever need to do so, compiler should be added to this.)
+    """
+
+    def __init__(self, arch, bits, os, llvm_branch, cmake=True, testbranch=False, distro=False):
+        assert arch in ['arm', 'x86']
+        assert bits in [32, 64]
+        assert os in ['linux', 'win', 'osx']
+        assert llvm_branch in [LLVM_TRUNK_BRANCH, LLVM_RELEASE_BRANCH, LLVM_OLD_BRANCH]
+        assert not (testbranch and distro)
+
+        self.arch = arch
+        self.bits = bits
+        self.os = os
+        self.llvm_branch = llvm_branch
+        self.cmake = cmake
+        self.testbranch = testbranch
+        # TODO: distro is an anachronism that should go away once proper CMake packaging lands
+        self.distro = distro
+
+    # The armbots aren't configured with Python at all,
+    # and supporting 32-bit Python on our 64-bit buildbots is painful
+    # (and usage of the python bindings on 32-bit hosts is unlikely anyway)
+    def handles_python():
+        return self.arch != 'arm' and self.bits != 32
+
+    def handles_hexagon():
+        return (builder_type.arch == 'x86'
+                and builder_type.bits == 64
+                and builder_type.os == 'linux'
+                and builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
+
+    def handles_wasm():
+        return (builder_type.arch == 'x86'
+                and builder_type.bits == 64
+                and builder_type.os == 'linux'
+                and builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
+
+    def has_nvidia():
+        return (builder_type.arch == 'x86'
+                and builder_type.bits == 64
+                and builder_type.os == 'linux')
+
+    def halide_target(self):
+        return '%s-%d-%s' % (self.arch, self.bits, self.os)
+
+    def builder_label(self):
+        # This currently tries to (somewhat) mimic the existing label pattern,
+        # but is arbitrary. (If changed, manual purging of buildbot temporaries
+        # is appropriate)
+        s = self.halide_target()
+
+        if self.testbranch:
+            s += '-testbranch'
+        # else:
+        #    s += '-master'
+
+        if self.distro:
+            s += '-distro'
+
+        s += '-' + to_name(self.llvm_branch)
+        s += '-cmake' if self.cmake else '-make'
+        return s
+
+    def __str__(self):
+        return '%s' % (self.halide_target())
 
 
 class InterpolateAndFixSlashes(Interpolate):
@@ -216,9 +295,7 @@ def get_halide_build_path(config, *subpaths):
     return get_builddir_subpath(os.path.join('halide-%s' % config, *subpaths))
 
 
-def add_get_source_steps(factory, llvm_branch):
-
-    assert llvm_branch in [LLVM_TRUNK_BRANCH, LLVM_RELEASE_BRANCH, LLVM_OLD_BRANCH]
+def add_get_source_steps(factory, builder_type):
 
     factory.addStep(Git(name='Get Halide master',
                         locks=[performance_lock.access('counting')],
@@ -228,12 +305,12 @@ def add_get_source_steps(factory, llvm_branch):
                         branch='master',
                         mode='incremental'))
 
-    factory.addStep(Git(name='Get LLVM ' + to_name(llvm_branch),
+    factory.addStep(Git(name='Get LLVM ' + to_name(builder_type.llvm_branch),
                         locks=[performance_lock.access('counting')],
                         codebase='llvm',
                         workdir=get_llvm_source_path(),
                         repourl='https://github.com/llvm/llvm-project.git',
-                        branch=llvm_branch,
+                        branch=builder_type.llvm_branch,
                         mode='incremental'))
 
 # Determined by running `set` in cmd.exe before and after vcvarsall.bat
@@ -287,13 +364,13 @@ VCVARSALL_ENV_VARS = [
 ]
 
 
-def get_msvc_config_steps(factory, os):
-    if os.startswith('win'):
-        if '-32' in os:
-            arch = ' x64_x86'  # ensure that we use the x64 host compiler, not the x86 host compiler
+def get_msvc_config_steps(factory, builder_type):
+    if builder_type.os == 'win':
+        if builder_type.bits == 32:
+            vcvars_arch = ' x64_x86'  # ensure that we use the x64 host compiler, not the x86 host compiler
         else:
-            arch = ' x64'
-        vcvarsall = 'vcvarsall.bat %s && set' % arch
+            vcvars_arch = ' x64'
+        vcvarsall = 'vcvarsall.bat %s && set' % vcvars_arch
 
         # TODO: surely there is a better way of locating vcvarsall
         vcvarsdir = "c:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build"
@@ -334,51 +411,45 @@ def get_distrib_name(props):
     return '/home/abadams/artifacts/halide-' + builder + '-' + rev + suffix
 
 
-def get_cmake_generator(os):
+def get_cmake_generator(builder_type):
     return 'Ninja'
 
 
-def get_cmake_options(os):
+def get_cmake_options(builder_type):
     options = []
     return options
 
 
-def get_halide_cmake_definitions(os, config, halide_target='host'):
+def get_halide_cmake_definitions(builder_type, config, halide_target='host'):
     cmake_definitions = {
         'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
         'CMAKE_BUILD_TYPE': config,
         'Halide_TARGET': halide_target,
         'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm'),
+        'WITH_PYTHON_BINDINGS': 'ON' if builder_type.handles_python() else 'OFF'
     }
 
     # The linux and arm linux buildbots have ccache installed
     # (TODO: can install on mac if we update XCode there)
-    if 'linux' in os:
+    if builder_type.os == 'linux':
         cmake_definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
         cmake_definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
 
-    if os.startswith('win-32'):
-        cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
+    # TODO: is this even necessary? We no longer attempt to build/test Python
+    # on any 32-bit system
+    # if builder_type.os == 'win' and builder_type.bits == 32:
+    #     cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
 
-    if os.startswith('win'):
+    if builder_type.os == 'win':
         cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = r'C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
-
-    # Armbots don't have Python configured, so python bindings won't build
-    if os.startswith('arm'):
-        cmake_definitions['WITH_PYTHON_BINDINGS'] = 'OFF'
-
-    # TODO: buildbots + config need love to make 32-bit Python work properly,
-    # just disable the testing for now
-    if os.startswith('linux-32'):
-        cmake_definitions['WITH_PYTHON_BINDINGS'] = 'OFF'
 
     return cmake_definitions
 
 
-def get_cmake_build_command(os, config, build_dir, target=None):
+def get_cmake_build_command(builder_type, config, build_dir, target=None):
     cmd = ['ninja',
            '-C', build_dir,
-           '-j', get_build_parallelism(os)]
+           '-j', get_build_parallelism(builder_type)]
     if target:
         cmd.append(target)
 
@@ -389,18 +460,18 @@ def get_cmake_build_command(os, config, build_dir, target=None):
     # cmd = ['cmake',
     #        '--build', build_dir,
     #        '--config', config,
-    #        '-j', get_build_parallelism(os)]
+    #        '-j', get_build_parallelism(builder_type)]
     # if target:
     #     cmd.extend(['--target', target])
 
     return cmd
 
 
-def get_llvm_cmake_definitions(os, config, llvm_branch):
+def get_llvm_cmake_definitions(builder_type, config):
     definitions = {
         'CMAKE_BUILD_TYPE': config,
         'CMAKE_INSTALL_PREFIX': get_llvm_install_path(config),
-        'LLVM_BUILD_32_BITS': ('ON' if '-32' in os else 'OFF'),
+        'LLVM_BUILD_32_BITS': ('ON' if builder_type.bits == 32 else 'OFF'),
         'LLVM_ENABLE_ASSERTIONS': 'ON',
         'LLVM_ENABLE_LIBXML2': 'OFF',
         'LLVM_ENABLE_PROJECTS': 'clang;lld',
@@ -409,7 +480,7 @@ def get_llvm_cmake_definitions(os, config, llvm_branch):
         'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC;WebAssembly',
     }
 
-    if os.startswith('linux-32'):
+    if builder_type.arch == 'x86' and builder_type.bits == 32 and builder_type.os == 'linux':
         definitions['CMAKE_FIND_ROOT_PATH'] = '/usr/lib/i386-linux-gnu'
         definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = 'ONLY'
 
@@ -417,13 +488,13 @@ def get_llvm_cmake_definitions(os, config, llvm_branch):
     # when assertions are enabled, but only if your XCode install has
     # certain frameworks installed; we want it disabled, as it prevents
     # prebuilt libraries from working properly with XCode 9.x.
-    if os.startswith('mac'):
+    if builder_type.os == 'osx':
         definitions['LLVM_ENABLE_SUPPORT_XCODE_SIGNPOSTS'] = 'FORCE_OFF'
 
     return definitions
 
 
-def get_env(os, config):
+def get_env(builder_type, config):
     # TODO: this is only necessary for Make (not CMake), I think,
     # but doesn't hurt to just use everywhere
     env = {'LLVM_CONFIG': get_llvm_build_path(config, 'bin/llvm-config')}
@@ -432,29 +503,21 @@ def get_env(os, config):
     cc = 'cc'
     ld = 'ld'
 
-    if os.startswith('linux'):
-        if '-gcc7' in os:
-            cc = 'gcc-7'
-            cxx = 'g++-7'
-        else:
-            assert(False)
-
+    if builder_type.arch == 'x86' and builder_type.os == 'linux':
+        cc = 'gcc-7'
+        cxx = 'g++-7'
         ld = 'ld'
-        if '-32' in os:
+        if builder_type.bits == 32:
             cxx += ' -m32'
             cc += ' -m32'
             ld += ' -melf_i386'
-    elif os.startswith('mac'):
-        if '-32' in os:
-            cxx += ' -m32'
-            cc += ' -m32'
-    elif os.startswith('win'):
+    elif builder_type.os == 'win':
         cxx = 'cl.exe'
         cc = 'cl.exe'
 
     # The linux and arm linux buildbots have ccache installed
     # (TODO: can install on mac if we update XCode there)
-    if 'linux' in os:
+    if builder_type.os == 'linux':
         cxx = 'ccache ' + cxx
         cc = 'ccache ' + cc
 
@@ -462,19 +525,21 @@ def get_env(os, config):
     env['CC'] = cc
     env['LD'] = ld
 
-    if os.startswith('linux'):
+    if builder_type.handles_hexagon():
             # Environment variables for testing Hexagon DSP
         env['HL_HEXAGON_TOOLS'] = '/usr/local/hexagon'
-        env['HL_HEXAGON_SIM_REMOTE'] = '${PWD}/worker/' + os + \
+        env['HL_HEXAGON_SIM_REMOTE'] = '${PWD}/worker/' + str(builder_type) + \
             '-trunk/halide/src/runtime/hexagon_remote/bin/v62/hexagon_sim_remote'
         env['HL_HEXAGON_SIM_CYCLES'] = '1'
-        env['LD_LIBRARY_PATH'] = '${LD_LIBRARY_PATH}:${PWD}/worker/' + os + \
+        env['LD_LIBRARY_PATH'] = '${LD_LIBRARY_PATH}:${PWD}/worker/' + str(builder_type) + \
             '-trunk/halide/src/runtime/hexagon_remote/bin/host:/usr/local/hexagon/lib/iss'
-    elif os.startswith('mac'):
+
+    if builder_type.os == 'osx':
         # Environment variable for turning on Metal API validation
         # This will have no effect on CPU testing, just Metal testing
         env['METAL_DEVICE_WRAPPER_TYPE'] = '1'
-    elif os.startswith('win'):
+
+    if builder_type.os == 'win':
         # Current NVidia drivers on our Windows buildbots can corrupt their own
         # cache, leading to many spurious failures. Disable the cache
         # for now, pending NVidia investigation.
@@ -491,40 +556,47 @@ def get_env(os, config):
     return env
 
 
-def get_build_parallelism(os):
+def get_build_parallelism(builder_type):
     # Standard wisdom is (nproc+2)
-    if os.startswith('linux'):
-        # TODO: our Linux bots also have 12 cores; this seems maybe too high?
-        return 8
-    elif os.startswith('mac'):
+    if builder_type.os == 'linux':
+        if builder_type.arch == 'x86':
+            # TODO: our Linux bots also have 12 cores; this seems maybe too high?
+            return 8
+        else:
+            assert builder_type.arch == 'arm'
+            return 2
+    elif builder_type.os == 'osx':
         # MacBot has 32GB and 6/12 core Xeon. We allow two builds at
         # once so set threads = (12/2)+2 == 8
         return 8
-    elif os.startswith('win'):
+    elif builder_type.os == 'win':
         # WinBots have 6/12 cores but are very slow.
         return 4
-    elif os.startswith('arm'):
-        return 2
     else:
-        return 1
+        assert False
 
 
-def get_workers(os):
-    if os.startswith('linux'):
-        return ['linux-worker' + sfx for sfx in worker_suffixes]
-    elif os.startswith('mac'):
+def get_workers(builder_type):
+    if builder_type.os == 'linux':
+        if builder_type.arch == 'x86':
+            return ['linux-worker' + sfx for sfx in worker_suffixes]
+        else:
+            assert builder_type.arch == 'arm'
+            if builder_type.bits == 32:
+                return ['arm32-linux-worker' + sfx for sfx in worker_suffixes]
+            else:
+                return ['arm64-linux-worker' + sfx for sfx in worker_suffixes]
+    elif builder_type.os == 'osx':
         return ['mac-worker' + sfx for sfx in worker_suffixes]
-    elif os.startswith('win'):
+    elif builder_type.os == 'win':
         return ['win-worker' + sfx for sfx in worker_suffixes]
-    elif os.startswith('arm32-linux'):
-        return ['arm32-linux-worker' + sfx for sfx in worker_suffixes]
-    elif os.startswith('arm64-linux'):
-        return ['arm64-linux-worker' + sfx for sfx in worker_suffixes]
+    else:
+        assert(False)
 
 
-def add_llvm_steps(factory, llvm_branch, os, configs, clean_rebuild):
+def add_llvm_steps(factory, builder_type, configs, clean_rebuild):
     for config in configs:
-        env = get_env(os, config)
+        env = get_env(builder_type, config)
 
         build_dir = get_llvm_build_path(config)
         install_dir = get_llvm_install_path(config)
@@ -556,9 +628,9 @@ def add_llvm_steps(factory, llvm_branch, os, configs, clean_rebuild):
                   env=env,
                   workdir=build_dir,
                   path=get_llvm_source_path('llvm'),
-                  generator=get_cmake_generator(os),
-                  definitions=get_llvm_cmake_definitions(os, config, llvm_branch),
-                  options=get_cmake_options(os)))
+                  generator=get_cmake_generator(builder_type),
+                  definitions=get_llvm_cmake_definitions(builder_type, config),
+                  options=get_cmake_options(builder_type)))
 
         factory.addStep(
             ShellCommand(name='Build LLVM %s' % config,
@@ -567,12 +639,12 @@ def add_llvm_steps(factory, llvm_branch, os, configs, clean_rebuild):
                          haltOnFailure=True,
                          workdir=build_dir,
                          env=env,
-                         command=get_cmake_build_command(os, config, build_dir, target='install')))
+                         command=get_cmake_build_command(builder_type, config, build_dir, target='install')))
 
 
-def add_halide_cmake_build_steps(factory, llvm_branch, os, configs):
+def add_halide_cmake_build_steps(factory, builder_type, configs):
     for config in configs:
-        env = get_env(os, config)
+        env = get_env(builder_type, config)
 
         # Always do a clean build for Halide
         source_dir = get_halide_source_path()
@@ -593,9 +665,9 @@ def add_halide_cmake_build_steps(factory, llvm_branch, os, configs):
                               workdir=build_dir,
                               env=env,
                               path=source_dir,
-                              generator=get_cmake_generator(os),
-                              definitions=get_halide_cmake_definitions(os, config),
-                              options=get_cmake_options(os)))
+                              generator=get_cmake_generator(builder_type),
+                              definitions=get_halide_cmake_definitions(builder_type, config),
+                              options=get_cmake_options(builder_type)))
 
         factory.addStep(
             ShellCommand(name='Build Halide %s' % config,
@@ -604,11 +676,11 @@ def add_halide_cmake_build_steps(factory, llvm_branch, os, configs):
                          haltOnFailure=True,
                          workdir=build_dir,
                          env=env,
-                         command=get_cmake_build_command(os, config, build_dir)))
+                         command=get_cmake_build_command(builder_type, config, build_dir)))
 
 
 # Return a dict with halide-targets as the keys, and a list of test-labels for each value.
-def get_test_labels(os, llvm_branch):
+def get_test_labels(builder_type):
     targets = defaultdict(list)
 
     targets['host'].extend(['internal', 'correctness', 'generator',
@@ -616,47 +688,39 @@ def get_test_labels(os, llvm_branch):
 
     # TODO: some JIT+generator tests are failing on arm32; disable for now
     # pending fixes (see https://github.com/halide/Halide/issues/4940)
-    if os.startswith('arm32'):
+    if builder_type.arch == 'arm' and builder_type.bits == 32 and builder_type.os == 'linux':
         targets['host'].remove('internal')
         targets['host'].remove('generator')
 
-    # The armbots aren't equipped to use python.
-    # TODO: buildbots + config need love to make 32-bit Python work properly,
-    # just disable the testing for now
-    if not os.startswith('arm') and not os.startswith('linux-32'):
+    if builder_type.handles_python():
         targets['host'].extend(['python'])
 
-    if os.startswith('linux-32-gcc7'):
-        # Also test without sse 4.1
-        targets['x86-32'].extend(['correctness'])
+    # Test without SSE4.1 on all x86 systems
+    if builder_type.arch == 'x86':
+        t = 'x86-%d-%s' % (builder_type.bits, builder_type.os)
+        targets[t].extend(['correctness'])
+        # on x86-64, also test with SSE4.1 (but nothing else that 'host' might sniff)
+        if builder_type.bits == 64:
+            targets['%s-sse41' % t].extend(['correctness'])
 
-    if os.startswith('linux-64-gcc7') or os.startswith('mac-64'):
-        # extended cpu/gpu tests
-        targets['x86-64'].extend(['correctness'])
-        targets['x86-64-sse41'].extend(['correctness'])
-
-    if os.startswith('linux-64-gcc7'):
-        # The linux build-bots have an nvidia card
+    if builder_type.has_nvidia():
         targets['host-cuda'].extend(['correctness', 'generator', 'apps'])
         targets['host-opencl'].extend(['correctness', 'generator', 'apps'])
         targets['host-cuda-opencl'].extend(['correctness_multi_gpu'])
+        # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
+        # if builder_type.os == 'win':
+        #   targets['host-d3d12compute'].extend(['correctness', 'generator', 'apps'])
 
-    if os.startswith('mac-64'):
+    if builder_type.os == 'osx':
         # test metal on OS X
         targets['host-metal'].extend(['correctness', 'generator', 'apps'])
 
-    if os.startswith('win-64'):
-        targets['host-cuda'].extend(['correctness', 'generator', 'apps'])
-        targets['host-opencl'].extend(['correctness', 'generator', 'apps'])
-        # TODO: temporarily disabled due to https://github.com/halide/Halide/issues/3909
-        # targets['host-d3d12compute'].extend(['correctness', 'generator', 'apps'])
-
-    if os.startswith('linux-64-gcc7') and llvm_branch == LLVM_TRUNK_BRANCH:
+    if builder_type.handles_hexagon():
         # Also test hexagon using the simulator
         targets['host-hvx_128'].extend(['correctness', 'generator', 'apps'])
         targets['host-hvx_64'].extend(['correctness', 'generator', 'apps'])
 
-    if os.startswith('linux-64-gcc7') and llvm_branch == LLVM_TRUNK_BRANCH:
+    if builder_type.handles_wasm():
         # Test WASM usage (only on LLVM trunk)
         # TODO: perhaps move this to the OSX buildbot as it is less heavily loaded
         targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
@@ -672,10 +736,10 @@ def is_time_critical_test(test):
     return test in ['performance']
 
 
-def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
-    parallelism = get_build_parallelism(os)
+def add_halide_cmake_test_steps(factory, builder_type, configs):
+    parallelism = get_build_parallelism(builder_type)
 
-    labels = get_test_labels(os, llvm_branch)
+    labels = get_test_labels(builder_type)
 
     for config in configs:
         source_dir = get_halide_source_path()
@@ -690,7 +754,7 @@ def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
         keys.insert(0, 'host')
 
         for halide_target in keys:
-            env = get_env(os, config)
+            env = get_env(builder_type, config)
             # HL_TARGET is now ignored by CMake builds, no need to set
             # (must specify -DHalide_TARGET to CMake instead)
             # env['HL_TARGET'] = halide_target
@@ -704,10 +768,10 @@ def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
                       env=env,
                       workdir=build_dir,
                       path=source_dir,
-                      generator=get_cmake_generator(os),
+                      generator=get_cmake_generator(builder_type),
                       definitions=get_halide_cmake_definitions(
-                          os, config, halide_target=halide_target),
-                      options=get_cmake_options(os)))
+                          builder_type, config, halide_target=halide_target),
+                      options=get_cmake_options(builder_type)))
 
             factory.addStep(
                 ShellCommand(name='Rebuild for Halide_TARGET=%s' % halide_target,
@@ -716,13 +780,11 @@ def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
                              haltOnFailure=True,
                              workdir=build_dir,
                              env=env,
-                             command=get_cmake_build_command(os, config, build_dir)))
+                             command=get_cmake_build_command(builder_type, config, build_dir)))
 
             test_labels = labels[halide_target]
 
-            # TODO: buildbots + config need love to make 32-bit Python work properly,
-            # just disable the testing for now
-            if os.startswith('arm') or os.startswith('linux-32'):
+            if not builder_type.handles_python():
                 if 'python' in test_labels:
                     test_labels.remove('python')
 
@@ -744,7 +806,7 @@ def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
                                 '--label-regex', '"%s"' % test_set,
                                 '--parallel', '%d' % parallelism])
 
-                if os.startswith('win') or os.startswith('linux'):
+                if builder_type.os == 'win' or builder_type.os == 'linux':
                     # TODO: disable lens_blur on win32 for now due to
                     # https://bugs.llvm.org/show_bug.cgi?id=46176
                     #
@@ -784,13 +846,13 @@ def add_halide_cmake_test_steps(factory, llvm_branch, os, configs):
                                  command=cmd))
 
 
-def create_make_factory(os, llvm_branch):
-    assert not os.startswith('win')
+def create_make_factory(builder_type):
+    assert builder_type.os != 'win'
 
     configs = ['Release']
     for config in configs:
-        env = get_env(os, config)
-        make_threads = get_build_parallelism(os)
+        env = get_env(builder_type, config)
+        make_threads = get_build_parallelism(builder_type)
         build_dir = get_halide_build_path(config)
 
         factory = BuildFactory()
@@ -798,11 +860,11 @@ def create_make_factory(os, llvm_branch):
         # It's never necessary to use get_msvc_config_steps() for Make,
         # since we never use Make with MSVC
 
-        add_get_source_steps(factory, llvm_branch)
+        add_get_source_steps(factory, builder_type)
 
         # TODO: we shouldn't need a clean rebuild anymore
-        clean_llvm_rebuild = False  # (llvm_branch == LLVM_TRUNK_BRANCH)
-        add_llvm_steps(factory, llvm_branch, os, configs, clean_llvm_rebuild)
+        clean_llvm_rebuild = False  # (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
+        add_llvm_steps(factory, builder_type, configs, clean_llvm_rebuild)
 
         # Force a full rebuild of Halide every time
         factory.addStep(RemoveDirectory(name="Remove Halide Build Dir",
@@ -812,17 +874,15 @@ def create_make_factory(os, llvm_branch):
         targets = [('distrib', 'host'),
                    ('build_tests', 'host')]
 
-        labels = get_test_labels(os, llvm_branch)
+        labels = get_test_labels(builder_type)
         for halide_target in list(labels.keys()):
 
-            # Make can't build/test WebAssembly
+            # Make can't build/test WebAssembly via Make (only via CMake)
             if "wasm" in halide_target:
                 continue
 
             for label in labels[halide_target]:
-                # TODO: buildbots + config need love to make 32-bit Python work properly,
-                # just disable the testing for now
-                if os.startswith('arm') or os.startswith('linux-32'):
+                if not builder_type.handles_python():
                     if 'python' in label:
                         continue
                     # TODO: some of the apps require python, so we must skip them for now also
@@ -856,7 +916,7 @@ def create_make_factory(os, llvm_branch):
                                                   '-j', p,
                                                   target],
                                          timeout=3600))
-            if target == 'distrib' and 'testbranch' not in os:
+            if target == 'distrib' and not builder_type.testbranch:
                 factory.addStep(
                     FileUpload(workersrc='distrib/halide.tgz',
                                workdir=build_dir,
@@ -871,23 +931,22 @@ def create_make_factory(os, llvm_branch):
 
     return factory
 
-# TODO replace this with cmake package
 
-
-def create_win_distro_factory(os, llvm_branch):
-    assert os.startswith('win')
+def create_win_distro_factory(builder_type):
+    # TODO: distro is an anachronism that should go away once proper CMake packaging lands
+    assert builder_type.os == 'win'
 
     factory = BuildFactory()
-    get_msvc_config_steps(factory, os)
+    get_msvc_config_steps(factory, builder_type)
 
-    add_get_source_steps(factory, llvm_branch)
+    add_get_source_steps(factory, builder_type)
 
     configs = ['Release', 'Debug']
 
-    clean_llvm_rebuild = (llvm_branch == LLVM_TRUNK_BRANCH)
-    add_llvm_steps(factory, llvm_branch, os, configs, clean_llvm_rebuild)
+    clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
+    add_llvm_steps(factory, builder_type, configs, clean_llvm_rebuild)
 
-    add_halide_cmake_build_steps(factory, llvm_branch, os, configs)
+    add_halide_cmake_build_steps(factory, builder_type, configs)
 
     # Make and upload a distro
     factory.addStep(RemoveDirectory(name="Remove Halide Distrib Dir",
@@ -960,61 +1019,60 @@ def create_win_distro_factory(os, llvm_branch):
     return factory
 
 
-def create_cmake_factory(os, llvm_branch):
+def create_cmake_factory(builder_type):
     factory = BuildFactory()
-    get_msvc_config_steps(factory, os)
+    get_msvc_config_steps(factory, builder_type)
 
-    add_get_source_steps(factory, llvm_branch)
+    add_get_source_steps(factory, builder_type)
 
     configs = ['Release']
 
-    clean_llvm_rebuild = (llvm_branch == LLVM_TRUNK_BRANCH)
-    add_llvm_steps(factory, llvm_branch, os, configs, clean_llvm_rebuild)
+    clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
+    add_llvm_steps(factory, builder_type, configs, clean_llvm_rebuild)
 
-    add_halide_cmake_build_steps(factory, llvm_branch, os, configs)
+    add_halide_cmake_build_steps(factory, builder_type, configs)
 
-    add_halide_cmake_test_steps(factory, llvm_branch, os, configs)
+    add_halide_cmake_test_steps(factory, builder_type, configs)
 
     return factory
 
 
-def create_factory(os, llvm_branch, use_cmake):
-    if os.startswith('win') and '-distro' in os:
-        return create_win_distro_factory(os, llvm_branch)
-    elif os.startswith('win') or use_cmake:
-        return create_cmake_factory(os, llvm_branch)
+def create_factory(builder_type):
+    # TODO: distro is an anachronism that should go away once proper CMake packaging lands
+    if builder_type.os == 'win' and builder_type.distro:
+        return create_win_distro_factory(builder_type)
+    elif builder_type.os == 'win' or builder_type.cmake:
+        return create_cmake_factory(builder_type)
     else:
-        return create_make_factory(os, llvm_branch)
+        return create_make_factory(builder_type)
 
 
-def create_builder(os, llvm_branch, use_cmake=False):
-    factory = create_factory(os, llvm_branch, use_cmake)
+def create_builder(builder_type):
+    factory = create_factory(builder_type)
 
-    tags = os.split('-')
-    tags.append('llvm-' + to_name(llvm_branch))
+    tags = builder_type.builder_label().split('-')
     if 'testbranch' not in tags:
         tags.append('master')
 
-    workers = get_workers(os)
+    workers = get_workers(builder_type)
     # TODO: brutal hack, linuxbots don't have enough space.
     # divide work between them for now.
     if 'linux-worker-2' in workers or 'linux-worker-3' in workers:
         # send trunk builds to one, everything else to the other
-        if 'trunk' in to_name(llvm_branch):
+        if 'trunk' in to_name(builder_type.llvm_branch):
             workers.remove('linux-worker-3')
         else:
             workers.remove('linux-worker-2')
 
-    print("create_builder(%s, %s, %s) -> workers %s" %
-          (str(os), str(llvm_branch), str(use_cmake), str(workers)))
-    builder = BuilderConfig(name=os + '-' + to_name(llvm_branch),
+    print("create_builder(%s) -> workers %s" %
+          (str(builder_type), str(workers)))
+    builder = BuilderConfig(name=builder_type.builder_label(),
                             workernames=workers,
                             factory=factory,
                             collapseRequests=True,
                             tags=tags)
 
-    builder.llvm_branch = llvm_branch
-    builder.os = os
+    builder.builder_type = builder_type
 
     c['builders'].append(builder)
 
@@ -1031,8 +1089,8 @@ def create_scheduler(llvm_branch):
             return change.branch == llvm_branch
         return not master_only(change, llvm_branch)
 
-    builders = [str(b.name) for b in c['builders'] if b.llvm_branch ==
-                llvm_branch and 'testbranch' not in b.name]
+    builders = [str(b.name) for b in c['builders']
+                if b.builder_type.llvm_branch == llvm_branch and not b.builder_type.testbranch]
     scheduler = schedulers.SingleBranchScheduler(
         name='halide-' + to_name(llvm_branch),
         codebases=['halide', 'llvm'],
@@ -1042,8 +1100,8 @@ def create_scheduler(llvm_branch):
 
     c['schedulers'].append(scheduler)
 
-    builders = [str(b.name) for b in c['builders'] if b.llvm_branch ==
-                llvm_branch and 'testbranch' in b.name]
+    builders = [str(b.name) for b in c['builders']
+                if b.builder_type.llvm_branch == llvm_branch and b.builder_type.testbranch]
     if builders:
         scheduler = schedulers.SingleBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
@@ -1055,7 +1113,8 @@ def create_scheduler(llvm_branch):
 
         c['schedulers'].append(scheduler)
 
-    builders = [str(b.name) for b in c['builders'] if b.llvm_branch == llvm_branch]
+    builders = [str(b.name) for b in c['builders']
+                if b.builder_type.llvm_branch == llvm_branch]
     scheduler = schedulers.ForceScheduler(
         name='force-' + to_name(llvm_branch),
         builderNames=builders,
@@ -1065,57 +1124,61 @@ def create_scheduler(llvm_branch):
 
 c['builders'] = []
 
-# Builders that test master. We test the most recent official release
-# of llvm on everything, to make it possible to do binary
-# distributions with a uniform llvm version. We also test against llvm
-# trunk, with lower priority, so that we can bisect llvm trunk
-# breakages on various platforms if they are discovered late.
-create_builder('arm32-linux-32', LLVM_TRUNK_BRANCH)
-create_builder('arm32-linux-32', LLVM_OLD_BRANCH)
+_BUILDER_TYPES = [
+    # Builders that test master. We test the most recent official release
+    # of llvm on everything, to make it possible to do binary
+    # distributions with a uniform llvm version. We also test against llvm
+    # trunk, with lower priority, so that we can bisect llvm trunk
+    # breakages on various platforms if they are discovered late.
+    BuilderType('arm', 32, 'linux', LLVM_TRUNK_BRANCH),
+    BuilderType('arm', 32, 'linux', LLVM_OLD_BRANCH),
 
-create_builder('arm64-linux-64', LLVM_TRUNK_BRANCH)
-create_builder('arm64-linux-64', LLVM_OLD_BRANCH)
+    BuilderType('arm', 64, 'linux', LLVM_TRUNK_BRANCH),
+    BuilderType('arm', 64, 'linux', LLVM_OLD_BRANCH),
 
-create_builder('linux-32-gcc7', LLVM_TRUNK_BRANCH)
-create_builder('linux-32-gcc7', LLVM_RELEASE_BRANCH)
-create_builder('linux-32-gcc7', LLVM_OLD_BRANCH)
+    BuilderType('x86', 32, 'linux', LLVM_TRUNK_BRANCH),
+    BuilderType('x86', 32, 'linux', LLVM_RELEASE_BRANCH),
 
-create_builder('linux-64-gcc7', LLVM_TRUNK_BRANCH)
-create_builder('linux-64-gcc7', LLVM_RELEASE_BRANCH)
-create_builder('linux-64-gcc7', LLVM_OLD_BRANCH)
+    BuilderType('x86', 64, 'linux', LLVM_TRUNK_BRANCH),
+    BuilderType('x86', 64, 'linux', LLVM_RELEASE_BRANCH),
+    BuilderType('x86', 64, 'linux', LLVM_OLD_BRANCH),
 
-create_builder('mac-64', LLVM_TRUNK_BRANCH)
-create_builder('mac-64', LLVM_RELEASE_BRANCH)
-create_builder('mac-64', LLVM_OLD_BRANCH)
+    BuilderType('x86', 64, 'osx', LLVM_TRUNK_BRANCH),
+    BuilderType('x86', 64, 'osx', LLVM_RELEASE_BRANCH),
+    BuilderType('x86', 64, 'osx', LLVM_OLD_BRANCH),
 
-create_builder('win-32', LLVM_TRUNK_BRANCH)
-create_builder('win-64', LLVM_TRUNK_BRANCH)
+    BuilderType('x86', 32, 'win', LLVM_TRUNK_BRANCH),
+    BuilderType('x86', 64, 'win', LLVM_TRUNK_BRANCH),
 
-create_builder('win-32-distro', LLVM_RELEASE_BRANCH)
-create_builder('win-64-distro', LLVM_RELEASE_BRANCH)
+    # TODO: distro is an anachronism that should go away once proper CMake packaging lands
+    BuilderType('x86', 32, 'win', LLVM_RELEASE_BRANCH, distro=True),
+    BuilderType('x86', 64, 'win', LLVM_RELEASE_BRANCH, distro=True),
 
-# Make some builders just for testing branches. Picking a fixed llvm
-# version will avoid LLVM rebuilds for the best turnaround. Usually the
-# most recent 'released' (non-trunk) version is the best choice.
-create_builder('win-64-testbranch',         LLVM_RELEASE_BRANCH)
-create_builder('win-32-testbranch',         LLVM_RELEASE_BRANCH)
-create_builder('mac-64-testbranch',         LLVM_RELEASE_BRANCH)
-create_builder('linux-64-gcc7-testbranch', LLVM_RELEASE_BRANCH)
-create_builder('linux-32-gcc7-testbranch', LLVM_RELEASE_BRANCH)
-create_builder('arm64-linux-64-testbranch', LLVM_RELEASE_BRANCH)
-create_builder('arm32-linux-32-testbranch', LLVM_RELEASE_BRANCH)
+    # Make some builders just for testing branches. Picking a fixed llvm
+    # version will avoid LLVM rebuilds for the best turnaround. Usually the
+    # most recent 'released' (non-trunk) version is the best choice.
+    BuilderType('arm', 32, 'linux', LLVM_RELEASE_BRANCH, testbranch=true),
+    BuilderType('arm', 64, 'linux', LLVM_RELEASE_BRANCH, testbranch=true),
+    BuilderType('x86', 32, 'linux', LLVM_RELEASE_BRANCH, testbranch=true),
+    BuilderType('x86', 32, 'win', LLVM_RELEASE_BRANCH, testbranch=true),
+    BuilderType('x86', 64, 'linux', LLVM_RELEASE_BRANCH, testbranch=true),
+    BuilderType('x86', 64, 'osx', LLVM_RELEASE_BRANCH, testbranch=true),
+    BuilderType('x86', 64, 'win', LLVM_RELEASE_BRANCH, testbranch=true),
 
-# And some CMake testing
-create_builder('mac-64-testbranch-cmake',         LLVM_RELEASE_BRANCH, use_cmake=True)
-create_builder('linux-64-gcc7-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
-create_builder('linux-32-gcc7-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
-create_builder('arm64-linux-64-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
-create_builder('arm32-linux-32-testbranch-cmake', LLVM_RELEASE_BRANCH, use_cmake=True)
+    # And some Make testing for testbranches too
+    BuilderType('arm', 32, 'linux', LLVM_RELEASE_BRANCH, cmake=False, testbranch=true),
+    BuilderType('arm', 64, 'linux', LLVM_RELEASE_BRANCH, cmake=False, testbranch=true),
+    BuilderType('x86', 32, 'linux', LLVM_RELEASE_BRANCH, cmake=False, testbranch=true),
+    BuilderType('x86', 64, 'linux', LLVM_RELEASE_BRANCH, cmake=False, testbranch=true),
+    BuilderType('x86', 64, 'osx', LLVM_RELEASE_BRANCH, cmake=False, testbranch=true),
 
-# Check for build breakages against other llvm versions too
-create_builder('linux-64-gcc7-testbranch', LLVM_OLD_BRANCH)
-create_builder('linux-64-gcc7-testbranch', LLVM_TRUNK_BRANCH)
-create_builder('linux-64-gcc7-testbranch-cmake', LLVM_TRUNK_BRANCH, use_cmake=True)
+    # Check for testbranch build breakages against other llvm versions too
+    BuilderType('x86', 64, 'linux', LLVM_OLD_BRANCH, testbranch=true),
+    BuilderType('x86', 64, 'linux', LLVM_TRUNK_BRANCH, testbranch=true),
+    BuilderType('x86', 64, 'linux', LLVM_TRUNK_BRANCH, cmake=False, testbranch=true),
+]
+for builder_type in _BUILDER_TYPES:
+    create_builder(builder_type)
 
 c['schedulers'] = []
 create_scheduler(LLVM_TRUNK_BRANCH)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -220,7 +220,7 @@ class BuilderType:
     def has_nvidia():
         return (builder_type.arch == 'x86'
                 and builder_type.bits == 64
-                and builder_type.os == 'linux')
+                and (builder_type.os == 'linux' or builder_type.os == 'win'))
 
     def halide_target(self):
         return '%s-%d-%s' % (self.arch, self.bits, self.os)


### PR DESCRIPTION
This PR started as a way to simply ensure that all halide-target strings were fully specified (to allow https://github.com/halide/Halide/pull/5181 to land), but morphed into a nontrivial rewrite. 

Up to now, we had a poorly-defined string (called `os` in most places) that sorta-defined what a given Builder would build on (and/or build for); it was sorta like a halide-target-string but wasn't one. This, in combination with an llvm-branch-name, and some other random stuff, was used to make builder decisions.

This change attempts to bring some order to this madness by collapsing all of that into an encapsulated type passed around.

(This will almost certainly need a day or so of testing to flush out issues.)
