### PR TITLE
Update WASM testing on buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1091,7 +1091,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
                 exclude_regex.append('lens_blur_filter')
 
             if exclude_regex:
-                apps_test_cmd = apps_test_cmd + ' --exclude-regex "%s"' % ('|'.join(exclude_regex))
+                apps_test_cmd += [' --exclude-regex', '"%s"' % ('|'.join(exclude_regex))]
 
             factory.addStep(
                 ShellCommand(name='Test apps for Halide_TARGET=%s' % halide_target,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -236,7 +236,7 @@ class BuilderType:
     def handles_wasm(self):
         return (self.arch == 'x86'
                 and self.bits == 64
-                and self.os == 'linux'
+                and (self.os == 'linux' or self.os == 'osx')
                 and self.llvm_branch == LLVM_TRUNK_BRANCH)
 
     def has_nvidia(self):
@@ -902,11 +902,17 @@ def get_test_labels(builder_type):
         # Also test hexagon using the simulator
         targets['host-hvx'].extend(['correctness', 'generator', 'apps'])
 
-    if builder_type.handles_wasm():
+    # Note that the Linux bots will also 'handle' wasm, but we are going to test
+    # only on OSX for now as it's currently our fastest bot, and also tends to be
+    # less loaded than the Linux bots.
+    if builder_type.handles_wasm() and self.os == 'osx':
         # Test WASM usage (only on LLVM trunk)
-        # TODO: perhaps move this to the OSX buildbot as it is less heavily loaded
         targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
             ['internal', 'correctness', 'generator', 'error', 'warning'])
+        # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
+        # so only test Generator here
+        targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int-wasm_threads'].extend(
+            ['generator'])
 
     return targets
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1008,11 +1008,6 @@ def add_halide_cmake_test_steps(factory, builder_type):
                 exclude_regex.append('lens_blur')
                 exclude_regex.append('unsharp')
 
-            if builder_type.os == 'windows':
-                # TODO: disable lens_blur_filter on windows for now due to
-                # https://github.com/halide/Halide/issues/5552
-                exclude_regex.append('lens_blur_filter')
-
             if builder_type.os == 'linux' or builder_type.bits == 32:
                 # TODO: disable tutorial_lesson_12_using_the_gpu (both C++ and python) on
                 # linux and 32-bit
@@ -1084,6 +1079,20 @@ def add_halide_cmake_test_steps(factory, builder_type):
             # Note: do *not* run the apps/ tests in parallel; many of them expect
             # to make full use of all cores, and running in parallel will just slow
             # things down.
+            apps_test_cmd = ['ctest',
+                             '--build-config', 'Release',
+                             '--output-on-failure',
+                             '--label-exclude', 'slow_tests']
+
+            exclude_regex = []
+            if builder_type.os == 'windows':
+                # TODO: disable lens_blur_filter on windows for now due to
+                # https://github.com/halide/Halide/issues/5552
+                exclude_regex.append('lens_blur_filter')
+
+            if exclude_regex:
+                apps_test_cmd = apps_test_cmd + ' --exclude-regex "%s"' % ('|'.join(exclude_regex))
+
             factory.addStep(
                 ShellCommand(name='Test apps for Halide_TARGET=%s' % halide_target,
                              description='Test apps for Halide_TARGET=%s' % halide_target,
@@ -1091,10 +1100,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
                              workdir=apps_build_dir,
                              env=env,
                              timeout=3600,
-                             command=['ctest',
-                                      '--build-config', 'Release',
-                                      '--output-on-failure',
-                                      '--label-exclude', 'slow_tests']))
+                             command=apps_test_cmd))
 
 
 def create_halide_make_factory(builder_type):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -905,7 +905,7 @@ def get_test_labels(builder_type):
     # Note that the Linux bots will also 'handle' wasm, but we are going to test
     # only on OSX for now as it's currently our fastest bot, and also tends to be
     # less loaded than the Linux bots.
-    if builder_type.handles_wasm() and self.os == 'osx':
+    if builder_type.handles_wasm() and builder_type.os == 'osx':
         # Test WASM usage (only on LLVM trunk)
         targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
             ['internal', 'correctness', 'generator', 'error', 'warning'])


### PR DESCRIPTION
- Add some testing for `wasm_threads` (Generator only)
- Do wasm testing on the OSX bot, not the Linux bots