### PR TITLE
Don't force rebuilds of testbranches from LLVM changes

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1107,15 +1107,29 @@ def create_halide_builders():
 
 def create_halide_scheduler(llvm_branch):
 
+    # fields in 'change' for the ChangeFilters:
+    # - project: the project string, as defined by the ChangeSource.
+    # - repository: the repository in which this change occurred.
+    # - branch: the branch on which this change occurred. Note that ‘trunk’ or ‘master’ is often denoted by None.
+    # - category: the category, again as defined by the ChangeSource.
+    # - codebase: the change’s codebase.
+
     def master_only(change, llvm_branch):
-        if 'llvm' in change.repository:
+        if change.codebase == 'llvm':
             return change.branch == llvm_branch
         return change.branch == 'master' or change.branch is None
 
-    def not_master(change, llvm_branch):
-        if 'llvm' in change.repository:
-            return change.branch == llvm_branch
-        return not master_only(change, llvm_branch)
+    # For testbranch builds, never trigger on LLVM changes: trunk LLVM
+    # changes frequently , but breakages from trunk LLVM are pretty infrequent
+    # (we're better off letting the periodic rebuild-halide-trunk builds catch these failures.)
+    #
+    # It also dodges some UB in buildbot, as the docs explicitly say:
+    # 'The behavior of this scheduler is undefined, if treeStableTimer is set,
+    # and changes from multiple branches, repositories or codebases are accepted by the filter.'
+    def testbranch_only(change):
+        if change.codebase == 'llvm':
+            return False
+        return change.branch is not None and change.branch != 'master'
 
     # ----- main
     builders = [str(b.name) for b in c['builders']
@@ -1124,8 +1138,8 @@ def create_halide_scheduler(llvm_branch):
         scheduler = schedulers.SingleBranchScheduler(
             name='halide-' + to_name(llvm_branch),
             codebases=['halide', 'llvm'],
-            change_filter=util.ChangeFilter(filter_fn=partial(
-                master_only, llvm_branch=llvm_branch)),
+            change_filter=util.ChangeFilter(
+                filter_fn=partial(master_only, llvm_branch=llvm_branch)),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 
@@ -1145,8 +1159,7 @@ def create_halide_scheduler(llvm_branch):
         scheduler = schedulers.SingleBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
             codebases=['halide', 'llvm'],
-            change_filter=util.ChangeFilter(
-                filter_fn=partial(not_master, llvm_branch=llvm_branch)),
+            change_filter=util.ChangeFilter(filter_fn=testbranch_only),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 


### PR DESCRIPTION
We currently trigger rebuilds for PRs (testbranch) if the Halide source changes *or* if the LLVM source changes. This PR eliminates the latter (for testbranches only), as changes in LLVM rarely break PRs this way, but changes in LLVM happen frequently enough that this sucks up a lot of buildbot time. (There's also apparently some UB involved that we can dodge; whether or not this will improve reliability is not clear.)