### PR TITLE
Remove configs

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -297,20 +297,20 @@ def get_llvm_source_path(*subpaths):
     return get_builddir_subpath(os.path.join('llvm-project', *subpaths))
 
 
-def get_llvm_build_path(config, *subpaths):
-    return get_builddir_subpath(os.path.join('llvm-build-%s' % config, *subpaths))
+def get_llvm_build_path(*subpaths):
+    return get_builddir_subpath(os.path.join('llvm-build', *subpaths))
 
 
-def get_llvm_install_path(config, *subpaths):
-    return get_builddir_subpath(os.path.join('llvm-install-%s' % config, *subpaths))
+def get_llvm_install_path(*subpaths):
+    return get_builddir_subpath(os.path.join('llvm-install', *subpaths))
 
 
 def get_halide_source_path(*subpaths):
-    return get_builddir_subpath(os.path.join('halide', *subpaths))
+    return get_builddir_subpath(os.path.join('halide-source', *subpaths))
 
 
-def get_halide_build_path(config, *subpaths):
-    return get_builddir_subpath(os.path.join('halide-%s' % config, *subpaths))
+def get_halide_build_path(*subpaths):
+    return get_builddir_subpath(os.path.join('halide-build', *subpaths))
 
 
 def add_get_halide_source_steps(factory, builder_type):
@@ -441,12 +441,12 @@ def get_cmake_options(builder_type):
     return options
 
 
-def get_halide_cmake_definitions(builder_type, config, halide_target='host'):
+def get_halide_cmake_definitions(builder_type, halide_target='host'):
     cmake_definitions = {
-        'Clang_DIR': get_llvm_install_path(config, 'lib/cmake/clang'),
-        'CMAKE_BUILD_TYPE': config,
+        'Clang_DIR': get_llvm_install_path('lib/cmake/clang'),
+        'CMAKE_BUILD_TYPE': 'Release',
         'Halide_TARGET': halide_target,
-        'LLVM_DIR': get_llvm_install_path(config, 'lib/cmake/llvm'),
+        'LLVM_DIR': get_llvm_install_path('lib/cmake/llvm'),
         'WITH_PYTHON_BINDINGS': 'ON' if builder_type.handles_python() else 'OFF'
     }
 
@@ -467,7 +467,7 @@ def get_halide_cmake_definitions(builder_type, config, halide_target='host'):
     return cmake_definitions
 
 
-def get_cmake_build_command(builder_type, config, build_dir, target=None):
+def get_cmake_build_command(builder_type, build_dir, target=None):
     cmd = ['ninja',
            '-C', build_dir,
            '-j', get_build_parallelism(builder_type)]
@@ -480,7 +480,7 @@ def get_cmake_build_command(builder_type, config, build_dir, target=None):
     #
     # cmd = ['cmake',
     #        '--build', build_dir,
-    #        '--config', config,
+    #        '--config', 'Release',
     #        '-j', get_build_parallelism(builder_type)]
     # if target:
     #     cmd.extend(['--target', target])
@@ -488,10 +488,10 @@ def get_cmake_build_command(builder_type, config, build_dir, target=None):
     return cmd
 
 
