### PR TITLE
A bit of clean-up

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -95,8 +95,7 @@ c['protocols'] = {'pb': {'port': 9990}}
 
 # Compute-intensive build steps will grab this lock in reader
 # mode. The performance test will grab it in exclusive mode.
-performance_lock = util.WorkerLock("performance_lock",
-                                   maxCount=9999)
+performance_lock = util.WorkerLock("performance_lock", maxCount=9999)
 
 # When building the LLVM nightlies, we can sync & build LLVM independently
 # from other work, but when we update the install directory, we need to ensure
@@ -106,8 +105,7 @@ performance_lock = util.WorkerLock("performance_lock",
 # but this isn't much harder to do.)
 llvm_build_locks = {}
 for llvm_branch in _LLVM_BRANCHES:
-    llvm_build_locks[llvm_branch] = util.WorkerLock("llvm_install_lock_%s" % to_name(llvm_branch),
-                                                    maxCount=9999)
+    llvm_build_locks[llvm_branch] = util.WorkerLock("llvm_install_lock_%s" % to_name(llvm_branch), maxCount=9999)
 
 # CHANGESOURCES
 
@@ -298,7 +296,7 @@ class BuilderType:
         assert False
 
     def __str__(self):
-        return '%s' % (self.halide_target())
+        return self.halide_target()
 
 
 class InterpolateAndFixSlashes(Interpolate):
@@ -330,8 +328,6 @@ def get_builddir_subpath(subpath):
 
 
 # TODO: make private to the LLVM code
-
-
 def get_llvm_source_path(*subpaths):
     return get_builddir_subpath(os.path.join('llvm-project', *subpaths))
 
@@ -503,7 +499,7 @@ def get_distrib_name(props, version, target, ext):
     # Note that this property is a dict for multi-codebase builds,
     # but just a string for single-codebase builds.
     rd = props.getProperty('got_revision')
-    if type(rd) is dict:
+    if isinstance(rd, dict):
         rev = rd['halide']
     else:
         rev = rd
@@ -695,7 +691,7 @@ def get_llvm_latest_commit(props):
     # Note that this property is a dict for multi-codebase builds,
     # but just a string for single-codebase builds.
     build_dir = props.getProperty('builddir')
-    assert type(build_dir) is not dict
+    assert not isinstance(build_dir, dict)
 
     build_dir = build_dir.replace('\\', '/')
     # Can't use got_revision here since we may be using git directly.
@@ -1251,8 +1247,7 @@ def create_halide_builders():
 
         # Create the builders for Halide master against all llvm versions.
         for llvm_branch in _LLVM_BRANCHES:
-            yield create_halide_builder(
-                arch, bits, os, llvm_branch, Purpose.halide_main)
+            yield create_halide_builder(arch, bits, os, llvm_branch, Purpose.halide_main)
 
         # Create the builders for testing Halide branches (aka pull requests).
         # Mostly just test against the LLVM 'release' branch, for best turnaround.
@@ -1262,8 +1257,7 @@ def create_halide_builders():
             # Also test Makefiles on x86-linux & osx, to ensure they
             # stay healthy. (Note: deliberately skip arm-linux, since they
             # are the slowest bots.)
-            yield create_halide_builder(
-                arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch, cmake=False)
+            yield create_halide_builder(arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch, cmake=False)
 
     # Test against main llvm branch for pull requests, too (for at least one target)
     yield create_halide_builder('x86', 64, 'linux', LLVM_TRUNK_BRANCH, Purpose.halide_testbranch)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -3,7 +3,7 @@
 
 import os
 import re
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from enum import Enum
 from functools import partial
 from pathlib import Path
@@ -65,21 +65,24 @@ c = BuildmasterConfig = {}
 
 password = Path('halide_bb_pass.txt').read_text().strip()
 
+# Can use Python 3.7 dataclasses instead, if we choose to upgrade to that.
+WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'arch', 'bits', 'os'])
+
 _WORKERS = [
-    ('linux-worker-1', 4),
-    ('linux-worker-2', 2),
-    ('linux-worker-3', 2),
-    ('linux-worker-4', 4),
-    ('mac-worker-1', 2),
-    ('arm32-linux-worker-1', 1),
-    ('arm32-linux-worker-2', 1),
-    ('arm64-linux-worker-1', 1),
-    ('arm64-linux-worker-2', 1),
-    ('win-worker-1', 1),
-    ('win-worker-2', 1),
+    ('linux-worker-1', WorkerConfig(max_builds=4, arch='x86', bits=[32, 64], os='linux')),
+    ('linux-worker-2', WorkerConfig(max_builds=2, arch='x86', bits=[32, 64], os='linux')),
+    ('linux-worker-3', WorkerConfig(max_builds=2, arch='x86', bits=[32, 64], os='linux')),
+    ('linux-worker-4', WorkerConfig(max_builds=4, arch='x86', bits=[32, 64], os='linux')),
+    ('mac-worker-1', WorkerConfig(max_builds=2, arch='x86', bits=[64], os='osx')),
+    ('arm32-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[32], os='linux')),
+    ('arm32-linux-worker-2', WorkerConfig(max_builds=1, arch='arm', bits=[32], os='linux')),
+    ('arm64-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[64], os='linux')),
+    ('arm64-linux-worker-2', WorkerConfig(max_builds=1, arch='arm', bits=[64], os='linux')),
+    ('win-worker-1', WorkerConfig(max_builds=1, arch='x86', bits=[32, 64], os='windows')),
+    ('win-worker-2', WorkerConfig(max_builds=1, arch='x86', bits=[32, 64], os='windows')),
 ]
 
-c['workers'] = [Worker(n, password, max_builds=mb) for n, mb in _WORKERS]
+c['workers'] = [Worker(n, password, max_builds=cfg.max_builds) for n, cfg in _WORKERS]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers.
@@ -277,23 +280,8 @@ class BuilderType:
         return tags
 
     def get_worker_names(self):
-        if self.os == 'linux':
-            if self.arch == 'x86':
-                return [n for n, mb in _WORKERS if n.startswith('linux-worker')]
-
-            if self.arch == 'arm':
-                if self.bits == 32:
-                    return [n for n, mb in _WORKERS if n.startswith('arm32-linux-worker')]
-                else:
-                    return [n for n, mb in _WORKERS if n.startswith('arm64-linux-worker')]
-
-        if self.os == 'osx':
-            return [n for n, mb in _WORKERS if n.startswith('mac-worker')]
-
-        if self.os == 'windows':
-            return [n for n, mb in _WORKERS if n.startswith('win-worker')]
-
-        assert False
+        return [n for n, cfg in _WORKERS
+                if self.arch == cfg.arch and self.bits in cfg.bits and self.os == cfg.os]
 
     def __str__(self):
         return self.halide_target()

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -114,16 +114,8 @@ for llvm_branch in _LLVM_BRANCHES:
 # the 'change_source' setting tells the buildmaster how it should find out
 # about source code changes.  Here we point to the buildbot clone of halide.
 
-c['change_source'] = []
 
 token = Path('github_token.txt').read_text().strip()
-
-c['change_source'].append(GitPoller(
-    repourl='git://github.com/halide/Halide.git',
-    workdir='gitpoller-halide-workdir',
-    branch='master',
-    pollInterval=60 * 5,  # Check Halide master every five minutes
-    pollAtLaunch=True))
 
 
 def pr_filter(pr):
@@ -147,20 +139,29 @@ def pr_filter(pr):
     return result
 
 
-c['change_source'].append(GitHubPullrequestPoller(
-    owner='halide',
-    repo='Halide',
-    token=token,
-    pullrequest_filter=pr_filter,
-    pollInterval=60 * 5,  # Check Halide PRs every five minutes
-    pollAtLaunch=True))
+c['change_source'] = [
+    GitPoller(
+        repourl='git://github.com/halide/Halide.git',
+        workdir='gitpoller-halide-workdir',
+        branch='master',
+        pollInterval=60 * 5,  # Check Halide master every five minutes
+        pollAtLaunch=True),
 
-c['change_source'].append(GitPoller(
-    repourl='https://github.com/llvm/llvm-project.git',
-    workdir='gitpoller-llvm-workdir',
-    branch=LLVM_TRUNK_BRANCH,
-    pollInterval=60 * 60 * 24,  # Only check llvm once every 24 hours
-    pollAtLaunch=True))
+    GitHubPullrequestPoller(
+        owner='halide',
+        repo='Halide',
+        token=token,
+        pullrequest_filter=pr_filter,
+        pollInterval=60 * 5,  # Check Halide PRs every five minutes
+        pollAtLaunch=True),
+
+    GitPoller(
+        repourl='https://github.com/llvm/llvm-project.git',
+        workdir='gitpoller-llvm-workdir',
+        branch=LLVM_TRUNK_BRANCH,
+        pollInterval=60 * 60 * 24,  # Only check llvm once every 24 hours
+        pollAtLaunch=True)
+]
 
 # CODEBASES
 
@@ -1250,30 +1251,26 @@ def create_halide_builders():
 
         # Create the builders for Halide master against all llvm versions.
         for llvm_branch in _LLVM_BRANCHES:
-            c['builders'].append(create_halide_builder(
-                arch, bits, os, llvm_branch, Purpose.halide_main))
+            yield create_halide_builder(
+                arch, bits, os, llvm_branch, Purpose.halide_main)
 
         # Create the builders for testing Halide branches (aka pull requests).
         # Mostly just test against the LLVM 'release' branch, for best turnaround.
-        c['builders'].append(create_halide_builder(
-            arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch))
+        yield create_halide_builder(arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch)
 
         if arch == 'x86' and os in ['linux', 'osx']:
             # Also test Makefiles on x86-linux & osx, to ensure they
             # stay healthy. (Note: deliberately skip arm-linux, since they
             # are the slowest bots.)
-            c['builders'].append(create_halide_builder(
-                arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch, cmake=False))
+            yield create_halide_builder(
+                arch, bits, os, LLVM_RELEASE_BRANCH, Purpose.halide_testbranch, cmake=False)
 
     # Test against main llvm branch for pull requests, too (for at least one target)
-    c['builders'].append(create_halide_builder(
-        'x86', 64, 'linux', LLVM_TRUNK_BRANCH, Purpose.halide_testbranch))
-    c['builders'].append(create_halide_builder(
-        'x86', 64, 'linux', LLVM_TRUNK_BRANCH, Purpose.halide_testbranch, cmake=False))
+    yield create_halide_builder('x86', 64, 'linux', LLVM_TRUNK_BRANCH, Purpose.halide_testbranch)
+    yield create_halide_builder('x86', 64, 'linux', LLVM_TRUNK_BRANCH, Purpose.halide_testbranch, cmake=False)
 
     # Test against the 'old' llvm branch for pull requests, too (for at least one target)
-    c['builders'].append(create_halide_builder(
-        'x86', 64, 'linux', LLVM_OLD_BRANCH, Purpose.halide_testbranch))
+    yield create_halide_builder('x86', 64, 'linux', LLVM_OLD_BRANCH, Purpose.halide_testbranch)
 
 
 def create_halide_scheduler(llvm_branch):
@@ -1312,7 +1309,7 @@ def create_halide_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_main]
     if builders:
-        scheduler = schedulers.SingleBranchScheduler(
+        yield schedulers.SingleBranchScheduler(
             name='halide-' + to_name(llvm_branch),
             codebases=['halide'],
             change_filter=util.ChangeFilter(
@@ -1320,20 +1317,16 @@ def create_halide_scheduler(llvm_branch):
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 
-        c['schedulers'].append(scheduler)
-
-        scheduler = schedulers.ForceScheduler(
+        yield schedulers.ForceScheduler(
             name='force-main-' + to_name(llvm_branch),
             builderNames=builders,
             codebases=['halide'])
-
-        c['schedulers'].append(scheduler)
 
     # ----- testbranch
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_testbranch]
     if builders:
-        scheduler = schedulers.SingleBranchScheduler(
+        yield schedulers.SingleBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
             codebases=['halide'],
             change_filter=util.ChangeFilter(
@@ -1341,14 +1334,10 @@ def create_halide_scheduler(llvm_branch):
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 
-        c['schedulers'].append(scheduler)
-
-        scheduler = schedulers.ForceScheduler(
+        yield schedulers.ForceScheduler(
             name='force-testbranch-' + to_name(llvm_branch),
             builderNames=builders,
             codebases=['halide'])
-
-        c['schedulers'].append(scheduler)
 
 
 def create_llvm_cmake_factory(builder_type):
@@ -1388,38 +1377,39 @@ def create_llvm_builders():
                                         locks=[llvm_build_locks[llvm_branch].access('exclusive')],
                                         tags=builder_type.builder_tags())
                 builder.builder_type = builder_type
-                c['builders'].append(builder)
+                yield builder
 
 
 def create_llvm_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.llvm_nightly]
     # Start every day at midnight Pacific; our buildbots use UTC for cron, so that's 8AM
-    scheduler = schedulers.Nightly(
+    yield schedulers.Nightly(
         name='llvm-nightly-' + to_name(llvm_branch),
         codebases=['llvm'],
         builderNames=builders,
         hour=8, minute=0)
 
-    c['schedulers'].append(scheduler)
-
     for b in builders:
-        scheduler = schedulers.ForceScheduler(
+        yield schedulers.ForceScheduler(
             name='force-llvm-nightly-%s' % b.replace('/', '_'),
             codebases=['llvm'],
             builderNames=[b])
 
-        c['schedulers'].append(scheduler)
+
+def create_builders():
+    yield from create_llvm_builders()
+    yield from create_halide_builders()
 
 
-c['builders'] = []
-create_llvm_builders()
-create_halide_builders()
+def create_schedulers():
+    for llvm_branch in _LLVM_BRANCHES:
+        yield from create_llvm_scheduler(llvm_branch)
+        yield from create_halide_scheduler(llvm_branch)
 
-c['schedulers'] = []
-for llvm_branch in _LLVM_BRANCHES:
-    create_llvm_scheduler(llvm_branch)
-    create_halide_scheduler(llvm_branch)
+
+c['builders'] = list(create_builders())
+c['schedulers'] = list(create_schedulers())
 
 
 # Set the builder priorities


### PR DESCRIPTION
Here are a handful of clean-up changes that I pulled out from my holiday explorations into the code.

1. Making all of the `c['config_key']` entries write-once by using generators (ie. `yield`-ing builders and schedulers)
2. Associate arch/bits/os information with the workers to make `get_worker_names` simple. 
3. Removing line-breaks that aren't necessitated by line-length limits
4. Using `isinstance` instead of `type() ==` for type comparisons