### PR TITLE
Stop building Debug distros on Windows

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -491,18 +491,10 @@ def get_llvm_cmake_definitions(builder_type, config):
     if builder_type.os == 'osx':
         definitions['LLVM_ENABLE_SUPPORT_XCODE_SIGNPOSTS'] = 'FORCE_OFF'
 
-    # Debug builds of LLVM can be so huge that they require this flag:
-    if builder_type.os == 'windows' and config == 'Debug':
-        definitions['CMAKE_CXX_FLAGS'] = '/bigobj'
-
     return definitions
 
 
-def get_env(builder_type, config):
-    # TODO: this is only necessary for Make (not CMake), I think,
-    # but doesn't hurt to just use everywhere
-    env = {'LLVM_CONFIG': get_llvm_build_path(config, 'bin/llvm-config')}
-
+def get_env(builder_type):
     cxx = 'c++'
     cc = 'cc'
     ld = 'ld'
@@ -602,9 +594,8 @@ def get_workers(builder_type):
 
 
 def add_llvm_steps(factory, builder_type, configs, clean_rebuild):
+    env = get_env(builder_type)
     for config in configs:
-        env = get_env(builder_type, config)
-
         build_dir = get_llvm_build_path(config)
         install_dir = get_llvm_install_path(config)
 
@@ -650,9 +641,8 @@ def add_llvm_steps(factory, builder_type, configs, clean_rebuild):
 
 
 def add_halide_cmake_build_steps(factory, builder_type, configs):
+    env = get_env(builder_type)
     for config in configs:
-        env = get_env(builder_type, config)
-
         # Always do a clean build for Halide
         source_dir = get_halide_source_path()
         build_dir = get_halide_build_path(config)
@@ -761,7 +751,7 @@ def add_halide_cmake_test_steps(factory, builder_type, configs):
         keys.insert(0, 'host')
 
         for halide_target in keys:
-            env = get_env(builder_type, config)
+            env = get_env(builder_type)
             # HL_TARGET is now ignored by CMake builds, no need to set
             # (must specify -DHalide_TARGET to CMake instead)
             # env['HL_TARGET'] = halide_target
@@ -871,7 +861,9 @@ def create_make_factory(builder_type):
 
     configs = ['Release']
     for config in configs:
-        env = get_env(builder_type, config)
+        env = get_env(builder_type)
+        env['LLVM_CONFIG'] = get_llvm_build_path(config, 'bin/llvm-config')
+
         make_threads = get_build_parallelism(builder_type)
         build_dir = get_halide_build_path(config)
 
@@ -972,7 +964,7 @@ def create_win_distro_factory(builder_type):
 
     add_get_source_steps(factory, builder_type)
 
-    configs = ['Release', 'Debug']
+    configs = ['Release']
 
     clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
     add_llvm_steps(factory, builder_type, configs, clean_llvm_rebuild)
@@ -991,7 +983,7 @@ def create_win_distro_factory(builder_type):
     factory.addStep(MakeDirectory(dir='distrib\\halide',
                                   locks=[performance_lock.access('counting')],
                                   haltOnFailure=False))
-    for d in ['Release', 'Debug', 'include', 'tools', 'tutorial', 'tutorial\\figures']:
+    for d in ['Release', 'include', 'tools', 'tutorial', 'tutorial\\figures']:
         factory.addStep(MakeDirectory(dir='distrib\\halide\\' + d,
                                       locks=[performance_lock.access('counting')],
                                       haltOnFailure=False))
@@ -999,8 +991,6 @@ def create_win_distro_factory(builder_type):
     file_pairs = [
         ('..\\halide-build-Release\\bin\\Release\\Halide.dll', 'Release'),
         ('..\\halide-build-Release\\lib\\Release\\Halide.lib', 'Release'),
-        ('..\\halide-build-Debug\\bin\\Debug\\Halide.dll', 'Debug'),
-        ('..\\halide-build-Debug\\lib\\Debug\\Halide.lib', 'Debug'),
         ('..\\halide-build-Release\\include\\Halide.h', 'include'),
         ('..\\halide\\src\\runtime\\HalideRuntim*.h', 'include'),
         ('..\\halide\\src\\runtime\\HalideBuffer.h', 'include'),


### PR DESCRIPTION
When building Windows distros, stop building the Debug variants; it takes a long time, is almost useless, and we don't think anyone uses it.

Also, as a drive-by fix, remove the 'config' option from `get_env()`; the only env var that we expect to vary between debug and release is LLVM_CONFIG, which is only set for makefile builds.

(Note that this change means the buildbots never attempt to do any debug builds of any sort anymore, but still iterate thru 'configs' lists that are just 'Release'; this is deliberate for now, as I'd rather wait to remove that plumbing after we're certain that Debug is gone for good.)