-def get_llvm_cmake_definitions(builder_type, config):
+def get_llvm_cmake_definitions(builder_type):
     definitions = {
-        'CMAKE_BUILD_TYPE': config,
-        'CMAKE_INSTALL_PREFIX': get_llvm_install_path(config),
+        'CMAKE_BUILD_TYPE': 'Release',
+        'CMAKE_INSTALL_PREFIX': get_llvm_install_path(),
         'LLVM_BUILD_32_BITS': ('ON' if builder_type.bits == 32 else 'OFF'),
         'LLVM_ENABLE_ASSERTIONS': 'ON',
         'LLVM_ENABLE_LIBXML2': 'OFF',
@@ -600,153 +600,149 @@ def get_build_parallelism(builder_type):
         assert False
 
 
-def add_llvm_steps(factory, builder_type, configs, clean_rebuild):
+def add_llvm_steps(factory, builder_type, clean_rebuild):
     env = get_env(builder_type)
-    for config in configs:
-        build_dir = get_llvm_build_path(config)
-        install_dir = get_llvm_install_path(config)
+    build_dir = get_llvm_build_path()
+    install_dir = get_llvm_install_path()
 
-        if clean_rebuild:
-            factory.addStep(RemoveDirectory(name="Remove LLVM Build Dir",
-                                            locks=[performance_lock.access('counting')],
-                                            dir=build_dir,
-                                            haltOnFailure=False))
-            factory.addStep(RemoveDirectory(name="Remove LLVM Install Dir",
-                                            locks=[performance_lock.access('counting')],
-                                            dir=install_dir,
-                                            haltOnFailure=False))
-
-        factory.addStep(MakeDirectory(name="Make LLVM Build Dir",
-                                      locks=[performance_lock.access('counting')],
-                                      dir=build_dir,
-                                      haltOnFailure=False))
-        factory.addStep(MakeDirectory(name="Make LLVM Install Dir",
-                                      locks=[performance_lock.access('counting')],
-                                      dir=install_dir,
-                                      haltOnFailure=False))
-
-        factory.addStep(
-            CMake(name='Configure LLVM %s' % config,
-                  description='Configure LLVM %s' % config,
-                  locks=[performance_lock.access('counting')],
-                  haltOnFailure=True,
-                  env=env,
-                  workdir=build_dir,
-                  path=get_llvm_source_path('llvm'),
-                  generator=get_cmake_generator(builder_type),
-                  definitions=get_llvm_cmake_definitions(builder_type, config),
-                  options=get_cmake_options(builder_type)))
-
-        factory.addStep(
-            ShellCommand(name='Build LLVM %s' % config,
-                         description='Build LLVM %s' % config,
-                         locks=[performance_lock.access('counting')],
-                         haltOnFailure=True,
-                         workdir=build_dir,
-                         env=env,
-                         command=get_cmake_build_command(builder_type, config, build_dir, target='install')))
-
-
-def add_halide_cmake_build_steps(factory, builder_type, configs):
-    env = get_env(builder_type)
-    for config in configs:
-        # Always do a clean build for Halide
-        source_dir = get_halide_source_path()
-        build_dir = get_halide_build_path(config)
-        factory.addStep(RemoveDirectory(name="Remove Halide Build Dir",
+    if clean_rebuild:
+        factory.addStep(RemoveDirectory(name="Remove LLVM Build Dir",
                                         locks=[performance_lock.access('counting')],
                                         dir=build_dir,
                                         haltOnFailure=False))
-        factory.addStep(MakeDirectory(name="Make Halide Build Dir",
-                                      locks=[performance_lock.access('counting')],
-                                      dir=build_dir,
-                                      haltOnFailure=False))
+        factory.addStep(RemoveDirectory(name="Remove LLVM Install Dir",
+                                        locks=[performance_lock.access('counting')],
+                                        dir=install_dir,
+                                        haltOnFailure=False))
 
-        factory.addStep(CMake(name='Configure Halide %s' % config,
-                              description='Configure Halide %s' % config,
-                              locks=[performance_lock.access('counting')],
-                              haltOnFailure=True,
-                              workdir=build_dir,
-                              env=env,
-                              path=source_dir,
-                              generator=get_cmake_generator(builder_type),
-                              definitions=get_halide_cmake_definitions(builder_type, config),
-                              options=get_cmake_options(builder_type)))
+    factory.addStep(MakeDirectory(name="Make LLVM Build Dir",
+                                  locks=[performance_lock.access('counting')],
+                                  dir=build_dir,
+                                  haltOnFailure=False))
+    factory.addStep(MakeDirectory(name="Make LLVM Install Dir",
+                                  locks=[performance_lock.access('counting')],
+                                  dir=install_dir,
+                                  haltOnFailure=False))
 
-        factory.addStep(
-            ShellCommand(name='Build Halide %s' % config,
-                         description='Build Halide %s' % config,
-                         locks=[performance_lock.access('counting')],
-                         haltOnFailure=True,
-                         workdir=build_dir,
-                         env=env,
-                         command=get_cmake_build_command(builder_type, config, build_dir)))
+    factory.addStep(
+        CMake(name='Configure LLVM',
+              description='Configure LLVM',
+              locks=[performance_lock.access('counting')],
+              haltOnFailure=True,
+              env=env,
+              workdir=build_dir,
+              path=get_llvm_source_path('llvm'),
+              generator=get_cmake_generator(builder_type),
+              definitions=get_llvm_cmake_definitions(builder_type),
+              options=get_cmake_options(builder_type)))
+
+    factory.addStep(
+        ShellCommand(name='Build LLVM',
+                     description='Build LLVM',
+                     locks=[performance_lock.access('counting')],
+                     haltOnFailure=True,
+                     workdir=build_dir,
+                     env=env,
+                     command=get_cmake_build_command(builder_type, build_dir, target='install')))
 
 
-def add_halide_cmake_package_steps(factory, builder_type, configs):
-    for config in configs:
-        assert config == 'Release'
+def add_halide_cmake_build_steps(factory, builder_type):
+    env = get_env(builder_type)
 
-        source_dir = get_halide_source_path()
+    # Always do a clean build for Halide
+    source_dir = get_halide_source_path()
+    build_dir = get_halide_build_path()
+    factory.addStep(RemoveDirectory(name="Remove Halide Build Dir",
+                                    locks=[performance_lock.access('counting')],
+                                    dir=build_dir,
+                                    haltOnFailure=False))
+    factory.addStep(MakeDirectory(name="Make Halide Build Dir",
+                                  locks=[performance_lock.access('counting')],
+                                  dir=build_dir,
+                                  haltOnFailure=False))
 
-        # TODO: this is clumsy; we assume an integer version for llvm
-        # and also assume the Halide version matches; this is sorta
-        # true now (for Halide trunk) but needs more sophistication
-        # once we make Halide release branches
-        # https://github.com/halide/Halide/issues/5263
-        version = '%s.0.0' % str(_TO_VERSION[builder_type.llvm_branch])
-        target = builder_type.halide_target()
-        ext = 'zip' if builder_type.os == 'windows' else 'tar.gz'
-        pkg_name = 'Halide-%s-%s.%s' % (version, target, ext)
+    factory.addStep(CMake(name='Configure Halide',
+                          description='Configure Halide',
+                          locks=[performance_lock.access('counting')],
+                          haltOnFailure=True,
+                          workdir=build_dir,
+                          env=env,
+                          path=source_dir,
+                          generator=get_cmake_generator(builder_type),
+                          definitions=get_halide_cmake_definitions(builder_type),
+                          options=get_cmake_options(builder_type)))
 
-        env = get_env(builder_type)
-        env['Clang_DIR'] = get_llvm_install_path(config, 'lib/cmake/clang')
-        env['LLVM_DIR'] = get_llvm_install_path(config, 'lib/cmake/llvm')
-        env['Halide_VERSION'] = version
+    factory.addStep(
+        ShellCommand(name='Build Halide',
+                     description='Build Halide',
+                     locks=[performance_lock.access('counting')],
+                     haltOnFailure=True,
+                     workdir=build_dir,
+                     env=env,
+                     command=get_cmake_build_command(builder_type, build_dir)))
 
-        if builder_type.os == 'windows':
-            # TODO: on Windows, we can't use Ninja for packaging (as we do everywhere
-            # else in this cfg) due to a bug in CMake 3.18, so we must use MSBuild;
-            # that means we must use a different build directory entirely. To simplify the
-            # world, we make this a subdir of the real build dir (so it gets cleaned properly).
-            # https://github.com/halide/Halide/issues/5264
-            build_dir = get_halide_build_path(config, "packaging_dir")
 
-            # build_dir contains an Interpolate, so we can't just use os.path.join(build_dir, ...)
-            pkg_path = get_halide_build_path(config, "packaging_dir", pkg_name)
+def add_halide_cmake_package_steps(factory, builder_type):
+    source_dir = get_halide_source_path()
 
-            if builder_type.arch == 'arm':
-                arch = 'ARM' if builder_type.bits == 32 else 'ARM64'
-            else:
-                arch = 'Win32' if builder_type.bits == 32 else 'x64'
-            cmd = [get_halide_source_path('tools/package-windows.bat'),
-                   source_dir, build_dir, arch]
+    # TODO: this is clumsy; we assume an integer version for llvm
+    # and also assume the Halide version matches; this is sorta
+    # true now (for Halide trunk) but needs more sophistication
+    # once we make Halide release branches
+    # https://github.com/halide/Halide/issues/5263
+    version = '%s.0.0' % str(_TO_VERSION[builder_type.llvm_branch])
+    target = builder_type.halide_target()
+    ext = 'zip' if builder_type.os == 'windows' else 'tar.gz'
+    pkg_name = 'Halide-%s-%s.%s' % (version, target, ext)
+
+    env = get_env(builder_type)
+    env['Clang_DIR'] = get_llvm_install_path('lib/cmake/clang')
+    env['LLVM_DIR'] = get_llvm_install_path('lib/cmake/llvm')
+    env['Halide_VERSION'] = version
+
+    if builder_type.os == 'windows':
+        # TODO: on Windows, we can't use Ninja for packaging (as we do everywhere
+        # else in this cfg) due to a bug in CMake 3.18, so we must use MSBuild;
+        # that means we must use a different build directory entirely. To simplify the
+        # world, we make this a subdir of the real build dir (so it gets cleaned properly).
+        # https://github.com/halide/Halide/issues/5264
+        build_dir = get_halide_build_path("packaging_dir")
+
+        # build_dir contains an Interpolate, so we can't just use os.path.join(build_dir, ...)
+        pkg_path = get_halide_build_path("packaging_dir", pkg_name)
+
+        if builder_type.arch == 'arm':
+            arch = 'ARM' if builder_type.bits == 32 else 'ARM64'
         else:
-            build_dir = get_halide_build_path(config)
-            pkg_path = get_halide_build_path(config, pkg_name)
-            cmd = [get_halide_source_path('tools/package-unix.sh'), source_dir, build_dir]
+            arch = 'Win32' if builder_type.bits == 32 else 'x64'
+        cmd = [get_halide_source_path('tools/package-windows.bat'),
+               source_dir, build_dir, arch]
+    else:
+        build_dir = get_halide_build_path()
+        pkg_path = get_halide_build_path(pkg_name)
+        cmd = [get_halide_source_path('tools/package-unix.sh'), source_dir, build_dir]
 
-        factory.addStep(
-            ShellCommand(name='Package Halide',
-                         description='Package Halide',
-                         workdir=build_dir,
-                         env=env,
-                         locks=[performance_lock.access('counting')],
-                         haltOnFailure=True,
-                         command=cmd))
+    factory.addStep(
+        ShellCommand(name='Package Halide',
+                     description='Package Halide',
+                     workdir=build_dir,
+                     env=env,
+                     locks=[performance_lock.access('counting')],
+                     haltOnFailure=True,
+                     command=cmd))
 
-        factory.addStep(
-            FileUpload(name='Upload Halide package',
-                       workersrc=pkg_path,
-                       locks=[performance_lock.access('counting')],
-                       haltOnFailure=True,
-                       mode=0o644,
-                       masterdest=get_distrib_name.withArgs(version, target, ext)))
+    factory.addStep(
+        FileUpload(name='Upload Halide package',
+                   workersrc=pkg_path,
+                   locks=[performance_lock.access('counting')],
+                   haltOnFailure=True,
+                   mode=0o644,
+                   masterdest=get_distrib_name.withArgs(version, target, ext)))
 
-        factory.addStep(MasterShellCommand(
-            workdir='/home/abadams/artifacts',
-            locks=[performance_lock.access('counting')],
-            command=['bash', '/home/abadams/build_bot_new/clean_artifacts.sh']))
+    factory.addStep(MasterShellCommand(
+        workdir='/home/abadams/artifacts',
+        locks=[performance_lock.access('counting')],
+        command=['bash', '/home/abadams/build_bot_new/clean_artifacts.sh']))
 
 
 # Return a dict with halide-targets as the keys, and a list of test-labels for each value.
@@ -804,212 +800,209 @@ def is_time_critical_test(test):
     return test in ['performance']
 
 
-def add_halide_cmake_test_steps(factory, builder_type, configs):
+def add_halide_cmake_test_steps(factory, builder_type):
     parallelism = get_build_parallelism(builder_type)
 
     labels = get_test_labels(builder_type)
 
-    for config in configs:
-        source_dir = get_halide_source_path()
-        build_dir = get_halide_build_path(config)
+    source_dir = get_halide_source_path()
+    build_dir = get_halide_build_path()
 
-        # Since we need to do at least a partial rebuild for each different target,
-        # we want to group things by target. Do host first, followed by a key-sorted
-        # order, to ensure predictability.
-        keys = list(labels.keys())
-        keys.remove('host')
-        keys.sort()
-        keys.insert(0, 'host')
+    # Since we need to do at least a partial rebuild for each different target,
+    # we want to group things by target. Do host first, followed by a key-sorted
+    # order, to ensure predictability.
+    keys = list(labels.keys())
+    keys.remove('host')
+    keys.sort()
+    keys.insert(0, 'host')
 
-        for halide_target in keys:
-            env = get_env(builder_type)
-            # HL_TARGET is now ignored by CMake builds, no need to set
-            # (must specify -DHalide_TARGET to CMake instead)
-            # env['HL_TARGET'] = halide_target
-            env['HL_JIT_TARGET'] = halide_target
+    for halide_target in keys:
+        env = get_env(builder_type)
+        # HL_TARGET is now ignored by CMake builds, no need to set
+        # (must specify -DHalide_TARGET to CMake instead)
+        # env['HL_TARGET'] = halide_target
+        env['HL_JIT_TARGET'] = halide_target
+
+        factory.addStep(
+            CMake(name='Reconfigure for Halide_TARGET=%s' % halide_target,
+                  description='Reconfigure for Halide_TARGET=%s' % halide_target,
+                  locks=[performance_lock.access('counting')],
+                  haltOnFailure=True,
+                  env=env,
+                  workdir=build_dir,
+                  path=source_dir,
+                  generator=get_cmake_generator(builder_type),
+                  definitions=get_halide_cmake_definitions(
+                      builder_type, halide_target=halide_target),
+                  options=get_cmake_options(builder_type)))
+
+        factory.addStep(
+            ShellCommand(name='Rebuild for Halide_TARGET=%s' % halide_target,
+                         description='Rebuild Halide for Halide_TARGET=%s' % halide_target,
+                         locks=[performance_lock.access('counting')],
+                         haltOnFailure=True,
+                         workdir=build_dir,
+                         env=env,
+                         command=get_cmake_build_command(builder_type, build_dir)))
+
+        test_labels = labels[halide_target]
+
+        if not builder_type.handles_python():
+            if 'python' in test_labels:
+                test_labels.remove('python')
+
+            # TODO: some of the apps require python, so we must skip them for now also
+            if 'apps' in test_labels:
+                test_labels.remove('apps')
+
+        parallel_test_labels = [
+            test for test in test_labels if not is_time_critical_test(test)]
+        exclusive_test_labels = [test for test in test_labels if is_time_critical_test(test)]
+
+        if len(parallel_test_labels):
+            test_set = '|'.join(parallel_test_labels)
+            # Note that we pass cmd as a single string deliberately,
+            # to avoid buildbot escaping issues with the | char
+            cmd = ' '.join(['ctest',
+                            '--build-config', 'Release',
+                            '--output-on-failure',
+                            '--label-regex', '"%s"' % test_set,
+                            '--parallel', '%d' % parallelism])
+
+            # Build up some special cases to exclude
+            exclude_regex = []
+            if builder_type.os == 'windows' or builder_type.os == 'linux':
+                # TODO: disable lens_blur on windows for now due to
+                # https://bugs.llvm.org/show_bug.cgi?id=46176
+                # and also due to windows testbots having inadequate GPU RAM
+                #
+                # And also on Linux due to inadequate GPU RAM
+                exclude_regex.append('interpolate')
+                exclude_regex.append('lens_blur')
+                exclude_regex.append('unsharp')
+
+            if builder_type.os == 'linux' or builder_type.bits == 32:
+                # TODO: disable tutorial_lesson_12_using_the_gpu (both C++ and python) on
+                # linux and 32-bit
+                exclude_regex.append('tutorial_lesson_12')
+
+            if builder_type.arch == 'arm' or builder_type.bits == 32:
+                # TODO: disable lesson_19 on arm32
+                # https://github.com/halide/Halide/issues/5224
+                exclude_regex.append('tutorial_lesson_19')
+
+            if exclude_regex:
+                cmd = cmd + ' --exclude-regex "%s"' % ('|'.join(exclude_regex))
 
             factory.addStep(
-                CMake(name='Reconfigure for Halide_TARGET=%s' % halide_target,
-                      description='Reconfigure for Halide_TARGET=%s' % halide_target,
-                      locks=[performance_lock.access('counting')],
-                      haltOnFailure=True,
-                      env=env,
-                      workdir=build_dir,
-                      path=source_dir,
-                      generator=get_cmake_generator(builder_type),
-                      definitions=get_halide_cmake_definitions(
-                          builder_type, config, halide_target=halide_target),
-                      options=get_cmake_options(builder_type)))
-
-            factory.addStep(
-                ShellCommand(name='Rebuild for Halide_TARGET=%s' % halide_target,
-                             description='Rebuild Halide for Halide_TARGET=%s' % halide_target,
+                ShellCommand(name='Test %s Halide_TARGET=%s' % (test_set, halide_target),
+                             description='Test %s Halide_TARGET=%s' % (
+                                 test_set, halide_target),
                              locks=[performance_lock.access('counting')],
-                             haltOnFailure=True,
                              workdir=build_dir,
                              env=env,
-                             command=get_cmake_build_command(builder_type, config, build_dir)))
+                             timeout=3600,
+                             command=cmd))
 
-            test_labels = labels[halide_target]
-
-            if not builder_type.handles_python():
-                if 'python' in test_labels:
-                    test_labels.remove('python')
-
-                # TODO: some of the apps require python, so we must skip them for now also
-                if 'apps' in test_labels:
-                    test_labels.remove('apps')
-
-            parallel_test_labels = [
-                test for test in test_labels if not is_time_critical_test(test)]
-            exclusive_test_labels = [test for test in test_labels if is_time_critical_test(test)]
-
-            if len(parallel_test_labels):
-                test_set = '|'.join(parallel_test_labels)
-                # Note that we pass cmd as a single string deliberately,
-                # to avoid buildbot escaping issues with the | char
-                cmd = ' '.join(['ctest',
-                                '--build-config', config,
-                                '--output-on-failure',
-                                '--label-regex', '"%s"' % test_set,
-                                '--parallel', '%d' % parallelism])
-
-                # Build up some special cases to exclude
-                exclude_regex = []
-                if builder_type.os == 'windows' or builder_type.os == 'linux':
-                    # TODO: disable lens_blur on windows for now due to
-                    # https://bugs.llvm.org/show_bug.cgi?id=46176
-                    # and also due to windows testbots having inadequate GPU RAM
-                    #
-                    # And also on Linux due to inadequate GPU RAM
-                    exclude_regex.append('interpolate')
-                    exclude_regex.append('lens_blur')
-                    exclude_regex.append('unsharp')
-
-                if builder_type.os == 'linux' or builder_type.bits == 32:
-                    # TODO: disable tutorial_lesson_12_using_the_gpu (both C++ and python) on
-                    # linux and 32-bit
-                    exclude_regex.append('tutorial_lesson_12')
-
-                if builder_type.arch == 'arm' or builder_type.bits == 32:
-                    # TODO: disable lesson_19 on arm32
-                    # https://github.com/halide/Halide/issues/5224
-                    exclude_regex.append('tutorial_lesson_19')
-
-                if exclude_regex:
-                    cmd = cmd + ' --exclude-regex "%s"' % ('|'.join(exclude_regex))
-
-                factory.addStep(
-                    ShellCommand(name='Test %s Halide_TARGET=%s' % (test_set, halide_target),
-                                 description='Test %s Halide_TARGET=%s' % (
-                                     test_set, halide_target),
-                                 locks=[performance_lock.access('counting')],
-                                 workdir=build_dir,
-                                 env=env,
-                                 timeout=3600,
-                                 command=cmd))
-
-            if len(exclusive_test_labels):
-                test_set = '|'.join(exclusive_test_labels)
-                # Note that we pass cmd as a single string deliberately,
-                # to avoid buildbot escaping issues with the | char
-                cmd = ' '.join(['ctest',
-                                '--build-config', config,
-                                '--output-on-failure',
-                                '--label-regex', '"%s"' % test_set])
-                factory.addStep(
-                    ShellCommand(name='Test %s Halide_TARGET=%s' % (test_set, halide_target),
-                                 description='Test %s Halide_TARGET=%s' % (
-                                     test_set, halide_target),
-                                 locks=[performance_lock.access('exclusive')],
-                                 workdir=build_dir,
-                                 env=env,
-                                 timeout=3600,
-                                 command=cmd))
+        if len(exclusive_test_labels):
+            test_set = '|'.join(exclusive_test_labels)
+            # Note that we pass cmd as a single string deliberately,
+            # to avoid buildbot escaping issues with the | char
+            cmd = ' '.join(['ctest',
+                            '--build-config', 'Release',
+                            '--output-on-failure',
+                            '--label-regex', '"%s"' % test_set])
+            factory.addStep(
+                ShellCommand(name='Test %s Halide_TARGET=%s' % (test_set, halide_target),
+                             description='Test %s Halide_TARGET=%s' % (
+                                 test_set, halide_target),
+                             locks=[performance_lock.access('exclusive')],
+                             workdir=build_dir,
+                             env=env,
+                             timeout=3600,
+                             command=cmd))
 
 
 def create_halide_make_factory(builder_type):
     assert builder_type.os != 'windows'
 
-    configs = ['Release']
-    for config in configs:
-        env = get_env(builder_type)
-        env['LLVM_CONFIG'] = get_llvm_build_path(config, 'bin/llvm-config')
+    env = get_env(builder_type)
+    env['LLVM_CONFIG'] = get_llvm_build_path('bin/llvm-config')
 
-        make_threads = get_build_parallelism(builder_type)
-        build_dir = get_halide_build_path(config)
+    make_threads = get_build_parallelism(builder_type)
+    build_dir = get_halide_build_path()
 
-        factory = BuildFactory()
+    factory = BuildFactory()
 
-        # It's never necessary to use get_msvc_config_steps() for Make,
-        # since we never use Make with MSVC
+    # It's never necessary to use get_msvc_config_steps() for Make,
+    # since we never use Make with MSVC
 
-        add_get_halide_source_steps(factory, builder_type)
-        add_get_llvm_source_steps(factory, builder_type)
+    add_get_halide_source_steps(factory, builder_type)
+    add_get_llvm_source_steps(factory, builder_type)
 
-        clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
-        add_llvm_steps(factory, builder_type, configs, clean_llvm_rebuild)
+    clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
+    add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
 
-        # Force a full rebuild of Halide every time
-        factory.addStep(RemoveDirectory(name="Remove Halide Build Dir",
-                                        locks=[performance_lock.access('counting')],
-                                        dir=build_dir))
+    # Force a full rebuild of Halide every time
+    factory.addStep(RemoveDirectory(name="Remove Halide Build Dir",
+                                    locks=[performance_lock.access('counting')],
+                                    dir=build_dir))
 
-        targets = [('build_tests', 'host')]
+    targets = [('build_tests', 'host')]
 
-        labels = get_test_labels(builder_type)
-        for halide_target in list(labels.keys()):
+    labels = get_test_labels(builder_type)
+    for halide_target in list(labels.keys()):
 
-            # Make can't build/test WebAssembly via Make (only via CMake)
-            if "wasm" in halide_target:
-                continue
+        # Make can't build/test WebAssembly via Make (only via CMake)
+        if "wasm" in halide_target:
+            continue
 
-            for label in labels[halide_target]:
-                if not builder_type.handles_python():
-                    if 'python' in label:
-                        continue
-                    # TODO: some of the apps require python, so we must skip them for now also
-                    if 'apps' in label:
-                        continue
+        for label in labels[halide_target]:
+            if not builder_type.handles_python():
+                if 'python' in label:
+                    continue
+                # TODO: some of the apps require python, so we must skip them for now also
+                if 'apps' in label:
+                    continue
 
-                if builder_type.arch == 'arm' or builder_type.bits == 32:
-                    # TODO: disable test_tutorial on arm and 32-bit builds as well
-                    # (we really only need to disable lessons 12 & 19
-                    # but the Makefile doesn't allow for that granularity)
-                    #
-                    # https://github.com/halide/Halide/issues/5144
-                    # https://github.com/halide/Halide/issues/5224
-                    if 'tutorial' in label:
-                        continue
+            if builder_type.arch == 'arm' or builder_type.bits == 32:
+                # TODO: disable test_tutorial on arm and 32-bit builds as well
+                # (we really only need to disable lessons 12 & 19
+                # but the Makefile doesn't allow for that granularity)
+                #
+                # https://github.com/halide/Halide/issues/5144
+                # https://github.com/halide/Halide/issues/5224
+                if 'tutorial' in label:
+                    continue
 
-                targets.append((label, halide_target))
+            targets.append((label, halide_target))
 
-        for (target, halide_target) in targets:
-            target_env = env.copy()
-            target_env['HL_TARGET'] = halide_target
-            target_env['HL_JIT_TARGET'] = halide_target
+    for (target, halide_target) in targets:
+        target_env = env.copy()
+        target_env['HL_TARGET'] = halide_target
+        target_env['HL_JIT_TARGET'] = halide_target
 
-            if is_time_critical_test(target):
-                p = 1
-                lock_mode = 'exclusive'
-            else:
-                p = make_threads
-                lock_mode = 'counting'
+        if is_time_critical_test(target):
+            p = 1
+            lock_mode = 'exclusive'
+        else:
+            p = make_threads
+            lock_mode = 'counting'
 
-            if target != 'build_tests':
-                target = 'test_%s' % target
+        if target != 'build_tests':
+            target = 'test_%s' % target
 
-            factory.addStep(ShellCommand(name='make ' + target,
-                                         description=target + ' ' + halide_target,
-                                         locks=[performance_lock.access(lock_mode)],
-                                         workdir=build_dir,
-                                         env=target_env,
-                                         haltOnFailure=False,
-                                         command=['make',
-                                                  '-f', get_halide_source_path('Makefile'),
-                                                  '-j', p,
-                                                  target],
-                                         timeout=3600))
+        factory.addStep(ShellCommand(name='make ' + target,
+                                     description=target + ' ' + halide_target,
+                                     locks=[performance_lock.access(lock_mode)],
+                                     workdir=build_dir,
+                                     env=target_env,
+                                     haltOnFailure=False,
+                                     command=['make',
+                                              '-f', get_halide_source_path('Makefile'),
+                                              '-j', p,
+                                              target],
+                                     timeout=3600))
     return factory
 
 
@@ -1020,18 +1013,16 @@ def create_halide_cmake_factory(builder_type):
     add_get_halide_source_steps(factory, builder_type)
     add_get_llvm_source_steps(factory, builder_type)
 
-    configs = ['Release']
-
     clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
-    add_llvm_steps(factory, builder_type, configs, clean_llvm_rebuild)
+    add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
 
-    add_halide_cmake_build_steps(factory, builder_type, configs)
+    add_halide_cmake_build_steps(factory, builder_type)
 
-    add_halide_cmake_test_steps(factory, builder_type, configs)
+    add_halide_cmake_test_steps(factory, builder_type)
 
     # If everything else looks ok, build a distrib.
     if not builder_type.testbranch:
-        add_halide_cmake_package_steps(factory, builder_type, configs)
+        add_halide_cmake_package_steps(factory, builder_type)
 
     return factory
 


### PR DESCRIPTION
Remove the 'config/configs' arguments being passed thru many methods; we stopped doing Debug builds on the buildbots a while back and aren't likely to resume anytime soon, so this is just noise.

(Note that this injects some trivial changes to names of some intermediate dirs.)

NOTE TO REVIEWERS: this is additive to https://github.com/halide/build_bot/pull/98 -- I deliberately split this into a separate PR to make it more reviewable (since there are lots of whitespace changes that add review noise). Please review 98 before reviewing this.