### PR TITLE
Use GitHub webhooks to receive changes

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -25,4 +25,5 @@ jobs:
           echo "$GITHUB_TOKEN" > github_token.txt
           cp github_token.txt buildbot_www_pass.txt
           cp github_token.txt halide_bb_pass.txt
+          cp github_token.txt webhook_token.txt
           buildbot checkconfig

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv/
 halide_bb_pass.txt
 github_token.txt
 buildbot_www_pass.txt
+webhook_token.txt
 http.log
 twistd.hostname
 twistd.log

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ a new master.
 3. Generate a secret to authenticate GitHub's webhook updates with the master. Call this `WEBHOOK_SECRET`.
 4. Choose a password for the `halidenightly` user to authenticate with the web interface. Call this `WWW_PASSWORD`.
 
-A convenient command for generating a secure secret is `ruby -rsecurerandom -e 'puts SecureRandom.hex(20)'`.
+A convenient command for generating a secure secret is `openssl rand -hex 20`.
 
 ## GitHub Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# Configuration for Halide buildbots
+# Python environment
 
-To get started:
-
-Install Python 3.6+, python3-pip, and python3-venv, then run:
+To get started setting up _either_ a worker or a master, install Python 3.6+, python3-pip, and python3-venv, then create
+a virtual environment and install our Python dependencies:
 
 ```console
 $ python3 -m venv venv
@@ -10,21 +9,91 @@ $ . venv/bin/activate
 $ pip install -r requirements.txt
 ```
 
-First, choose a buildbot password `$PASSWORD`. Then create and launch the build master:
+# Master configuration
+
+## Web server settings
+
+Using your production-quality web server of choice (Apache, Nginx, etc.), choose a URL at which to host the master. Call
+this `BUILDBOT_WWW`. Then, set up a reverse proxy for the buildbot webserver (on port 8012). For Apache, your
+configuration might look like:
+
+```
+ProxyPass /ws ws://localhost:8012/ws
+ProxyPassReverse /ws ws://localhost:8012/ws
+ProxyPass / http://localhost:8012/
+ProxyPassReverse / http://localhost:8012/
+
+SetEnvIf X-Url-Scheme https HTTPS=1
+ProxyPreserveHost On
+```
+
+Note that you will need to enable `proxy_wstunnel` for this to work (via `a2enmod`). It is essential that HTTPS only is
+used (to protect)
+
+**Close port 8012 to the internet.** If you can't have port 9990 open, redirect another port to it. Whichever port this
+is, call it `MASTER_PORT`.
+
+Make a note of your master's IP address. Call this `MASTER_ADDR`.
+
+## Secrets
+
+Four secrets control authentication with external users and servers. These will need to be determined before starting up
+a new master.
+
+1. Obtain a [GitHub personal access token](https://github.com/settings/tokens) with at least the `repo` scope enabled (
+   other scopes that are not currently used but might be later are `write:packages` and `delete:packages`). Call
+   this `GITHUB_TOKEN`.
+2. Generate a secret for the workers to authenticate with the master. Call this `WORKER_SECRET`.
+3. Generate a secret to authenticate GitHub's webhook updates with the master. Call this `WEBHOOK_SECRET`.
+4. Choose a password for the `halidenightly` user to authenticate with the web interface. Call this `WWW_PASSWORD`.
+
+A convenient command for generating a secure secret is `ruby -rsecurerandom -e 'puts SecureRandom.hex(20)'`.
+
+## GitHub Configuration
+
+Make your way to the Webhooks section of your repository settings. The url
+is `https://github.com/{owner}/{repo}/settings/hooks`. The following settings are the correct ones:
+
+1. **Payload URL:** `$BUILDBOT_WWW/change_hook/github`
+2. **Content type:** `application/json`
+3. **Secret:** `$WEBHOOK_SECRET`
+4. **SSL verification:** Select _Enable SSL verification_
+5. **Which events would you like to trigger this webhook?**
+   a. **Let me select individual events.**. Check _"Pull requests"_ and _"Pushes"_.
+
+## Starting the master
+
+First, write all the secrets to the corresponding files:
 
 ```console
-$ echo "$PASSWORD" > master/halide_bb_pass.txt
-$ echo "<github-api-token>" > master/github_token.txt
+$ echo "$GITHUB_TOKEN" > master/github_token.txt
+$ echo "$WORKER_SECRET" > master/halide_bb_pass.txt
+$ echo "$WEBHOOK_SECRET" > master/webhook_token.txt
+$ echo "$WWW_PASSWORD" > master/buildbot_www_pass.txt
+```
+
+Then, create a database for the master to save its work. This only needs to be done once.
+
+```console
 $ buildbot upgrade-master master
+```
+
+Finally, start the master!
+
+```console
 $ buildbot start master
 ```
 
