### PR TITLE
Refactor the buildbots to use the LLVM nightlies instead of the per-builder LLVMs.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -788,8 +788,8 @@ def add_halide_cmake_package_steps(factory, builder_type):
     pkg_name = 'Halide-%s-%s.%s' % (version, target, ext)
 
     env = get_env(builder_type)
-    env['Clang_DIR'] = get_llvm_install_path(builder_type, , 'lib/cmake/clang')
-    env['LLVM_DIR'] = get_llvm_install_path(builder_type, , 'lib/cmake/llvm')
+    env['Clang_DIR'] = get_llvm_install_path(builder_type, 'lib/cmake/clang')
+    env['LLVM_DIR'] = get_llvm_install_path(builder_type, 'lib/cmake/llvm')
     env['Halide_VERSION'] = version
 
     if builder_type.os == 'windows':

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1131,10 +1131,6 @@ def get_interesting_halide_targets():
 def create_halide_builder(arch, bits, os, llvm_branch, purpose, cmake=True):
     builder_type = BuilderType(arch, bits, os, llvm_branch, purpose, cmake=cmake)
     workers = builder_type.get_worker_names()
-    # TODO: brutal hack, linuxbot2 doesn't have a lot of disk space,
-    # only allow main builds to go there
-    if 'linux-worker-2' in workers and builder_type.llvm_branch != LLVM_TRUNK_BRANCH:
-        workers.remove('linux-worker-2')
     builder = BuilderConfig(name=builder_type.builder_label(),
                             workernames=workers,
                             factory=create_halide_factory(builder_type),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1188,11 +1188,11 @@ def create_halide_scheduler(llvm_branch):
     # - codebase: the change’s codebase.
 
     def master_only(change, llvm_branch):
-        assert change.codebase == 'halide':
+        assert change.codebase == 'halide'
         return change.branch == 'master' or change.branch is None
 
     def testbranch_only(change):
-        assert change.codebase == 'halide':
+        assert change.codebase == 'halide'
         return change.branch is not None and change.branch != 'master'
 
     # ----- main

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -156,10 +156,8 @@ all_repositories = {
 
 def codebase_generator(chdict):
     repo = chdict['repository']
-    if repo in all_repositories:
-        return all_repositories[repo]
-    else:
-        return 'halide'
+    assert repo in all_repositories, "Codebase not found for chdict: " + str(chdict)
+    return all_repositories[repo]
 
 c['codebaseGenerator'] = codebase_generator
 
@@ -246,20 +244,25 @@ class BuilderType:
     def halide_target(self):
         return '%s-%d-%s' % (self.arch, self.bits, self.os)
 
+    def llvm_builder_label(self):
+        return 'llvm-%s-%s' % (to_name(self.llvm_branch), self.halide_target())
+
+    def halide_builder_label(self):
+        # This currently tries to (somewhat) mimic the existing label pattern,
+        # but is arbitrary. (If changed, manual purging of buildbot temporaries
+        # is appropriate)
+        s = self.halide_target()
+        if self.purpose == Purpose.halide_testbranch:
+            s += '-testbranch'
+        s += '-' + to_name(self.llvm_branch)
+        s += '-cmake' if self.cmake else '-make'
+        return s
+
     def builder_label(self):
         if self.purpose == Purpose.llvm_nightly:
-            s = 'llvm-%s-%s' % (to_name(self.llvm_branch), self.halide_target())
+            return self.llvm_builder_label()
         else:
-            # This currently tries to (somewhat) mimic the existing label pattern,
-            # but is arbitrary. (If changed, manual purging of buildbot temporaries
-            # is appropriate)
-            s = self.halide_target()
-            if self.purpose == Purpose.halide_testbranch:
-                s += '-testbranch'
-            s += '-' + to_name(self.llvm_branch)
-            s += '-cmake' if self.cmake else '-make'
-
-        return s
+            return self.halide_builder_label()
 
     def builder_tags(self):
         tags = self.builder_label().split('-')
@@ -317,17 +320,24 @@ class InterpolateAndFixSlashes(Interpolate):
 def get_builddir_subpath(subpath):
     return InterpolateAndFixSlashes('%(prop:builddir)s/' + subpath)
 
+# TODO: make private to the LLVM code
+
 
 def get_llvm_source_path(*subpaths):
     return get_builddir_subpath(os.path.join('llvm-project', *subpaths))
 
 
+# TODO: make private to the LLVM code
 def get_llvm_build_path(*subpaths):
     return get_builddir_subpath(os.path.join('llvm-build', *subpaths))
 
 
-def get_llvm_install_path(*subpaths):
-    return get_builddir_subpath(os.path.join('llvm-install', *subpaths))
+def get_llvm_install_path(builder_type, *subpaths):
+    # Note that `builder_type.purpose` can be a Halide builder or an LLVM builder;
+    # we want to ignore that aspect and produce the same effective path
+    # regardless (ie, based only on the other aspects of the builder_type).
+    llvm_workdir = builder_type.llvm_builder_label()
+    return get_builddir_subpath(os.path.join('..', llvm_workdir, 'llvm-install', *subpaths))
 
 
 def get_halide_source_path(*subpaths):
@@ -475,7 +485,9 @@ def get_msvc_config_steps(factory, builder_type):
 def get_distrib_name(props, version, target, ext):
     # Note that this property is a dict for multi-codebase builds,
     # but just a string for single-codebase builds.
-    rev = props.getProperty('got_revision')['halide']
+    rev = props.getProperty('got_revision')
+    assert type(rev) is not dict
+
     builder_label = props.getProperty('buildername')
 
     # Always upload to /home/abadams/artifacts -- regardless of user --
@@ -499,10 +511,10 @@ def get_cmake_options(builder_type):
 
 def get_halide_cmake_definitions(builder_type, halide_target='host'):
     cmake_definitions = {
-        'Clang_DIR': get_llvm_install_path('lib/cmake/clang'),
+        'Clang_DIR': get_llvm_install_path(builder_type, 'lib/cmake/clang'),
         'CMAKE_BUILD_TYPE': 'Release',
         'Halide_TARGET': halide_target,
-        'LLVM_DIR': get_llvm_install_path('lib/cmake/llvm'),
+        'LLVM_DIR': get_llvm_install_path(builder_type, 'lib/cmake/llvm'),
         'WITH_PYTHON_BINDINGS': 'ON' if builder_type.handles_python() else 'OFF'
     }
 
@@ -547,7 +559,7 @@ def get_cmake_build_command(builder_type, build_dir, target=None):
 def get_llvm_cmake_definitions(builder_type):
     definitions = {
         'CMAKE_BUILD_TYPE': 'Release',
-        'CMAKE_INSTALL_PREFIX': get_llvm_install_path(),
+        'CMAKE_INSTALL_PREFIX': get_llvm_install_path(builder_type),
         'LLVM_BUILD_32_BITS': ('ON' if builder_type.bits == 32 else 'OFF'),
         'LLVM_ENABLE_ASSERTIONS': 'ON',
         'LLVM_ENABLE_LIBXML2': 'OFF',
@@ -661,12 +673,9 @@ def get_build_parallelism(builder_type):
 def get_llvm_latest_commit(props):
     # Note that this property is a dict for multi-codebase builds,
     # but just a string for single-codebase builds.
-    bd = props.getProperty('builddir')
-    print("bd", bd)
-    if type(bd) is dict:
-        build_dir = bd['llvm']
-    else:
-        build_dir = bd
+    build_dir = props.getProperty('builddir')
+    assert type(build_dir) is not dict
+
     build_dir = build_dir.replace('\\', '/')
     # Can't use got_revision here since we may be using git directly.
     return "cd %s/llvm-project && git log -1 > %s/llvm-install/llvm_latest_commit.txt" % (build_dir, build_dir)
@@ -675,7 +684,7 @@ def get_llvm_latest_commit(props):
 def add_llvm_steps(factory, builder_type, clean_rebuild):
     env = get_env(builder_type)
     build_dir = get_llvm_build_path()
-    install_dir = get_llvm_install_path()
+    install_dir = get_llvm_install_path(builder_type)
     llvm_branch = builder_type.llvm_branch
     llvm_name = to_name(llvm_branch)
 
@@ -779,8 +788,8 @@ def add_halide_cmake_package_steps(factory, builder_type):
     pkg_name = 'Halide-%s-%s.%s' % (version, target, ext)
 
     env = get_env(builder_type)
-    env['Clang_DIR'] = get_llvm_install_path('lib/cmake/clang')
-    env['LLVM_DIR'] = get_llvm_install_path('lib/cmake/llvm')
+    env['Clang_DIR'] = get_llvm_install_path(builder_type, , 'lib/cmake/clang')
+    env['LLVM_DIR'] = get_llvm_install_path(builder_type, , 'lib/cmake/llvm')
     env['Halide_VERSION'] = version
 
     if builder_type.os == 'windows':
@@ -1010,7 +1019,7 @@ def create_halide_make_factory(builder_type):
     assert builder_type.os != 'windows'
 
     env = get_env(builder_type)
-    env['LLVM_CONFIG'] = get_llvm_build_path('bin/llvm-config')
+    env['LLVM_CONFIG'] = get_llvm_install_path(builder_type, 'bin/llvm-config')
 
     make_threads = get_build_parallelism(builder_type)
     build_dir = get_halide_build_path()
@@ -1021,10 +1030,6 @@ def create_halide_make_factory(builder_type):
     # since we never use Make with MSVC
 
     add_get_halide_source_steps(factory, builder_type)
-    add_get_llvm_source_steps(factory, builder_type)
-
-    clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
-    add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
 
     # Force a full rebuild of Halide every time
     factory.addStep(RemoveDirectory(name="Remove Halide Build Dir",
@@ -1092,15 +1097,8 @@ def create_halide_make_factory(builder_type):
 def create_halide_cmake_factory(builder_type):
     factory = BuildFactory()
     get_msvc_config_steps(factory, builder_type)
-
     add_get_halide_source_steps(factory, builder_type)
-    add_get_llvm_source_steps(factory, builder_type)
-
-    clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)
-    add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
-
     add_halide_cmake_build_steps(factory, builder_type)
-
     add_halide_cmake_test_steps(factory, builder_type)
 
     # If everything else looks ok, build a distrib.
@@ -1190,20 +1188,11 @@ def create_halide_scheduler(llvm_branch):
     # - codebase: the change’s codebase.
 
     def master_only(change, llvm_branch):
-        if change.codebase == 'llvm':
-            return change.branch == llvm_branch
+        assert change.codebase == 'halide':
         return change.branch == 'master' or change.branch is None
 
-    # For testbranch builds, never trigger on LLVM changes: trunk LLVM
-    # changes frequently , but breakages from trunk LLVM are pretty infrequent
-    # (we're better off letting the periodic rebuild-halide-trunk builds catch these failures.)
-    #
-    # It also dodges some UB in buildbot, as the docs explicitly say:
-    # 'The behavior of this scheduler is undefined, if treeStableTimer is set,
-    # and changes from multiple branches, repositories or codebases are accepted by the filter.'
     def testbranch_only(change):
-        if change.codebase == 'llvm':
-            return False
+        assert change.codebase == 'halide':
         return change.branch is not None and change.branch != 'master'
 
     # ----- main
@@ -1212,7 +1201,7 @@ def create_halide_scheduler(llvm_branch):
     if builders:
         scheduler = schedulers.SingleBranchScheduler(
             name='halide-' + to_name(llvm_branch),
-            codebases=['halide', 'llvm'],
+            codebases=['halide'],
             change_filter=util.ChangeFilter(
                 filter_fn=partial(master_only, llvm_branch=llvm_branch)),
             treeStableTimer=60 * 5,  # seconds
@@ -1223,7 +1212,7 @@ def create_halide_scheduler(llvm_branch):
         scheduler = schedulers.ForceScheduler(
             name='force-main-' + to_name(llvm_branch),
             builderNames=builders,
-            codebases=['halide', 'llvm'])
+            codebases=['halide'])
 
         c['schedulers'].append(scheduler)
 
@@ -1233,7 +1222,7 @@ def create_halide_scheduler(llvm_branch):
     if builders:
         scheduler = schedulers.SingleBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
-            codebases=['halide', 'llvm'],
+            codebases=['halide'],
             change_filter=util.ChangeFilter(filter_fn=testbranch_only),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
@@ -1243,7 +1232,7 @@ def create_halide_scheduler(llvm_branch):
         scheduler = schedulers.ForceScheduler(
             name='force-testbranch-' + to_name(llvm_branch),
             builderNames=builders,
-            codebases=['halide', 'llvm'])
+            codebases=['halide'])
 
         c['schedulers'].append(scheduler)
 
@@ -1270,7 +1259,7 @@ def create_llvm_builders():
                 # Note that we need the builder name to be unique across workers,
                 # but we want the builddir on the *worker* side to be the same for all workers
                 # (to simplify things).
-                label = builder_type.builder_label()
+                label = builder_type.llvm_builder_label()
                 builder = BuilderConfig(name="%s/%s" % (label, w),
                                         workerbuilddir=label,
                                         workernames=[w],


### PR DESCRIPTION
(Needs testing; offering for review to see if there are concerns.)