### PR TITLE
Add new buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -66,8 +66,10 @@ c = BuildmasterConfig = {}
 password = Path('halide_bb_pass.txt').read_text().strip()
 
 _WORKERS = [
+    ('linux-worker-1', 8),
     ('linux-worker-2', 2),
     ('linux-worker-3', 2),
+    ('linux-worker-4', 8),
     ('mac-worker-1', 2),
     ('arm32-linux-worker-1', 1),
     ('arm32-linux-worker-2', 1),
@@ -1224,6 +1226,11 @@ def get_interesting_halide_targets():
 def create_halide_builder(arch, bits, os, llvm_branch, purpose, cmake=True):
     builder_type = BuilderType(arch, bits, os, llvm_branch, purpose, cmake=cmake)
     workers = builder_type.get_worker_names()
+    # TODO: don't use these two for Halide just yet (LLVM only)
+    if 'linux-worker-1' in workers:
+        workers.remove('linux-worker-1')
+    if 'linux-worker-4' in workers:
+        workers.remove('linux-worker-4')
     builder = BuilderConfig(name=builder_type.builder_label(),
                             workernames=workers,
                             factory=create_halide_factory(builder_type),


### PR DESCRIPTION
linux-1 and linux-4 are being configured; this adds them, but only for LLVM nightlies, so that halide testbranches aren't affected while I do some testing.