### PR TITLE
Build LLVM nightlies on all workers

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -80,6 +80,18 @@ c['protocols'] = {'pb': {'port': 9990}}
 performance_lock = util.WorkerLock("performance_lock",
                                    maxCount=9999)
 
+# When building the LLVM nightlies, we can sync & build LLVM independently
+# from other work, but when we update the install directory, we need to ensure
+# we have an exclusive lock across the entire worker. (Since we have a small
+# number of LLVM versions, and since 'make install' doesn't take very long,
+# we could probably just get by with a single lock for *any* llvm install,
+# but this isn't much harder to do.)
+llvm_build_locks = {}
+for llvm_branch in _LLVM_BRANCHES:
+    llvm_build_locks[llvm_branch] = util.WorkerLock("llvm_install_lock_%s" % to_name(llvm_branch),
+                                                    maxCount=9999)
+
+
 # CHANGESOURCES
 
 # the 'change_source' setting tells the buildmaster how it should find out
@@ -174,7 +186,7 @@ from buildbot.process.properties import Interpolate
 class Purpose(Enum):
     halide_main = 1
     halide_testbranch = 2
-    # llvm = 3  # TODO: not yet, but soon
+    llvm_nightly = 3
 
 
 class BuilderType:
@@ -185,7 +197,7 @@ class BuilderType:
        - Halide 'target' in the form of arch-bits-os
        - LLVM branch to be used
        - CMake vs Make
-       - main-branch vs testbranch
+       - main-branch vs testbranch vs llvm-nightly
 
        It doesn't currently include any 'features' because we don't currently
        bake any in at build time.
@@ -235,16 +247,18 @@ class BuilderType:
         return '%s-%d-%s' % (self.arch, self.bits, self.os)
 
     def builder_label(self):
-        # This currently tries to (somewhat) mimic the existing label pattern,
-        # but is arbitrary. (If changed, manual purging of buildbot temporaries
-        # is appropriate)
-        s = self.halide_target()
+        if self.purpose == Purpose.llvm_nightly:
+            s = 'llvm-%s-%s' % (to_name(self.llvm_branch), self.halide_target())
+        else:
+            # This currently tries to (somewhat) mimic the existing label pattern,
+            # but is arbitrary. (If changed, manual purging of buildbot temporaries
+            # is appropriate)
+            s = self.halide_target()
+            if self.purpose == Purpose.halide_testbranch:
+                s += '-testbranch'
+            s += '-' + to_name(self.llvm_branch)
+            s += '-cmake' if self.cmake else '-make'
 
-        if self.purpose == Purpose.halide_testbranch:
-            s += '-testbranch'
-
-        s += '-' + to_name(self.llvm_branch)
-        s += '-cmake' if self.cmake else '-make'
         return s
 
     def builder_tags(self):
@@ -616,29 +630,30 @@ def add_llvm_steps(factory, builder_type, clean_rebuild):
     env = get_env(builder_type)
     build_dir = get_llvm_build_path()
     install_dir = get_llvm_install_path()
+    llvm_branch = builder_type.llvm_branch
+    llvm_name = to_name(llvm_branch)
 
     if clean_rebuild:
