### PR TITLE
Update GitHubStatusPush usage

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1501,7 +1501,7 @@ c['db'] = {
 # GitHub Integration
 
 # Only testbranch builders need to be considered here
-builders = [str(b.name) for b in c['builders'] if and b.builder_type.purpose == Purpose.halide_testbranch]
+builders = [str(b.name) for b in c['builders'] if b.builder_type.purpose == Purpose.halide_testbranch]
 generator = reporters.BuildStartEndStatusGenerator(builders=builders,
                                                    start_formatter=reporter.MessageFormatter(subject = 'Build started.'),
                                                    end_formatter=reporter.MessageFormatter(subject = 'Build done.'))

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -11,11 +11,12 @@ from pathlib import Path
 from buildbot.changes.github import GitHubPullrequestPoller
 from buildbot.changes.gitpoller import GitPoller
 from buildbot.config import BuilderConfig
-from buildbot.plugins import reporters
 from buildbot.plugins import schedulers, util
 from buildbot.process.factory import BuildFactory
 from buildbot.process.properties import Interpolate
 from buildbot.process.properties import renderer
+from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
+from buildbot.reporters.github import GitHubStatusPush
 from buildbot.steps.cmake import CMake
 from buildbot.steps.master import MasterShellCommand
 from buildbot.steps.shell import SetPropertyFromCommand
@@ -1502,13 +1503,13 @@ c['db'] = {
 
 # Only testbranch builders need to be considered here
 builders = [str(b.name) for b in c['builders'] if b.builder_type.purpose == Purpose.halide_testbranch]
-generator = reporters.BuildStartEndStatusGenerator(builders=builders,
-                                                   start_formatter=reporter.MessageFormatter(subject = 'Build started.'),
-                                                   end_formatter=reporter.MessageFormatter(subject = 'Build done.'))
-gs = reporters.GitHubStatusPush(token=token,
-                                context=Interpolate("buildbot/%(prop:buildername)s"),
-                                generators=[generator],
-                                verbose=True)
+generator = BuildStartEndStatusGenerator(builders=builders,
+                                         start_formatter=reporter.MessageFormatter(subject = 'Build started.'),
+                                         end_formatter=reporter.MessageFormatter(subject = 'Build done.'))
+gs = GitHubStatusPush(token=token,
+                      context=Interpolate("buildbot/%(prop:buildername)s"),
+                      generators=[generator],
+                      verbose=True)
 c['services'] = [gs]
 
 # Disable sending usage data

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -17,6 +17,7 @@ from buildbot.process.properties import Interpolate
 from buildbot.process.properties import renderer
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.github import GitHubStatusPush
+from buildbot.reporters.message import MessageFormatter
 from buildbot.steps.cmake import CMake
 from buildbot.steps.master import MasterShellCommand
 from buildbot.steps.shell import SetPropertyFromCommand
@@ -1504,8 +1505,8 @@ c['db'] = {
 # Only testbranch builders need to be considered here
 builders = [str(b.name) for b in c['builders'] if b.builder_type.purpose == Purpose.halide_testbranch]
 generator = BuildStartEndStatusGenerator(builders=builders,
-                                         start_formatter=reporter.MessageFormatter(subject = 'Build started.'),
-                                         end_formatter=reporter.MessageFormatter(subject = 'Build done.'))
+                                         start_formatter=MessageFormatter(subject = 'Build started.'),
+                                         end_formatter=MessageFormatter(subject = 'Build done.'))
 gs = GitHubStatusPush(token=token,
                       context=Interpolate("buildbot/%(prop:buildername)s"),
                       generators=[generator],

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1500,13 +1500,15 @@ c['db'] = {
 
 # GitHub Integration
 
-builders = [str(b.name) for b in c['builders']]
+# Only testbranch builders need to be considered here
+builders = [str(b.name) for b in c['builders'] if and b.builder_type.purpose == Purpose.halide_testbranch]
+generator = reporters.BuildStartEndStatusGenerator(builders=builders,
+                                                   start_formatter=reporter.MessageFormatter(subject = 'Build started.'),
+                                                   end_formatter=reporter.MessageFormatter(subject = 'Build done.'))
 gs = reporters.GitHubStatusPush(token=token,
                                 context=Interpolate("buildbot/%(prop:buildername)s"),
-                                startDescription='Build started.',
-                                endDescription='Build done.',
-                                verbose=True,
-                                builders=builders)
+                                generators=[generator],
+                                verbose=True)
 c['services'] = [gs]
 
 # Disable sending usage data


### PR DESCRIPTION
- Update to use non-deprecated arguments to GitHubStatusPush per BB 2.10.0 release notes
- Skip non-testbranch builders since we never need them for GitHubStatusPush anyway

(Longer term maybe this should be replaced entirely with webhook usage)