### PR TITLE
Kill 'distro' special casing for Windows

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -183,12 +183,11 @@ class BuilderType:
        setup. (If we ever need to do so, compiler should be added to this.)
     """
 
-    def __init__(self, arch, bits, os, llvm_branch, cmake=True, testbranch=False, distro=False):
+    def __init__(self, arch, bits, os, llvm_branch, cmake=True, testbranch=False):
         assert arch in ['arm', 'x86']
         assert bits in [32, 64]
         assert os in ['linux', 'windows', 'osx']
         assert llvm_branch in [LLVM_TRUNK_BRANCH, LLVM_RELEASE_BRANCH, LLVM_OLD_BRANCH]
-        assert not (testbranch and distro)
 
         self.arch = arch
         self.bits = bits
@@ -196,8 +195,6 @@ class BuilderType:
         self.llvm_branch = llvm_branch
         self.cmake = cmake
         self.testbranch = testbranch
-        # TODO: distro is an anachronism that should go away once proper CMake packaging lands
-        self.distro = distro
 
     # The armbots aren't configured with Python at all,
     # and supporting 32-bit Python on our 64-bit buildbots is painful
@@ -235,9 +232,6 @@ class BuilderType:
             s += '-testbranch'
         # else:
         #    s += '-master'
-
-        if self.distro:
-            s += '-distro'
 
         s += '-' + to_name(self.llvm_branch)
         s += '-cmake' if self.cmake else '-make'
@@ -958,7 +952,7 @@ def create_make_factory(builder_type):
 
 
 def create_win_distro_factory(builder_type):
-    # TODO: distro is an anachronism that should go away once proper CMake packaging lands
+    # TODO: distro is an anachronism that will go away once proper CMake packaging lands
     assert builder_type.os == 'windows'
 
     factory = BuildFactory()
@@ -1043,6 +1037,10 @@ def create_win_distro_factory(builder_type):
 
 
 def create_cmake_factory(builder_type):
+    # TODO: distro is an anachronism that will go away once proper CMake packaging lands
+    if builder_type.os == 'windows' and llvm_branch == LLVM_RELEASE_BRANCH and not builder_type.testbranch:
+        return create_win_distro_factory(builder_type)
+
     factory = BuildFactory()
     get_msvc_config_steps(factory, builder_type)
 
@@ -1061,10 +1059,7 @@ def create_cmake_factory(builder_type):
 
 
 def create_factory(builder_type):
-    # TODO: distro is an anachronism that should go away once proper CMake packaging lands
-    if builder_type.os == 'windows' and builder_type.distro:
-        return create_win_distro_factory(builder_type)
-    elif builder_type.os == 'windows' or builder_type.cmake:
+    if builder_type.cmake:
         return create_cmake_factory(builder_type)
     else:
         return create_make_factory(builder_type)
@@ -1176,11 +1171,10 @@ _BUILDER_TYPES = [
     BuilderType('x86', 64, 'osx', LLVM_OLD_BRANCH, cmake=False),
 
     BuilderType('x86', 32, 'windows', LLVM_TRUNK_BRANCH),
-    BuilderType('x86', 64, 'windows', LLVM_TRUNK_BRANCH),
+    BuilderType('x86', 32, 'windows', LLVM_RELEASE_BRANCH),
 
-    # TODO: distro is an anachronism that should go away once proper CMake packaging lands
-    BuilderType('x86', 32, 'windows', LLVM_RELEASE_BRANCH, distro=True),
-    BuilderType('x86', 64, 'windows', LLVM_RELEASE_BRANCH, distro=True),
+    BuilderType('x86', 64, 'windows', LLVM_TRUNK_BRANCH),
+    BuilderType('x86', 64, 'windows', LLVM_RELEASE_BRANCH),
 
     # Make some builders just for testing branches. Picking a fixed llvm
     # version will avoid LLVM rebuilds for the best turnaround. Usually the


### PR DESCRIPTION
This was a holdover from my previous refactoring work, but it's a wart that is confusing, and we can (exactly) infer it from distro == (windows and llvm_release_branch and not testbranch)

(should be no change in functionality, just cleaning up awkwardness)