-        factory.addStep(RemoveDirectory(name="Remove LLVM Build Dir",
+        factory.addStep(RemoveDirectory(name="Remove LLVM %s Build Dir" % llvm_name,
                                         locks=[performance_lock.access('counting')],
                                         dir=build_dir,
                                         haltOnFailure=False))
-        factory.addStep(RemoveDirectory(name="Remove LLVM Install Dir",
+        factory.addStep(RemoveDirectory(name="Remove LLVM %s Install Dir" % llvm_name,
                                         locks=[performance_lock.access('counting')],
                                         dir=install_dir,
                                         haltOnFailure=False))
 
-    factory.addStep(MakeDirectory(name="Make LLVM Build Dir",
+    factory.addStep(MakeDirectory(name="Make LLVM %s Build Dir" % llvm_name,
                                   locks=[performance_lock.access('counting')],
                                   dir=build_dir,
                                   haltOnFailure=False))
-    factory.addStep(MakeDirectory(name="Make LLVM Install Dir",
+    factory.addStep(MakeDirectory(name="Make LLVM %s Install Dir" % llvm_name,
                                   locks=[performance_lock.access('counting')],
                                   dir=install_dir,
                                   haltOnFailure=False))
 
     factory.addStep(
-        CMake(name='Configure LLVM',
-              description='Configure LLVM',
+        CMake(name='Configure LLVM %s' % llvm_name,
               locks=[performance_lock.access('counting')],
               haltOnFailure=True,
               env=env,
@@ -649,13 +664,30 @@ def add_llvm_steps(factory, builder_type, clean_rebuild):
               options=get_cmake_options(builder_type)))
 
     factory.addStep(
-        ShellCommand(name='Build LLVM',
-                     description='Build LLVM',
+        ShellCommand(name='Build LLVM %s' % llvm_name,
                      locks=[performance_lock.access('counting')],
                      haltOnFailure=True,
                      workdir=build_dir,
                      env=env,
                      command=get_cmake_build_command(builder_type, build_dir, target='install')))
+
+    # Save the SHA of LLVM's head rev into ${INSTALL}/llvm_version.txt,
+    # just to make debugging simpler
+    #
+    # TODO: CMake insists on escaping '>' in weird and stupid ways, so this fails.
+    # Find some other way to do this.
+    #
+    # factory.addStep(
+    #     ShellCommand(name='Stamp Install Directory for LLVM %s' % llvm_name,
+    #                  locks=[performance_lock.access('counting')],
+    #                  haltOnFailure=True,
+    #                  workdir=get_llvm_source_path(),
+    #                  env=env,
+    #                  command=[
+    #                      'git rev-parse HEAD',
+    #                      '>',
+    #                      get_llvm_install_path('llvm_version.txt')
+    #                  ]))
 
 
 def add_halide_cmake_build_steps(factory, builder_type):
@@ -1070,6 +1102,11 @@ def create_halide_builder(arch, bits, os, llvm_branch, purpose, cmake=True):
                             workernames=workers,
                             factory=create_halide_factory(builder_type),
                             collapseRequests=True,
+                            # We need counting access to our llvm branch during Halide builds.
+                            # (We could probably get by with access during only a subset of
+                            # our steps, but there doesn't appear to be a way to group
+                            # lock requests across multiple-but-not-all-steps in a Build.)
+                            locks=[llvm_build_locks[llvm_branch].access('counting')],
                             tags=builder_type.builder_tags())
     builder.builder_type = builder_type
     return builder
@@ -1106,7 +1143,6 @@ def create_halide_builders():
 
 
 def create_halide_scheduler(llvm_branch):
-
     # fields in 'change' for the ChangeFilters:
     # - project: the project string, as defined by the ChangeSource.
     # - repository: the repository in which this change occurred.
@@ -1173,41 +1209,113 @@ def create_halide_scheduler(llvm_branch):
         c['schedulers'].append(scheduler)
 
 
+def create_llvm_cmake_factory(builder_type):
+    factory = BuildFactory()
+    get_msvc_config_steps(factory, builder_type)
+    add_get_llvm_source_steps(factory, builder_type)
+
+    clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
+    add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
+
+    return factory
+
+
+def create_llvm_builders():
+    for arch, bits, os in get_interesting_halide_targets():
+        # Note that we want these Builders to run on *every* eligible worker;
+        # the goal is to ensure that all LLVM builds are updated locally
+        # on all of the workers.
+        for llvm_branch in _LLVM_BRANCHES:
+            builder_type = BuilderType(arch, bits, os, llvm_branch, Purpose.llvm_nightly)
+            for w in builder_type.get_worker_names():
+                # Note that we need the builder name to be unique across workers,
+                # but we want the builddir on the *worker* side to be the same for all workers
+                # (to simplify things).
+                label = builder_type.builder_label()
+                builder = BuilderConfig(name="%s/%s" % (label, w),
+                                        workerbuilddir=label,
+                                        workernames=[w],
+                                        factory=create_llvm_cmake_factory(builder_type),
+                                        collapseRequests=True,
+                                        # We want exclusive access to this workerlock
+                                        # thru all this Builder's steps. (We could probably
+                                        # get by with holding it just during the install phase,
+                                        # but we'd have to finesse some details like removing
+                                        # the old install directory within the lock, and this
+                                        # is much simpler.)
+                                        locks=[llvm_build_locks[llvm_branch].access('exclusive')],
+                                        tags=builder_type.builder_tags())
+                builder.builder_type = builder_type
+                c['builders'].append(builder)
+
+
+def create_llvm_scheduler(llvm_branch):
+    builders = [str(b.name) for b in c['builders']
+                if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.llvm_nightly]
+    # Start every day at midnight Pacific; our buildbots use UTC for cron, so that's 8AM
+    scheduler = schedulers.Nightly(
+        name='llvm-nightly-' + to_name(llvm_branch),
+        codebases=['llvm'],
+        builderNames=builders,
+        hour=8, minute=0)
+
+    c['schedulers'].append(scheduler)
+
+    for b in builders:
+        scheduler = schedulers.ForceScheduler(
+            name='force-llvm-nightly-%s' % b.replace('/', '_'),
+            codebases=['llvm'],
+            builderNames=[b])
+
+        c['schedulers'].append(scheduler)
+
+
 c['builders'] = []
+create_llvm_builders()
 create_halide_builders()
 
 c['schedulers'] = []
 for llvm_branch in _LLVM_BRANCHES:
+    create_llvm_scheduler(llvm_branch)
     create_halide_scheduler(llvm_branch)
 
 # Set the builder priorities
 
 
-def prioritize_builders(master, builders):
+def prioritize_builders(buildmaster, builders):
     def importance(builder):
-        # Branch testers all need to come back before we can merge a PR,
-        # so they all have equal highest priority.
-        if 'testbranch' in builder.name:
+        builder_type = builder.config.builder_type
+        assert builder_type
+
+        # LLVM nightlies run only once a day (late at night) and should always
+        # get priority over everything else.
+        if builder_type.purpose == Purpose.llvm_nightly:
             return 0
+
+        # Branch testers all need to come back before we can merge a PR,
+        # so they all have equal next-highest priority.
+        if builder_type.purpose == Purpose.halide_testbranch:
+            return 1
 
         # non-branch testers are mostly used for bisecting failures that
         # didn't show up in the branch testers and doing binary
         # releases. We care most about the most recently-released llvm so
         # that we have a full set of builds for releases, then llvm trunk
         # for bisection, then older llvm versions.
-        if to_name(LLVM_RELEASE_BRANCH) in builder.name:
-            return 1
-        if to_name(LLVM_TRUNK_BRANCH) in builder.name:
+        if builder_type.llvm_branch == LLVM_RELEASE_BRANCH:
             return 2
-        if to_name(LLVM_OLD_BRANCH) in builder.name:
+        if builder_type.llvm_branch == LLVM_TRUNK_BRANCH:
             return 3
-        return 4
+        if builder_type.llvm_branch == LLVM_OLD_BRANCH:
+            return 4
+        return 5
 
     builders.sort(key=importance)
 
     print("prioritize_builders:")
     for b in builders:
-        print(("  PB: %s -> pri %d" % (b.name, importance(b))))
+        print("  PB: %s (%s) -> pri %d" %
+              (b.name, b.config.builder_type.builder_label(), importance(b)))
 
     return builders
 


### PR DESCRIPTION
This is part one of the effort to remove redundant LLVM rebuilds from the buildbots to save time and space.

This PR:

- Adds nightly tasks to build LLVM installs once per *worker*, starting at midnight PST. (As before, non-trunk builds are always incremental, trunk builds are always clean.)

- It adds WorkerLocks that should be appropriate to ensuring that no Halide build can be active if the LLVM insall it relies on is currently being (re)built.

- It does *not* yet change the logic to have Halide builds of any sort rely on the llvm nightlies; I wanted to get everything building reliably first, and also have people eyeball the WorkerLock setup to see if there are any obvious race conditions that I am overlooking.

If this looks good, I'll land it and move on to actually using the nightlies instead of doing redundant rebuilds.