### PR TITLE
Disable lens_blur_filter in some cases to stop false failures

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -992,6 +992,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
                 # And also on Linux due to inadequate GPU RAM
                 exclude_regex.append('interpolate')
                 exclude_regex.append('lens_blur')
+                exclude_regex.append('lens_blur_filter')
                 exclude_regex.append('unsharp')
 
             if builder_type.os == 'linux' or builder_type.bits == 32:


### PR DESCRIPTION
We have got to upgrade the GPUs in our test machines.