### PR TITLE
Disable linuxbots 2 and 3

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -70,8 +70,9 @@ WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'arch', 'bits', 'os'])
 
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, arch='x86', bits=[32, 64], os='linux')),
-    ('linux-worker-2', WorkerConfig(max_builds=2, arch='x86', bits=[32, 64], os='linux')),
-    ('linux-worker-3', WorkerConfig(max_builds=2, arch='x86', bits=[32, 64], os='linux')),
+    # Disable linuxbot 2 and 3 for now, since they are *much* slower than 1 and 4
+    # ('linux-worker-2', WorkerConfig(max_builds=2, arch='x86', bits=[32, 64], os='linux')),
+    # ('linux-worker-3', WorkerConfig(max_builds=2, arch='x86', bits=[32, 64], os='linux')),
     ('linux-worker-4', WorkerConfig(max_builds=4, arch='x86', bits=[32, 64], os='linux')),
     ('mac-worker-1', WorkerConfig(max_builds=2, arch='x86', bits=[64], os='osx')),
     ('arm32-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[32], os='linux')),


### PR DESCRIPTION
Since the newlinuxbots (1 and 4) are ~2.5x as fast as the old ones, the old ones are now (to some extent) a liability in that things scheduled on them are now the bottlenecks. Let's try disabling them and see if throughput improves.