### PR TITLE
Allow all builds to run on linuxbot3

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1050,14 +1050,10 @@ def create_builder(builder_type):
         tags.append('master')
 
     workers = get_workers(builder_type)
-    # TODO: brutal hack, linuxbots don't have enough space.
-    # divide work between them for now.
-    if 'linux-worker-2' in workers or 'linux-worker-3' in workers:
-        # send trunk builds to one, everything else to the other
-        if 'trunk' in to_name(builder_type.llvm_branch):
-            workers.remove('linux-worker-3')
-        else:
-            workers.remove('linux-worker-2')
+    # TODO: brutal hack, linuxbot2 doesn't have a lot of disk space,
+    # only allow trunk builds to go there
+    if 'linux-worker-2' in workers and 'trunk' not in to_name(builder_type.llvm_branch):
+        workers.remove('linux-worker-2')
 
     print("create_builder(%s) -> workers %s" %
           (builder_type.builder_label(), str(workers)))


### PR DESCRIPTION
We previously only allowed 10.0 and 11.0 builds there, due to disk space issues, but after reconfiguring it now has plenty of space and can build anything. (Linuxbot2 is still restricted to trunk-only to avoid space issues.)