-To launch a build worker:
+## Starting a worker
+
+The master recognizes workers by their reported names, eg. `linux-worker-4` or `win-worker-1`. To launch the buildbot
+daemon on the worker named `$WORKER_NAME`, run the following commands after setting up the Python environment as
+detailed above:
 
 ```console
-$ echo "$PASSWORD" > worker/halide_bb_pass.txt
-$ export HALIDE_BB_WORKER_NAME=<worker_name>  # required
-$ export HALIDE_BB_MASTER_ADDR=<master_ip>    # default = public Halide master
-$ export HALIDE_BB_MASTER_PORT=<master_port>  # default = 9990
+$ echo "$WORKER_SECRET" > worker/halide_bb_pass.txt
+$ export HALIDE_BB_WORKER_NAME=$WORKER_NAME  # required
+$ export HALIDE_BB_MASTER_ADDR=$MASTER_ADDR  # default = public Halide master
+$ export HALIDE_BB_MASTER_PORT=$MASTER_PORT  # default = 9990
 $ buildbot-worker start worker
 ```

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1448,7 +1448,7 @@ generator = BuildStartEndStatusGenerator(builders=[b.name for b in c['builders']
                                          end_formatter=MessageFormatterRenderable('Build done.'))
 
 gs = GitHubStatusPush(token=GITHUB_TOKEN,
-                      context=(Interpolate("buildbot/%(prop:buildername)s")),
+                      context=Interpolate("buildbot/%(prop:buildername)s"),
                       generators=[generator],
                       verbose=True)
 c['services'] = [gs]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1361,9 +1361,6 @@ c['prioritizeBuilders'] = prioritize_builders
 # GitHub pull request filter
 
 class SafeGitHubEventHandler(GitHubEventHandler):
-    def handle_push(self, payload, event):
-        return super().handle_push(payload, event)
-
     def handle_pull_request(self, payload, event):
         pr = payload['pull_request']
         try:

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1447,7 +1447,9 @@ c['db'] = {
 
 # GitHub Integration
 
-generator = BuildStartEndStatusGenerator(builders=[b.name for b in c['builders']],
+# Only testbranch builders need to be considered here
+builders = [str(b.name) for b in c['builders'] if b.builder_type.purpose == Purpose.halide_testbranch]
+generator = BuildStartEndStatusGenerator(builders=builders,
                                          start_formatter=MessageFormatterRenderable('Build started.'),
                                          end_formatter=MessageFormatterRenderable('Build done.'))
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1362,8 +1362,6 @@ c['prioritizeBuilders'] = prioritize_builders
 
 class SafeGitHubEventHandler(GitHubEventHandler):
     def handle_push(self, payload, event):
-        # Don't register changes that aren't to master or release/N.x
-        print(f"Got push: {payload}")
         return super().handle_push(payload, event)
 
     def handle_pull_request(self, payload, event):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1385,7 +1385,8 @@ class SafeGitHubEventHandler(GitHubEventHandler):
             print(f'SafeGitHubEventHandler: missing key "{e}"')
             return self.skip()
 
-    def skip(self):
+    @staticmethod
+    def skip():
         return [], 'git'
 
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -29,6 +29,19 @@ from buildbot.steps.worker import RemoveDirectory
 from buildbot.worker import Worker
 from buildbot.www.hooks.github import GitHubEventHandler
 
+# This is the dictionary that the buildmaster pays attention to. We also use
+# a shorter alias to save typing.
+c = BuildmasterConfig = {}
+
+# SECRETS
+
+GITHUB_TOKEN = Path('github_token.txt').read_text().strip()
+WORKER_SECRET = Path('halide_bb_pass.txt').read_text().strip()
+WEBHOOK_SECRET = Path('webhook_token.txt').read_text().strip()
+WWW_PASSWORD = Path('buildbot_www_pass.txt').read_text().strip()
+
+# LLVM
+
 # At any given time, we test (at least) 3 LLVM versions:
 # - the current trunk (changes daily)
 # - the most recent release (expected to be stable)
@@ -54,17 +67,7 @@ def to_name(llvm_branch):
     return '%d' % _TO_VERSION[llvm_branch]
 
 
-# This is the dictionary that the buildmaster pays attention to. We also use
-# a shorter alias to save typing.
-c = BuildmasterConfig = {}
-
-# BUILDWORKERS
-
-# The 'workers' list defines the set of recognized buildworkers. Each element is
-# a Worker object, specifying a unique worker name and password.  The same
-# worker name and password must be configured on the worker.
-
-password = Path('halide_bb_pass.txt').read_text().strip()
+# WORKERS
 
 # Can use Python 3.7 dataclasses instead, if we choose to upgrade to that.
 WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'arch', 'bits', 'os'])
@@ -84,15 +87,10 @@ _WORKERS = [
     ('win-worker-2', WorkerConfig(max_builds=1, arch='x86', bits=[32, 64], os='windows')),
 ]
 
-c['workers'] = [Worker(n, password, max_builds=cfg.max_builds) for n, cfg in _WORKERS]
-
-# 'protocols' contains information about protocols which master will use for
-# communicating with workers.
-# You must define at least 'port' option that workers could connect to your master
-# with this protocol.
-# 'port' must match the value configured into the buildworkers (with their
-# --master option)
-c['protocols'] = {'pb': {'port': 9990}}
+# The 'workers' list defines the set of recognized buildworkers. Each element is
+# a Worker object, specifying a unique worker name and password.  The same
+# worker name and password must be configured on the worker.
+c['workers'] = [Worker(n, WORKER_SECRET, max_builds=cfg.max_builds) for n, cfg in _WORKERS]
 
 # LOCKS
 
@@ -1392,8 +1390,10 @@ class SafeGitHubEventHandler(GitHubEventHandler):
 
 # WEB SERVER
 
-password = Path('buildbot_www_pass.txt').read_text().strip()
-secret = Path('webhook_token.txt').read_text().strip()
+# 'protocols' contains information about protocols which master will use for communicating with workers.
+# You must define at least 'port' option that workers could connect to your master with this protocol.
+# 'port' must match the value configured into the buildworkers (with their --master option)
+c['protocols'] = {'pb': {'port': 9990}}
 
 authz = util.Authz(
     allowRules=[util.ForceBuildEndpointMatcher(role="admins"),
@@ -1403,12 +1403,12 @@ authz = util.Authz(
     roleMatchers=[util.RolesFromUsername(roles=["admins"], usernames=["halidenightly"])])
 
 c['www'] = dict(
-    auth=util.UserPasswordAuth({'halidenightly': password}),
+    auth=util.UserPasswordAuth({'halidenightly': WWW_PASSWORD}),
     authz=authz,
     port=8012,
     change_hook_dialects={
         'github': {
-            'secret': secret,
+            'secret': WEBHOOK_SECRET,
             'codebase': 'halide',
             'skips': [],
             'class': SafeGitHubEventHandler,
@@ -1451,7 +1451,7 @@ generator = BuildStartEndStatusGenerator(builders=[b.name for b in c['builders']
 context = Interpolate("buildbot/%(prop:buildername)s")
 # context = Interpolate("buildbot-beta/%(prop:buildername)s")
 
-gs = GitHubStatusPush(token=Path('github_token.txt').read_text().strip(),
+gs = GitHubStatusPush(token=GITHUB_TOKEN,
                       context=context,
                       generators=[generator],
                       verbose=True)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1366,16 +1366,20 @@ class SafeGitHubEventHandler(GitHubEventHandler):
         try:
             # Skip anything with the 'skip_buildbots' label
             if any(label['name'] == 'skip_buildbots' for label in pr['labels']):
+                print("PR %s was skipped due to skip_buildbots" % str(pr['html_url']))
                 return self.skip()
 
             # Test anything (even external) that has 'halidebuildbots' as a reviewer.
             if any(r['login'] == 'halidebuildbots' for r in pr['requested_reviewers']):
+                print("PR %s was handled due halidebuildbots" % str(pr['html_url']))
                 return super().handle_pull_request(payload, event)
 
             # Skip external pull requests that originate from a fork, ie. not from a trusted collaborator.
             if pr['head']['repo']['full_name'] != 'halide/Halide':
+                print("PR %s was skipped due to being external:" % str(pr['head']['repo']['full_name']))
                 return self.skip()
 
+            print("PR %s is being handled normally" % str(pr['html_url']))
             return super().handle_pull_request(payload, event)
 
         except KeyError as e:

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -8,7 +8,6 @@ from collections import defaultdict, namedtuple
 from enum import Enum
 from pathlib import Path
 
-from buildbot.changes.github import GitHubPullrequestPoller
 from buildbot.changes.gitpoller import GitPoller
 from buildbot.config import BuilderConfig
 from buildbot.plugins import schedulers, util
@@ -1360,6 +1359,7 @@ def prioritize_builders(buildmaster, builders):
 
 c['prioritizeBuilders'] = prioritize_builders
 
+
 # GitHub pull request filter
 
 class SafeGitHubEventHandler(GitHubEventHandler):
@@ -1387,6 +1387,7 @@ class SafeGitHubEventHandler(GitHubEventHandler):
 
     def skip(self):
         return [], 'git'
+
 
 # WEB SERVER
 
@@ -1446,8 +1447,8 @@ generator = BuildStartEndStatusGenerator(builders=[b.name for b in c['builders']
                                          start_formatter=MessageFormatterRenderable('Build started.'),
                                          end_formatter=MessageFormatterRenderable('Build done.'))
 
-context=Interpolate("buildbot/%(prop:buildername)s")
-# context=Interpolate("buildbot-beta/%(prop:buildername)s")
+context = Interpolate("buildbot/%(prop:buildername)s")
+# context = Interpolate("buildbot-beta/%(prop:buildername)s")
 
 gs = GitHubStatusPush(token=Path('github_token.txt').read_text().strip(),
                       context=context,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -23,10 +23,12 @@ from buildbot.steps.master import MasterShellCommand
 from buildbot.steps.shell import SetPropertyFromCommand
 from buildbot.steps.shell import ShellCommand
 from buildbot.steps.source.git import Git
+from buildbot.steps.source.github import GitHub
 from buildbot.steps.transfer import FileUpload
 from buildbot.steps.worker import MakeDirectory
 from buildbot.steps.worker import RemoveDirectory
 from buildbot.worker import Worker
+from buildbot.www.hooks.github import GitHubEventHandler
 
 # At any given time, we test (at least) 3 LLVM versions:
 # - the current trunk (changes daily)
@@ -36,7 +38,7 @@ from buildbot.worker import Worker
 # the branches that correspond to these will rotate as new versions
 # are released, but the underlying test logic should not need changing
 
-LLVM_TRUNK_BRANCH = 'master'
+LLVM_TRUNK_BRANCH = 'main'
 LLVM_RELEASE_BRANCH = 'release/11.x'
 LLVM_OLD_BRANCH = 'release/10.x'
 
@@ -113,50 +115,10 @@ for llvm_branch in _LLVM_BRANCHES:
 
 # CHANGESOURCES
 
-# the 'change_source' setting tells the buildmaster how it should find out
-# about source code changes.  Here we point to the buildbot clone of halide.
-
-
-token = Path('github_token.txt').read_text().strip()
-
-
-def pr_filter(pr):
-    # Auto test anything in the halide master repo
-    # print("Considering PR: ", pr['title'], pr['html_url'])
-    # for (k, v) in pr.items():
-    #     print(k, v)
-    repo = pr['head']['repo']
-    result = repo is not None and repo['full_name'] == 'halide/Halide'
-    reviewers = pr['requested_reviewers']
-    if reviewers is not None:
-        for r in reviewers:
-            result = result or (r['login'] == 'halidebuildbots')
-    # Any PR labeled with 'skip_buildbots' should be skipped
-    labels = pr['labels']
-    if labels is not None:
-        for lbl in labels:
-            if lbl['name'] == 'skip_buildbots':
-                result = False
-    print("Testing PR : ", pr['title'], pr['html_url'], ' => ', result)
-    return result
-
+# Here we point the buildbot at third-party codebases, ie. dependencies
+# We use the GitHub mirror of LLVM, pointed at master (main).
 
 c['change_source'] = [
-    GitPoller(
-        repourl='git://github.com/halide/Halide.git',
-        workdir='gitpoller-halide-workdir',
-        branch='master',
-        pollInterval=60 * 5,  # Check Halide master every five minutes
-        pollAtLaunch=True),
-
-    GitHubPullrequestPoller(
-        owner='halide',
-        repo='Halide',
-        token=token,
-        pullrequest_filter=pr_filter,
-        pollInterval=60 * 5,  # Check Halide PRs every five minutes
-        pollAtLaunch=True),
-
     GitPoller(
         repourl='https://github.com/llvm/llvm-project.git',
         workdir='gitpoller-llvm-workdir',
@@ -347,13 +309,13 @@ def get_halide_install_path(*subpaths):
 
 
 def add_get_halide_source_steps(factory, builder_type):
-    factory.addStep(Git(name='Get Halide source',
-                        locks=[performance_lock.access('counting')],
-                        codebase='halide',
-                        workdir=get_halide_source_path(),
-                        repourl='git://github.com/halide/Halide.git',
-                        branch='master',
-                        mode='incremental'))
+    factory.addStep(GitHub(name='Get Halide source',
+                           locks=[performance_lock.access('counting')],
+                           codebase='halide',
+                           workdir=get_halide_source_path(),
+                           repourl='git://github.com/halide/Halide.git',
+                           branch='master',
+                           mode='incremental'))
 
 
 def add_get_llvm_source_steps(factory, builder_type):
@@ -1261,7 +1223,7 @@ def create_halide_scheduler(llvm_branch):
         yield schedulers.SingleBranchScheduler(
             name='halide-' + to_name(llvm_branch),
             codebases=['halide'],
-            change_filter=util.ChangeFilter(codebase='halide', branch='master'),
+            change_filter=util.ChangeFilter(category=None, codebase='halide', branch='master'),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 
@@ -1278,7 +1240,7 @@ def create_halide_scheduler(llvm_branch):
             name='halide-testbranch-' + to_name(llvm_branch),
             codebases=['halide'],
             # use negative lookahead to exclude master, but capture everything else
-            change_filter=util.ChangeFilter(codebase='halide', branch_re='^(?!master$).*$'),
+            change_filter=util.ChangeFilter(category='pull', codebase='halide', branch_re='^(?!master$).*$'),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 
@@ -1393,21 +1355,43 @@ def prioritize_builders(buildmaster, builders):
             return 4
         return 5
 
-    builders.sort(key=importance)
-
-    print("prioritize_builders:")
-    for b in builders:
-        print("  PB: %s (%s) -> pri %d" %
-              (b.name, b.config.builder_type.builder_label(), importance(b)))
-
-    return builders
+    return list(sorted(builders, key=importance))
 
 
 c['prioritizeBuilders'] = prioritize_builders
 
+# GitHub pull request filter
+
+class SafeGitHubEventHandler(GitHubEventHandler):
+    def handle_pull_request(self, payload, event):
+        pr = payload['pull_request']
+        try:
+            # Skip anything with the 'skip_buildbots' label
+            if any(label['name'] == 'skip_buildbots' for label in pr['labels']):
+                return self.skip()
+
+            # Test anything (even external) that has 'halidebuildbots' as a reviewer.
+            if any(r['login'] == 'halidebuildbots' for r in pr['requested_reviewers']):
+                return super().handle_pull_request(payload, event)
+
+            # Skip external PRs
+            if pr['head']['repo']['full_name'] != 'halide/Halide':
+                return self.skip()
+
+            return super().handle_pull_request(payload, event)
+
+        except KeyError as e:
+            print(f'SafeGitHubEventHandler: malformed payload: {payload}')
+            print(f'SafeGitHubEventHandler: missing key "{e}"')
+            return self.skip()
+
+    def skip(self):
+        return [], 'git'
+
 # WEB SERVER
 
 password = Path('buildbot_www_pass.txt').read_text().strip()
+secret = Path('webhook_token.txt').read_text().strip()
 
 authz = util.Authz(
     allowRules=[util.ForceBuildEndpointMatcher(role="admins"),
@@ -1420,6 +1404,14 @@ c['www'] = dict(
     auth=util.UserPasswordAuth({'halidenightly': password}),
     authz=authz,
     port=8012,
+    change_hook_dialects={
+        'github': {
+            'secret': secret,
+            'codebase': 'halide',
+            'skips': [],
+            'class': SafeGitHubEventHandler,
+        },
+    },
 )
 
 # PROJECT IDENTITY
@@ -1438,7 +1430,7 @@ c['titleURL'] = 'http://halide-lang.org'
 # without some help.
 
 c['buildbotURL'] = 'https://buildbot.halide-lang.org/master/'
-# c['buildbotURL'] = 'http://buildbot.alexreinking.com:8012/'
+# c['buildbotURL'] = 'https://buildbot.alexreinking.com/'
 
 # DB URL
 
@@ -1450,13 +1442,15 @@ c['db'] = {
 
 # GitHub Integration
 
-# Only testbranch builders need to be considered here
-builders = [str(b.name) for b in c['builders'] if b.builder_type.purpose == Purpose.halide_testbranch]
-generator = BuildStartEndStatusGenerator(builders=builders,
+generator = BuildStartEndStatusGenerator(builders=[b.name for b in c['builders']],
                                          start_formatter=MessageFormatterRenderable('Build started.'),
                                          end_formatter=MessageFormatterRenderable('Build done.'))
-gs = GitHubStatusPush(token=token,
-                      context=Interpolate("buildbot/%(prop:buildername)s"),
+
+context=Interpolate("buildbot/%(prop:buildername)s")
+# context=Interpolate("buildbot-beta/%(prop:buildername)s")
+
+gs = GitHubStatusPush(token=Path('github_token.txt').read_text().strip(),
+                      context=context,
                       generators=[generator],
                       verbose=True)
 c['services'] = [gs]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1361,6 +1361,11 @@ c['prioritizeBuilders'] = prioritize_builders
 # GitHub pull request filter
 
 class SafeGitHubEventHandler(GitHubEventHandler):
+    def handle_push(self, payload, event):
+        # Don't register changes that aren't to master or release/N.x
+        print(f"Got push: {payload}")
+        return super().handle_push(payload, event)
+
     def handle_pull_request(self, payload, event):
         pr = payload['pull_request']
         try:
@@ -1448,7 +1453,7 @@ c['db'] = {
 # GitHub Integration
 
 # Only testbranch builders need to be considered here
-builders = [str(b.name) for b in c['builders'] if b.builder_type.purpose == Purpose.halide_testbranch]
+builders = [str(b.name) for b in c['builders'] if b.builder_type.purpose != Purpose.llvm_nightly]
 generator = BuildStartEndStatusGenerator(builders=builders,
                                          start_formatter=MessageFormatterRenderable('Build started.'),
                                          end_formatter=MessageFormatterRenderable('Build done.'))

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1366,20 +1366,20 @@ class SafeGitHubEventHandler(GitHubEventHandler):
         try:
             # Skip anything with the 'skip_buildbots' label
             if any(label['name'] == 'skip_buildbots' for label in pr['labels']):
-                print("PR %s was skipped due to skip_buildbots" % str(pr['html_url']))
+                # print("PR %s was skipped due to skip_buildbots" % str(pr['html_url']))
                 return self.skip()
 
             # Test anything (even external) that has 'halidebuildbots' as a reviewer.
             if any(r['login'] == 'halidebuildbots' for r in pr['requested_reviewers']):
-                print("PR %s was handled due halidebuildbots" % str(pr['html_url']))
+                # print("PR %s was handled due halidebuildbots" % str(pr['html_url']))
                 return super().handle_pull_request(payload, event)
 
             # Skip external pull requests that originate from a fork, ie. not from a trusted collaborator.
             if pr['head']['repo']['full_name'] != 'halide/Halide':
-                print("PR %s was skipped due to being external:" % str(pr['head']['repo']['full_name']))
+                # print("PR %s was skipped due to being external:" % str(pr['head']['repo']['full_name']))
                 return self.skip()
 
-            print("PR %s is being handled normally" % str(pr['html_url']))
+            # print("PR %s is being handled normally" % str(pr['html_url']))
             return super().handle_pull_request(payload, event)
 
         except KeyError as e:

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -112,8 +112,8 @@ for llvm_branch in _LLVM_BRANCHES:
 
 # CHANGESOURCES
 
-# Here we point the buildbot at third-party codebases, ie. dependencies
-# We use the GitHub mirror of LLVM, pointed at master (main).
+# Here we point the buildbot at third-party codebases, ie. dependencies.
+# Currently, we only have LLVM's `main` (trunk) branch configured.
 
 c['change_source'] = [
     GitPoller(
@@ -1372,7 +1372,7 @@ class SafeGitHubEventHandler(GitHubEventHandler):
             if any(r['login'] == 'halidebuildbots' for r in pr['requested_reviewers']):
                 return super().handle_pull_request(payload, event)
 
-            # Skip external PRs
+            # Skip external pull requests that originate from a fork, ie. not from a trusted collaborator.
             if pr['head']['repo']['full_name'] != 'halide/Halide':
                 return self.skip()
 
@@ -1432,7 +1432,6 @@ c['titleURL'] = 'http://halide-lang.org'
 # without some help.
 
 c['buildbotURL'] = 'https://buildbot.halide-lang.org/master/'
-# c['buildbotURL'] = 'https://buildbot.alexreinking.com/'
 
 # DB URL
 
@@ -1448,11 +1447,8 @@ generator = BuildStartEndStatusGenerator(builders=[b.name for b in c['builders']
                                          start_formatter=MessageFormatterRenderable('Build started.'),
                                          end_formatter=MessageFormatterRenderable('Build done.'))
 
-context = Interpolate("buildbot/%(prop:buildername)s")
-# context = Interpolate("buildbot-beta/%(prop:buildername)s")
-
 gs = GitHubStatusPush(token=GITHUB_TOKEN,
-                      context=context,
+                      context=(Interpolate("buildbot/%(prop:buildername)s")),
                       generators=[generator],
                       verbose=True)
 c['services'] = [gs]


### PR DESCRIPTION
This makes the master respond to pushed events from GitHub itself, rather than polling the GitHub API every five minutes looking for changes. This has many upsides: 

1. GitHub won't fail to deliver a change the way the poller fails to notice changes.
2. The master will receive changes _immediately_, ie. improved latency.
3. Adding `halidebuildbots` as a reviewer should work now, so say goodbye to clone-PRs! _n.b. I still need to test this._
4. We now have a way of extending the buildbot to respond to _other_ events GitHub can report. For instance, we could maybe have the buildbot respond to magic comments to restart builds, rather than pushing to them.

The only downside is that we can miss changes if the master goes down. For PRs, this is no worse (just push to them), but for the `master` branch, this might be annoying (have to merge a PR).

Note that you will need to follow the updated directions in the README to set up the webhooks for the master. This is actually very easy.

---

A couple of riders: 

1. I put a bunch of documentation in the README for setting up the webhooks, but also for setting up a web server to host a second master (as I am currently doing to test these changes without seriously disrupting our workflow).
2. Change `LLVM_TRUNK_BRANCH` from `master` to `main`, because that's what it is now. For some time, `master` will mirror `main`, but it can lag behind by a few hours. The name `master` was supposed to have been removed outright on Jan 7. See: https://lists.llvm.org/pipermail/llvm-dev/2020-November/146615.html
3. Report status on _all_ builds, not just test-branch builds, so we can get status links on the main repository page and the commits list: see https://github.com/halide/Halide/commits/master