### PR TITLE
Add hack to unbreak LLVM 10 under MSVC 16.7.x

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -343,6 +343,22 @@ def add_get_llvm_source_steps(factory, builder_type):
                         branch=builder_type.llvm_branch,
                         mode='incremental'))
 
+    # LLVM 10 is broken under MSVC 16.7.x as of October 2020.
+    # Until a fix is backported, use the same grotesque hack that MS itself
+    # is using for vcpkg: https://github.com/microsoft/vcpkg/pull/12884
+    if builder_type.llvm_branch == 'release/10.x' and builder_type.os == 'windows':
+        factory.addStep(ShellCommand(name='Patch LLVM 10',
+                                     locks=[performance_lock.access('counting')],
+                                     haltOnFailure=True,
+                                     workdir=get_llvm_source_path(),
+                                     command=[
+                                         'sed',
+                                         '-i',
+                                         "s/#ifdef HAVE_STD_IS_TRIVIALLY_COPYABLE/#if 0/g",
+                                         "llvm/include/llvm/Support/type_traits.h"
+                                     ]))
+
+
 # Determined by running `set` in cmd.exe before and after vcvarsall.bat
 # and diffing the output. It's likely that we don't need all of these
 # to make things work, but I haven't bothered to figure out what is irrelevant,


### PR DESCRIPTION
(testing this now, feel free to approve but don't merge yet)