### PR TITLE
Don't test Makefile builds on arm linux

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1160,9 +1160,10 @@ def create_halide_builders():
         c['builders'].append(create_halide_builder(
             arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch))
 
-        if os != 'windows':
-            # Also test Makefiles where possible
-            # (TODO: maybe limit Makefile testing to just x86-64-linux?)
+        if arch == 'x86' and os in ['linux', 'osx']:
+            # Also test Makefiles on x86-linux & osx, to ensure they
+            # stay healthy. (Note: deliberately skip arm-linux, since they
+            # are the slowest bots.)
             c['builders'].append(create_halide_builder(
                 arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch, cmake=False))
 


### PR DESCRIPTION
They are slow and testing both cmake and make on the armbots is a waste of time. Restrict Makefile testing to x86-linux and osx instead.