### PR TITLE
Add `tutorial` to test labels on buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -612,7 +612,7 @@ def get_test_labels(os, llvm_branch):
     targets = defaultdict(list)
 
     targets['host'].extend(['internal', 'correctness', 'generator',
-                            'error', 'warning', 'apps', 'performance'])
+                            'error', 'warning', 'apps', 'performance', 'tutorial'])
 
     # TODO: some JIT+generator tests are failing on arm32; disable for now
     # pending fixes (see https://github.com/halide/Halide/issues/4940)


### PR DESCRIPTION
I'm guessing this was removed at some point because some of them were failing for some configuations, but we really need test coverage here -- this just re-enables for host, with the assumption we'll likely need some more granular blacklisting added after we see how things look.