### PR TITLE
Refactoring in Buildbot

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -21,12 +21,7 @@ LLVM_TRUNK_BRANCH = 'master'
 LLVM_RELEASE_BRANCH = 'release/11.x'
 LLVM_OLD_BRANCH = 'release/10.x'
 
-# Map the branchnames to the "old" naming style, for continuity
-_TO_NAME = {
-    LLVM_TRUNK_BRANCH: 'trunk',
-    LLVM_RELEASE_BRANCH: '1100',
-    LLVM_OLD_BRANCH: '1000',
-}
+_LLVM_BRANCHES = [LLVM_TRUNK_BRANCH, LLVM_RELEASE_BRANCH, LLVM_OLD_BRANCH]
 
 _TO_VERSION = {
     LLVM_TRUNK_BRANCH: 12,
@@ -36,7 +31,7 @@ _TO_VERSION = {
 
 
 def to_name(llvm_branch):
-    return _TO_NAME[llvm_branch]
+    return '%d' % _TO_VERSION[llvm_branch]
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -193,7 +188,7 @@ class BuilderType:
         assert arch in ['arm', 'x86']
         assert bits in [32, 64]
         assert os in ['linux', 'windows', 'osx']
-        assert llvm_branch in [LLVM_TRUNK_BRANCH, LLVM_RELEASE_BRANCH, LLVM_OLD_BRANCH]
+        assert llvm_branch in _LLVM_BRANCHES
 
         self.arch = arch
         self.bits = bits
@@ -242,6 +237,29 @@ class BuilderType:
         s += '-' + to_name(self.llvm_branch)
         s += '-cmake' if self.cmake else '-make'
         return s
+
+    def builder_tags(self):
+        tags = self.builder_label().split('-')
+        if 'testbranch' not in tags:
+            tags.append('master')
+        return tags
+
+    def get_worker_names(self):
+        if self.os == 'linux':
+            if self.arch == 'x86':
+                return ['linux-worker' + sfx for sfx in worker_suffixes]
+            else:
+                assert self.arch == 'arm'
+                if self.bits == 32:
+                    return ['arm32-linux-worker' + sfx for sfx in worker_suffixes]
+                else:
+                    return ['arm64-linux-worker' + sfx for sfx in worker_suffixes]
+        elif self.os == 'osx':
+            return ['mac-worker' + sfx for sfx in worker_suffixes]
+        elif self.os == 'windows':
+            return ['win-worker' + sfx for sfx in worker_suffixes]
+        else:
+            assert(False)
 
     def __str__(self):
         return '%s' % (self.halide_target())
@@ -295,9 +313,8 @@ def get_halide_build_path(config, *subpaths):
     return get_builddir_subpath(os.path.join('halide-%s' % config, *subpaths))
 
 
-def add_get_source_steps(factory, builder_type):
-
-    factory.addStep(Git(name='Get Halide master',
+def add_get_halide_source_steps(factory, builder_type):
+    factory.addStep(Git(name='Get Halide source',
                         locks=[performance_lock.access('counting')],
                         codebase='halide',
                         workdir=get_halide_source_path(),
@@ -305,6 +322,8 @@ def add_get_source_steps(factory, builder_type):
                         branch='master',
                         mode='incremental'))
 
+
+def add_get_llvm_source_steps(factory, builder_type):
     factory.addStep(Git(name='Get LLVM ' + to_name(builder_type.llvm_branch),
                         locks=[performance_lock.access('counting')],
                         codebase='llvm',
@@ -581,24 +600,6 @@ def get_build_parallelism(builder_type):
         assert False
 
 
-def get_workers(builder_type):
-    if builder_type.os == 'linux':
-        if builder_type.arch == 'x86':
-            return ['linux-worker' + sfx for sfx in worker_suffixes]
-        else:
-            assert builder_type.arch == 'arm'
-            if builder_type.bits == 32:
-                return ['arm32-linux-worker' + sfx for sfx in worker_suffixes]
-            else:
-                return ['arm64-linux-worker' + sfx for sfx in worker_suffixes]
-    elif builder_type.os == 'osx':
-        return ['mac-worker' + sfx for sfx in worker_suffixes]
-    elif builder_type.os == 'windows':
-        return ['win-worker' + sfx for sfx in worker_suffixes]
-    else:
-        assert(False)
-
-
 def add_llvm_steps(factory, builder_type, configs, clean_rebuild):
     env = get_env(builder_type)
     for config in configs:
@@ -796,11 +797,10 @@ def get_test_labels(builder_type):
 
     return targets
 
-# Return true if the test label (or single-test name) is 'time critical' and must
-# be run with an exclusive lock on the buildbot (typically, performance tests)
-
 
 def is_time_critical_test(test):
+    # Return true if the test label (or single-test name) is 'time critical' and must
+    # be run with an exclusive lock on the buildbot (typically, performance tests)
     return test in ['performance']
 
 
@@ -928,7 +928,7 @@ def add_halide_cmake_test_steps(factory, builder_type, configs):
                                  command=cmd))
 
 
-def create_make_factory(builder_type):
+def create_halide_make_factory(builder_type):
     assert builder_type.os != 'windows'
 
     configs = ['Release']
@@ -944,7 +944,8 @@ def create_make_factory(builder_type):
         # It's never necessary to use get_msvc_config_steps() for Make,
         # since we never use Make with MSVC
 
-        add_get_source_steps(factory, builder_type)
+        add_get_halide_source_steps(factory, builder_type)
+        add_get_llvm_source_steps(factory, builder_type)
 
         clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
         add_llvm_steps(factory, builder_type, configs, clean_llvm_rebuild)
@@ -1012,11 +1013,12 @@ def create_make_factory(builder_type):
     return factory
 
 
-def create_cmake_factory(builder_type):
+def create_halide_cmake_factory(builder_type):
     factory = BuildFactory()
     get_msvc_config_steps(factory, builder_type)
 
-    add_get_source_steps(factory, builder_type)
+    add_get_halide_source_steps(factory, builder_type)
+    add_get_llvm_source_steps(factory, builder_type)
 
     configs = ['Release']
 
@@ -1034,40 +1036,36 @@ def create_cmake_factory(builder_type):
     return factory
 
 
-def create_factory(builder_type):
+def create_halide_factory(builder_type):
     if builder_type.cmake:
-        return create_cmake_factory(builder_type)
+        return create_halide_cmake_factory(builder_type)
     else:
-        return create_make_factory(builder_type)
+        return create_halide_make_factory(builder_type)
 
 
-def create_builder(builder_type):
-    factory = create_factory(builder_type)
+def create_halide_builder(builder_type):
+    factory = create_halide_factory(builder_type)
 
-    tags = builder_type.builder_label().split('-')
-    if 'testbranch' not in tags:
-        tags.append('master')
-
-    workers = get_workers(builder_type)
+    workers = builder_type.get_worker_names()
     # TODO: brutal hack, linuxbot2 doesn't have a lot of disk space,
-    # only allow trunk builds to go there
-    if 'linux-worker-2' in workers and 'trunk' not in to_name(builder_type.llvm_branch):
+    # only allow main builds to go there
+    if 'linux-worker-2' in workers and builder_type.llvm_branch != LLVM_TRUNK_BRANCH:
         workers.remove('linux-worker-2')
 
-    print("create_builder(%s) -> workers %s" %
+    print("create_halide_builder(%s) -> workers %s" %
           (builder_type.builder_label(), str(workers)))
     builder = BuilderConfig(name=builder_type.builder_label(),
                             workernames=workers,
                             factory=factory,
                             collapseRequests=True,
-                            tags=tags)
+                            tags=builder_type.builder_tags())
 
     builder.builder_type = builder_type
 
     c['builders'].append(builder)
 
 
-def create_scheduler(llvm_branch):
+def create_halide_scheduler(llvm_branch):
 
     def master_only(change, llvm_branch):
         if 'llvm' in change.repository:
@@ -1112,9 +1110,10 @@ def create_scheduler(llvm_branch):
 
     c['schedulers'].append(scheduler)
 
+
 c['builders'] = []
 
-_BUILDER_TYPES = [
+_HALIDE_BUILDER_TYPES = [
     # Builders that test master. We test the most recent official release
     # of llvm on everything, to make it possible to do binary
     # distributions with a uniform llvm version. We also test against llvm
@@ -1172,13 +1171,12 @@ _BUILDER_TYPES = [
     BuilderType('x86', 64, 'linux', LLVM_TRUNK_BRANCH, testbranch=True),
     BuilderType('x86', 64, 'linux', LLVM_TRUNK_BRANCH, cmake=False, testbranch=True),
 ]
-for builder_type in _BUILDER_TYPES:
-    create_builder(builder_type)
+for builder_type in _HALIDE_BUILDER_TYPES:
+    create_halide_builder(builder_type)
 
 c['schedulers'] = []
-create_scheduler(LLVM_TRUNK_BRANCH)
-create_scheduler(LLVM_RELEASE_BRANCH)
-create_scheduler(LLVM_OLD_BRANCH)
+for llvm_branch in _LLVM_BRANCHES:
+    create_halide_scheduler(llvm_branch)
 
 # Create a scheduler to force a test of a branch
 builders = [str(b.name) for b in c['builders'] if 'testbranch' in b.name]


### PR DESCRIPTION
This should be mostly no-changes-expected, except that we now name all builds with the integral version of LLVM (eg 11 rather than 1100), including trunk (eg 12 rather than trunk), so that we no longer have a label that changes meaning over time.

The refactoring here is being done in order to make subsequent changes (with functional differences) easier to review; these include:

- adding 'halide' to various names to disambiguate from future additions with similar names

- moving some logic into BuilderType methods

- splitting some methods up into halide vs llvm portions