### PR TITLE
Still more refactoring

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -192,7 +192,7 @@ class BuilderType:
        setup. (If we ever need to do so, compiler should be added to this.)
     """
 
-    def __init__(self, arch, bits, os, llvm_branch, cmake=True, purpose=Purpose.halide_main):
+    def __init__(self, arch, bits, os, llvm_branch, purpose, cmake=True):
         assert arch in ['arm', 'x86']
         assert bits in [32, 64]
         assert os in ['linux', 'windows', 'osx']
@@ -239,8 +239,6 @@ class BuilderType:
 
         if self.purpose == Purpose.halide_testbranch:
             s += '-testbranch'
-        # else:
-        #    s += '-master'
 
         s += '-' + to_name(self.llvm_branch)
         s += '-cmake' if self.cmake else '-make'
@@ -248,7 +246,7 @@ class BuilderType:
 
     def builder_tags(self):
         tags = self.builder_label().split('-')
-        if 'testbranch' not in tags:
+        if self.purpose == Purpose.halide_main:
             tags.append('master')
         return tags
 
@@ -1055,8 +1053,8 @@ def get_interesting_halide_targets():
                 yield arch, bits, os
 
 
-def create_halide_builder(arch, bits, os, llvm_branch, cmake=True, purpose=Purpose.halide_main):
-    builder_type = BuilderType(arch, bits, os, llvm_branch, cmake=cmake, purpose=purpose)
+def create_halide_builder(arch, bits, os, llvm_branch, purpose, cmake=True):
+    builder_type = BuilderType(arch, bits, os, llvm_branch, purpose, cmake=cmake)
     workers = builder_type.get_worker_names()
     # TODO: brutal hack, linuxbot2 doesn't have a lot of disk space,
     # only allow main builds to go there
@@ -1076,28 +1074,29 @@ def create_halide_builders():
 
         # Create the builders for Halide master against all llvm versions.
         for llvm_branch in _LLVM_BRANCHES:
-            c['builders'].append(create_halide_builder(arch, bits, os, llvm_branch))
+            c['builders'].append(create_halide_builder(
+                arch, bits, os, llvm_branch, Purpose.halide_main))
 
         # Create the builders for testing Halide branches (aka pull requests).
         # Mostly just test against the LLVM 'release' branch, for best turnaround.
         c['builders'].append(create_halide_builder(
-            arch, bits, os, LLVM_RELEASE_BRANCH, purpose=Purpose.halide_testbranch))
+            arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch))
 
         if os != 'windows':
             # Also test Makefiles where possible
             # (TODO: maybe limit Makefile testing to just x86-64-linux?)
             c['builders'].append(create_halide_builder(
-                arch, bits, os, LLVM_RELEASE_BRANCH, purpose=Purpose.halide_testbranch, cmake=False))
+                arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch, cmake=False))
 
     # Test against main llvm branch for pull requests, too (for at least one target)
     c['builders'].append(create_halide_builder(
-        'x86', 64, 'linux', LLVM_MAIN_BRANCH, purpose=Purpose.halide_testbranch))
+        'x86', 64, 'linux', LLVM_MAIN_BRANCH, Purpose.halide_testbranch))
     c['builders'].append(create_halide_builder(
-        'x86', 64, 'linux', LLVM_MAIN_BRANCH, purpose=Purpose.halide_testbranch, cmake=False))
+        'x86', 64, 'linux', LLVM_MAIN_BRANCH, Purpose.halide_testbranch, cmake=False))
 
     # Test against the 'old' llvm branch for pull requests, too (for at least one target)
     c['builders'].append(create_halide_builder(
-        'x86', 64, 'linux', LLVM_OLD_BRANCH, purpose=Purpose.halide_testbranch))
+        'x86', 64, 'linux', LLVM_OLD_BRANCH, Purpose.halide_testbranch))
 
 
 def create_halide_scheduler(llvm_branch):
@@ -1112,6 +1111,7 @@ def create_halide_scheduler(llvm_branch):
             return change.branch == llvm_branch
         return not master_only(change, llvm_branch)
 
+    # ----- main
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_main]
     scheduler = schedulers.SingleBranchScheduler(
@@ -1123,23 +1123,28 @@ def create_halide_scheduler(llvm_branch):
 
     c['schedulers'].append(scheduler)
 
+    scheduler = schedulers.ForceScheduler(
+        name='force-main-' + to_name(llvm_branch),
+        builderNames=builders,
+        codebases=['halide', 'llvm'])
+
+    c['schedulers'].append(scheduler)
+
+    # ----- testbranch
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_testbranch]
-    if builders:
-        scheduler = schedulers.SingleBranchScheduler(
-            name='halide-testbranch-' + to_name(llvm_branch),
-            codebases=['halide', 'llvm'],
-            change_filter=util.ChangeFilter(
-                filter_fn=partial(not_master, llvm_branch=llvm_branch)),
-            treeStableTimer=60 * 5,  # seconds
-            builderNames=builders)
+    scheduler = schedulers.SingleBranchScheduler(
+        name='halide-testbranch-' + to_name(llvm_branch),
+        codebases=['halide', 'llvm'],
+        change_filter=util.ChangeFilter(
+            filter_fn=partial(not_master, llvm_branch=llvm_branch)),
+        treeStableTimer=60 * 5,  # seconds
+        builderNames=builders)
 
-        c['schedulers'].append(scheduler)
+    c['schedulers'].append(scheduler)
 
-    builders = [str(b.name) for b in c['builders']
-                if b.builder_type.llvm_branch == llvm_branch]
     scheduler = schedulers.ForceScheduler(
-        name='force-' + to_name(llvm_branch),
+        name='force-testbranch-' + to_name(llvm_branch),
         builderNames=builders,
         codebases=['halide', 'llvm'])
 
@@ -1151,16 +1156,6 @@ create_halide_builders()
 c['schedulers'] = []
 for llvm_branch in _LLVM_BRANCHES:
     create_halide_scheduler(llvm_branch)
-
-# Create a scheduler to force a test of a branch
-builders = [str(b.name)
-            for b in c['builders'] if b.builder_type.purpose == Purpose.halide_testbranch]
-scheduler = schedulers.ForceScheduler(
-    name='testbranch',
-    builderNames=builders,
-    codebases=['halide',
-               'llvm'])
-c['schedulers'].append(scheduler)
 
 # Set the builder priorities
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -7,6 +7,7 @@ from buildbot.changes.gitpoller import GitPoller
 from buildbot.changes.github import GitHubPullrequestPoller
 from buildbot.plugins import schedulers, util
 from collections import defaultdict
+from enum import Enum
 from functools import partial
 
 # At any given time, we test (at least) 3 LLVM versions:
@@ -167,6 +168,12 @@ from buildbot.process.properties import renderer
 from buildbot.process.properties import Interpolate
 
 
+class Purpose(Enum):
+    halide_main = 1
+    halide_testbranch = 2
+    # llvm = 3  # TODO: not yet, but soon
+
+
 class BuilderType:
     """A class to encapsulate the settings for a specific Builder.
        (Do not confuse with CMake's 'BUILD_TYPE', which is something else.)
@@ -175,6 +182,7 @@ class BuilderType:
        - Halide 'target' in the form of arch-bits-os
        - LLVM branch to be used
        - CMake vs Make
+       - main-branch vs testbranch
 
        It doesn't currently include any 'features' because we don't currently
        bake any in at build time.
@@ -184,7 +192,7 @@ class BuilderType:
        setup. (If we ever need to do so, compiler should be added to this.)
     """
 
-    def __init__(self, arch, bits, os, llvm_branch, cmake=True, testbranch=False):
+    def __init__(self, arch, bits, os, llvm_branch, cmake=True, purpose=Purpose.halide_main):
         assert arch in ['arm', 'x86']
         assert bits in [32, 64]
         assert os in ['linux', 'windows', 'osx']
@@ -195,7 +203,7 @@ class BuilderType:
         self.os = os
         self.llvm_branch = llvm_branch
         self.cmake = cmake
-        self.testbranch = testbranch
+        self.purpose = purpose
 
     # The armbots aren't configured with Python at all,
     # and supporting 32-bit Python on our 64-bit buildbots is painful
@@ -229,7 +237,7 @@ class BuilderType:
         # is appropriate)
         s = self.halide_target()
 
-        if self.testbranch:
+        if self.purpose == Purpose.halide_testbranch:
             s += '-testbranch'
         # else:
         #    s += '-master'
@@ -1021,7 +1029,7 @@ def create_halide_cmake_factory(builder_type):
     add_halide_cmake_test_steps(factory, builder_type)
 
     # If everything else looks ok, build a distrib.
-    if not builder_type.testbranch:
+    if builder_type.purpose == Purpose.halide_main:
         add_halide_cmake_package_steps(factory, builder_type)
 
     return factory
@@ -1034,26 +1042,62 @@ def create_halide_factory(builder_type):
         return create_halide_make_factory(builder_type)
 
 
-def create_halide_builder(builder_type):
-    factory = create_halide_factory(builder_type)
+def get_interesting_halide_targets():
+    for arch in ['arm', 'x86']:
+        for bits in [32, 64]:
+            for os in ['linux', 'osx', 'windows']:
+                if arch == 'arm' and os != 'linux':
+                    # arm is linux-only for now
+                    continue
+                if os == 'osx' and bits != 64:
+                    # osx is 64-bit only, period
+                    continue
+                yield arch, bits, os
 
+
+def create_halide_builder(arch, bits, os, llvm_branch, cmake=True, purpose=Purpose.halide_main):
+    builder_type = BuilderType(arch, bits, os, llvm_branch, cmake=cmake, purpose=purpose)
     workers = builder_type.get_worker_names()
     # TODO: brutal hack, linuxbot2 doesn't have a lot of disk space,
     # only allow main builds to go there
     if 'linux-worker-2' in workers and builder_type.llvm_branch != LLVM_TRUNK_BRANCH:
         workers.remove('linux-worker-2')
-
-    print("create_halide_builder(%s) -> workers %s" %
-          (builder_type.builder_label(), str(workers)))
     builder = BuilderConfig(name=builder_type.builder_label(),
                             workernames=workers,
-                            factory=factory,
+                            factory=create_halide_factory(builder_type),
                             collapseRequests=True,
                             tags=builder_type.builder_tags())
-
     builder.builder_type = builder_type
+    return builder
 
-    c['builders'].append(builder)
+
+def create_halide_builders():
+    for arch, bits, os in get_interesting_halide_targets():
+
+        # Create the builders for Halide master against all llvm versions.
+        for llvm_branch in _LLVM_BRANCHES:
+            c['builders'].append(create_halide_builder(arch, bits, os, llvm_branch))
+
+        # Create the builders for testing Halide branches (aka pull requests).
+        # Mostly just test against the LLVM 'release' branch, for best turnaround.
+        c['builders'].append(create_halide_builder(
+            arch, bits, os, LLVM_RELEASE_BRANCH, purpose=Purpose.halide_testbranch))
+
+        if os != 'windows':
+            # Also test Makefiles where possible
+            # (TODO: maybe limit Makefile testing to just x86-64-linux?)
+            c['builders'].append(create_halide_builder(
+                arch, bits, os, LLVM_RELEASE_BRANCH, purpose=Purpose.halide_testbranch, cmake=False))
+
+    # Test against main llvm branch for pull requests, too (for at least one target)
+    c['builders'].append(create_halide_builder(
+        'x86', 64, 'linux', LLVM_MAIN_BRANCH, purpose=Purpose.halide_testbranch))
+    c['builders'].append(create_halide_builder(
+        'x86', 64, 'linux', LLVM_MAIN_BRANCH, purpose=Purpose.halide_testbranch, cmake=False))
+
+    # Test against the 'old' llvm branch for pull requests, too (for at least one target)
+    c['builders'].append(create_halide_builder(
+        'x86', 64, 'linux', LLVM_OLD_BRANCH, purpose=Purpose.halide_testbranch))
 
 
 def create_halide_scheduler(llvm_branch):
@@ -1069,7 +1113,7 @@ def create_halide_scheduler(llvm_branch):
         return not master_only(change, llvm_branch)
 
     builders = [str(b.name) for b in c['builders']
-                if b.builder_type.llvm_branch == llvm_branch and not b.builder_type.testbranch]
+                if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_main]
     scheduler = schedulers.SingleBranchScheduler(
         name='halide-' + to_name(llvm_branch),
         codebases=['halide', 'llvm'],
@@ -1080,7 +1124,7 @@ def create_halide_scheduler(llvm_branch):
     c['schedulers'].append(scheduler)
 
     builders = [str(b.name) for b in c['builders']
-                if b.builder_type.llvm_branch == llvm_branch and b.builder_type.testbranch]
+                if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_testbranch]
     if builders:
         scheduler = schedulers.SingleBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
@@ -1102,75 +1146,15 @@ def create_halide_scheduler(llvm_branch):
     c['schedulers'].append(scheduler)
 
 
-c['builders'] = []
-
-_HALIDE_BUILDER_TYPES = [
-    # Builders that test master. We test the most recent official release
-    # of llvm on everything, to make it possible to do binary
-    # distributions with a uniform llvm version. We also test against llvm
-    # trunk, with lower priority, so that we can bisect llvm trunk
-    # breakages on various platforms if they are discovered late.
-
-    BuilderType('arm', 32, 'linux', LLVM_TRUNK_BRANCH),
-    BuilderType('arm', 32, 'linux', LLVM_RELEASE_BRANCH),
-    BuilderType('arm', 32, 'linux', LLVM_OLD_BRANCH),
-
-    BuilderType('arm', 64, 'linux', LLVM_TRUNK_BRANCH),
-    BuilderType('arm', 64, 'linux', LLVM_RELEASE_BRANCH),
-    BuilderType('arm', 64, 'linux', LLVM_OLD_BRANCH),
-
-    BuilderType('x86', 32, 'linux', LLVM_TRUNK_BRANCH),
-    BuilderType('x86', 32, 'linux', LLVM_RELEASE_BRANCH),
-    BuilderType('x86', 32, 'linux', LLVM_OLD_BRANCH),
-
-    BuilderType('x86', 64, 'linux', LLVM_TRUNK_BRANCH),
-    BuilderType('x86', 64, 'linux', LLVM_RELEASE_BRANCH),
-    BuilderType('x86', 64, 'linux', LLVM_OLD_BRANCH),
-
-    BuilderType('x86', 64, 'osx', LLVM_TRUNK_BRANCH),
-    BuilderType('x86', 64, 'osx', LLVM_RELEASE_BRANCH),
-    BuilderType('x86', 64, 'osx', LLVM_OLD_BRANCH),
-
-    BuilderType('x86', 32, 'windows', LLVM_TRUNK_BRANCH),
-    BuilderType('x86', 32, 'windows', LLVM_RELEASE_BRANCH),
-    BuilderType('x86', 32, 'windows', LLVM_OLD_BRANCH),
-
-    BuilderType('x86', 64, 'windows', LLVM_TRUNK_BRANCH),
-    BuilderType('x86', 64, 'windows', LLVM_RELEASE_BRANCH),
-    BuilderType('x86', 64, 'windows', LLVM_OLD_BRANCH),
-
-    # Make some builders just for testing branches. Picking a fixed llvm
-    # version will avoid LLVM rebuilds for the best turnaround. Usually the
-    # most recent 'released' (non-trunk) version is the best choice.
-    BuilderType('arm', 32, 'linux', LLVM_RELEASE_BRANCH, testbranch=True),
-    BuilderType('arm', 64, 'linux', LLVM_RELEASE_BRANCH, testbranch=True),
-    BuilderType('x86', 32, 'linux', LLVM_RELEASE_BRANCH, testbranch=True),
-    BuilderType('x86', 32, 'windows', LLVM_RELEASE_BRANCH, testbranch=True),
-    BuilderType('x86', 64, 'linux', LLVM_RELEASE_BRANCH, testbranch=True),
-    BuilderType('x86', 64, 'osx', LLVM_RELEASE_BRANCH, testbranch=True),
-    BuilderType('x86', 64, 'windows', LLVM_RELEASE_BRANCH, testbranch=True),
-
-    # And some Make testing for testbranches too
-    BuilderType('arm', 32, 'linux', LLVM_RELEASE_BRANCH, cmake=False, testbranch=True),
-    BuilderType('arm', 64, 'linux', LLVM_RELEASE_BRANCH, cmake=False, testbranch=True),
-    BuilderType('x86', 32, 'linux', LLVM_RELEASE_BRANCH, cmake=False, testbranch=True),
-    BuilderType('x86', 64, 'linux', LLVM_RELEASE_BRANCH, cmake=False, testbranch=True),
-    BuilderType('x86', 64, 'osx', LLVM_RELEASE_BRANCH, cmake=False, testbranch=True),
-
-    # Check for testbranch build breakages against other llvm versions too
-    BuilderType('x86', 64, 'linux', LLVM_OLD_BRANCH, testbranch=True),
-    BuilderType('x86', 64, 'linux', LLVM_TRUNK_BRANCH, testbranch=True),
-    BuilderType('x86', 64, 'linux', LLVM_TRUNK_BRANCH, cmake=False, testbranch=True),
-]
-for builder_type in _HALIDE_BUILDER_TYPES:
-    create_halide_builder(builder_type)
+create_halide_builders()
 
 c['schedulers'] = []
 for llvm_branch in _LLVM_BRANCHES:
     create_halide_scheduler(llvm_branch)
 
 # Create a scheduler to force a test of a branch
-builders = [str(b.name) for b in c['builders'] if 'testbranch' in b.name]
+builders = [str(b.name)
+            for b in c['builders'] if b.builder_type.purpose == Purpose.halide_testbranch]
 scheduler = schedulers.ForceScheduler(
     name='testbranch',
     builderNames=builders,


### PR DESCRIPTION
More changes that should be value-neutral, put in place to make functional-changes easier to review:

- Create the Halide builders algorithmically rather than from a giant list

- Change BuilderType.testbranch into an enum ("purpose") so that we can add more options (notable, llvm nightly builds)

NOTE TO REVIEWER: this is additive to #98 and #99; please review them first.