### PR TITLE
Improve robustness

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -22,7 +22,7 @@ from buildbot.schedulers.basic import SingleBranchScheduler, AnyBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.steps.cmake import CMake
-from buildbot.steps.master import MasterShellCommand, SetProperty
+from buildbot.steps.master import MasterShellCommand, SetProperties
 from buildbot.steps.shell import SetPropertyFromCommand, ShellCommand
 from buildbot.steps.source.git import Git
 from buildbot.steps.source.github import GitHub
@@ -574,6 +574,8 @@ def add_env_setup_step(factory, builder_type):
     factory.addStep(SetPropertiesFromEnv(name='Read worker environment',
                                          variables=['VCPKG_ROOT', 'LD_LIBRARY_PATH', 'HL_HEXAGON_TOOLS']))
 
+    vcpkg_root = Property('VCPKG_ROOT', default=None)
+
     if builder_type.handles_hexagon():
         # Environment variables for testing Hexagon DSP
         hexagon_remote_bin = get_halide_source_path('src', 'runtime', 'hexagon_remote', 'bin')
@@ -591,7 +593,8 @@ def add_env_setup_step(factory, builder_type):
         env['METAL_DEVICE_WRAPPER_TYPE'] = '1'
 
     if builder_type.os == 'windows':
-        env['VCPKG_ROOT'] = Property('VCPKG_ROOT', default='C:/vcpkg')
+        vcpkg_root = Property('VCPKG_ROOT', default='C:/vcpkg')
+        env['VCPKG_ROOT'] = vcpkg_root
 
         # Current NVidia drivers on our Windows buildbots can corrupt their own
         # cache, leading to many spurious failures. Disable the cache
@@ -601,9 +604,11 @@ def add_env_setup_step(factory, builder_type):
         # We don't ever want an Abort, Rerty, Ignore dialog in our tests
         env['HL_DISABLE_WINDOWS_ABORT_DIALOG'] = '1'
 
-    factory.addStep(SetProperty(name='Initialize environment',
-                                property='env',
-                                value=extend_property('env', **env)))
+    factory.addStep(SetProperties(
+        name='Initialize environment',
+        properties=dict(
+            env=extend_property('env', **env),
+            VCPKG_ROOT=vcpkg_root)))
 
 
 def get_build_parallelism(builder_type):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1362,6 +1362,14 @@ c['prioritizeBuilders'] = prioritize_builders
 # GitHub pull request filter
 
 class SafeGitHubEventHandler(GitHubEventHandler):
+    def handle_push(self, payload, event):
+        ref = payload['ref']
+        if re.match(r"^refs/(heads|tags)/(master|main|release/\d+\.x)$", ref):
+            return super().handle_push(payload, event)
+        else:
+            print(f'SafeGitHubEventHandler: ignoring push event for ref: {ref}')
+            return self.skip()
+
     def handle_pull_request(self, payload, event):
         pr = payload['pull_request']
         try:

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -475,7 +475,7 @@ def get_halide_cmake_definitions(builder_type, halide_target='host'):
     #     cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
 
     if builder_type.os == 'windows':
-        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = Interpolate('%(prop:VCPKG_ROOT)s/scripts/buildsystems/vcpkg.cmake')
+        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = '%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake'
 
     return cmake_definitions
 
@@ -591,7 +591,7 @@ def add_env_setup_step(factory, builder_type):
         env['METAL_DEVICE_WRAPPER_TYPE'] = '1'
 
     if builder_type.os == 'windows':
-        env['VCPKG_ROOT'] = Property('VCPKG_ROOT', default='C:/vcpkg')
+        env['VCPKG_ROOT'] = Transform(lambda x: x.replace('\\', '/'), Property('VCPKG_ROOT', default='C:/vcpkg'))
 
         # Current NVidia drivers on our Windows buildbots can corrupt their own
         # cache, leading to many spurious failures. Disable the cache

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -498,7 +498,7 @@ def get_halide_cmake_definitions(builder_type, halide_target='host'):
     #     cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
 
     if builder_type.os == 'windows':
-        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = r'C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
+        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = Interpolate('%(prop:VCPKG_ROOT)s/scripts/buildsystems/vcpkg.cmake')
 
     return cmake_definitions
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -475,7 +475,7 @@ def get_halide_cmake_definitions(builder_type, halide_target='host'):
     #     cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
 
     if builder_type.os == 'windows':
-        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = Interpolate('%(prop:VCPKG_ROOT)s/scripts/buildsystems/vcpkg.cmake')
+        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = '${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake'
 
     return cmake_definitions
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -12,15 +12,13 @@ from buildbot.changes.gitpoller import GitPoller
 from buildbot.config import BuilderConfig
 from buildbot.plugins import schedulers, util
 from buildbot.process.factory import BuildFactory
-from buildbot.process.properties import Interpolate, Property
-from buildbot.process.properties import renderer
+from buildbot.process.properties import Interpolate, Property, renderer
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.github import GitHubStatusPush
 from buildbot.reporters.message import MessageFormatterRenderable
 from buildbot.steps.cmake import CMake
-from buildbot.steps.master import MasterShellCommand
-from buildbot.steps.shell import SetPropertyFromCommand, SetProperty
-from buildbot.steps.shell import ShellCommand
+from buildbot.steps.master import MasterShellCommand, SetProperty
+from buildbot.steps.shell import SetPropertyFromCommand, ShellCommand
 from buildbot.steps.source.git import Git
 from buildbot.steps.source.github import GitHub
 from buildbot.steps.transfer import FileUpload

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -12,14 +12,14 @@ from buildbot.changes.gitpoller import GitPoller
 from buildbot.config import BuilderConfig
 from buildbot.plugins import schedulers, util
 from buildbot.process.factory import BuildFactory
-from buildbot.process.properties import Interpolate
+from buildbot.process.properties import Interpolate, Property
 from buildbot.process.properties import renderer
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.github import GitHubStatusPush
 from buildbot.reporters.message import MessageFormatterRenderable
 from buildbot.steps.cmake import CMake
 from buildbot.steps.master import MasterShellCommand
-from buildbot.steps.shell import SetPropertyFromCommand
+from buildbot.steps.shell import SetPropertyFromCommand, SetProperty
 from buildbot.steps.shell import ShellCommand
 from buildbot.steps.source.git import Git
 from buildbot.steps.source.github import GitHub
@@ -409,37 +409,34 @@ VCVARSALL_ENV_VARS = [
 
 
 def get_msvc_config_steps(factory, builder_type):
-    if builder_type.os == 'windows':
-        if builder_type.bits == 32:
-            vcvars_arch = ' x64_x86'  # ensure that we use the x64 host compiler, not the x86 host compiler
-        else:
-            vcvars_arch = ' x64'
-        vcvarsall = 'vcvarsall.bat %s && set' % vcvars_arch
+    # ensure that we use the x64 host compiler, not the x86 host compiler
+    arch_for_bits = {32: 'x64_x86', 64: 'x64'}
+    vcvarsall = 'vcvarsall.bat %s && set' % arch_for_bits[builder_type.bits]
 
-        # TODO: surely there is a better way of locating vcvarsall
-        vcvarsdir = "c:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build"
+    # TODO: surely there is a better way of locating vcvarsall
+    vcvarsdir = "c:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build"
 
-        # `vsvarsall && set` dumps all the settings to stdout;
-        # we'll extract & save just the subset we think are likely to be relevant.
-        def save_interesting_env_vars(rc, stdout, stderr):
-            d = {}
-            for line in stdout.split('\n'):
-                match = re.match("^([a-zA-Z0-9_-]+)=(.*)$", line.strip())
-                if match:
-                    key = match.group(1).upper()
-                    value = match.group(2)
-                    if key in VCVARSALL_ENV_VARS:
-                        d["_HALIDE_VCVAR_%s" % key] = value
-            return d
+    # `vsvarsall && set` dumps all the settings to stdout;
+    # we'll extract & save just the subset we think are likely to be relevant.
+    def save_interesting_env_vars(rc, stdout, stderr):
+        d = {}
+        for line in stdout.split('\n'):
+            match = re.match("^([a-zA-Z0-9_-]+)=(.*)$", line.strip())
+            if match:
+                key = match.group(1).upper()
+                value = match.group(2)
+                if key in VCVARSALL_ENV_VARS:
+                    d[key] = value
+        return {'env': d}
 
-        factory.addStep(
-            SetPropertyFromCommand(name='Run VcVarsAll',
-                                   description='Run VcVarsAll',
-                                   workdir=vcvarsdir,
-                                   locks=[performance_lock.access('counting')],
-                                   haltOnFailure=True,
-                                   command=vcvarsall,
-                                   extract_fn=save_interesting_env_vars))
+    factory.addStep(
+        SetPropertyFromCommand(name='Run VcVarsAll',
+                               description='Run VcVarsAll',
+                               workdir=vcvarsdir,
+                               locks=[performance_lock.access('counting')],
+                               haltOnFailure=True,
+                               command=vcvarsall,
+                               extract_fn=save_interesting_env_vars))
 
 
 @renderer
@@ -548,7 +545,21 @@ def get_llvm_cmake_definitions(builder_type):
     return definitions
 
 
-def get_env(builder_type):
+def extend_property(dict_name, **kwargs):
+    @util.renderer
+    def render(props):
+        table = props.getProperty(dict_name, default={})
+        table.extend(**kwargs)
+        return table
+
+    return render
+
+
+def add_env_setup_step(factory, builder_type):
+    if builder_type.os == 'windows':
+        # do this first because the SetPropertyFromCommand step isn't smart enough to merge
+        get_msvc_config_steps(factory, builder_type)
+
     cxx = 'c++'
     cc = 'cc'
     ld = 'ld'
@@ -608,12 +619,7 @@ def get_env(builder_type):
         # We don't ever want an Abort, Rerty, Ignore dialog in our tests
         env['HL_DISABLE_WINDOWS_ABORT_DIALOG'] = '1'
 
-        # Add all the env vars that we slurped from calling vcvarsall
-        # and stashed as properties
-        for key in VCVARSALL_ENV_VARS:
-            env[key] = Interpolate("%(prop:_HALIDE_VCVAR_" + key + ")s")
-
-    return env
+    factory.addStep(SetProperty(property='env', value=extend_property('env', **env)))
 
 
 def get_build_parallelism(builder_type):
@@ -649,7 +655,6 @@ def get_llvm_latest_commit(props):
 
 
 def add_llvm_steps(factory, builder_type, clean_rebuild):
-    env = get_env(builder_type)
     build_dir = get_llvm_build_path()
     install_dir = get_llvm_install_path(builder_type)
     llvm_branch = builder_type.llvm_branch
@@ -678,7 +683,7 @@ def add_llvm_steps(factory, builder_type, clean_rebuild):
         CMake(name='Configure LLVM %s' % llvm_name,
               locks=[performance_lock.access('counting')],
               haltOnFailure=True,
-              env=env,
+              env=Property('env'),
               workdir=build_dir,
               path=get_llvm_source_path('llvm'),
               generator=get_cmake_generator(builder_type),
@@ -690,7 +695,7 @@ def add_llvm_steps(factory, builder_type, clean_rebuild):
                      locks=[performance_lock.access('counting')],
                      haltOnFailure=True,
                      workdir=build_dir,
-                     env=env,
+                     env=Property('env'),
                      command=get_cmake_build_command(builder_type, build_dir, targets=['install'])))
 
     # Save the SHA of LLVM's head rev into ${INSTALL}/llvm_version.txt,
@@ -701,13 +706,11 @@ def add_llvm_steps(factory, builder_type, clean_rebuild):
                      locks=[performance_lock.access('counting')],
                      haltOnFailure=True,
                      workdir=get_llvm_source_path(),
-                     env=env,
+                     env=Property('env'),
                      command=get_llvm_latest_commit))
 
 
 def add_halide_cmake_build_steps(factory, builder_type):
-    env = get_env(builder_type)
-
     # Always do a clean build for Halide
     source_dir = get_halide_source_path()
     build_dir = get_halide_build_path()
@@ -735,7 +738,7 @@ def add_halide_cmake_build_steps(factory, builder_type):
                           locks=[performance_lock.access('counting')],
                           haltOnFailure=True,
                           workdir=build_dir,
-                          env=env,
+                          env=Property('env'),
                           path=source_dir,
                           generator=get_cmake_generator(builder_type),
                           definitions=get_halide_cmake_definitions(builder_type),
@@ -747,7 +750,7 @@ def add_halide_cmake_build_steps(factory, builder_type):
                      locks=[performance_lock.access('counting')],
                      haltOnFailure=True,
                      workdir=build_dir,
-                     env=env,
+                     env=Property('env'),
                      command=get_cmake_build_command(builder_type, build_dir, targets=['all', 'install'])))
 
 
@@ -764,10 +767,10 @@ def add_halide_cmake_package_steps(factory, builder_type):
     ext = 'zip' if builder_type.os == 'windows' else 'tar.gz'
     pkg_name = 'Halide-%s-%s.%s' % (version, target, ext)
 
-    env = get_env(builder_type)
-    env['Clang_DIR'] = get_llvm_install_path(builder_type, 'lib/cmake/clang')
-    env['LLVM_DIR'] = get_llvm_install_path(builder_type, 'lib/cmake/llvm')
-    env['Halide_VERSION'] = version
+    env = extend_property('env',
+                          Clang_DIR=get_llvm_install_path(builder_type, 'lib/cmake/clang'),
+                          LLVM_DIR=get_llvm_install_path(builder_type, 'lib/cmake/llvm'),
+                          Halide_VERSION=version)
 
     if builder_type.os == 'windows':
         # TODO: on Windows, we can't use Ninja for packaging (as we do everywhere
@@ -892,11 +895,10 @@ def add_halide_cmake_test_steps(factory, builder_type):
     keys.insert(0, 'host')
 
     for halide_target in keys:
-        env = get_env(builder_type)
         # HL_TARGET is now ignored by CMake builds, no need to set
         # (must specify -DHalide_TARGET to CMake instead)
         # env['HL_TARGET'] = halide_target
-        env['HL_JIT_TARGET'] = halide_target
+        env = extend_property('env', HL_JIT_TARGET=halide_target)
 
         factory.addStep(
             CMake(name='Reconfigure for Halide_TARGET=%s' % halide_target,
@@ -1060,13 +1062,11 @@ def add_halide_cmake_test_steps(factory, builder_type):
 def create_halide_make_factory(builder_type):
     assert builder_type.os != 'windows'
 
-    env = get_env(builder_type)
-    env['LLVM_CONFIG'] = get_llvm_install_path(builder_type, 'bin/llvm-config')
-
     make_threads = get_build_parallelism(builder_type)
     build_dir = get_halide_build_path()
 
     factory = BuildFactory()
+    add_env_setup_step(factory, builder_type)
 
     # It's never necessary to use get_msvc_config_steps() for Make,
     # since we never use Make with MSVC
@@ -1108,9 +1108,10 @@ def create_halide_make_factory(builder_type):
             targets.append((label, halide_target))
 
     for (target, halide_target) in targets:
-        target_env = env.copy()
-        target_env['HL_TARGET'] = halide_target
-        target_env['HL_JIT_TARGET'] = halide_target
+        env = extend_property('env',
+                              LLVM_CONFIG=get_llvm_install_path(builder_type, 'bin/llvm-config'),
+                              HL_TARGET=halide_target,
+                              HL_JIT_TARGET=halide_target)
 
         if is_time_critical_test(target):
             p = 1
@@ -1126,7 +1127,7 @@ def create_halide_make_factory(builder_type):
                                      description=target + ' ' + halide_target,
                                      locks=[performance_lock.access(lock_mode)],
                                      workdir=build_dir,
-                                     env=target_env,
+                                     env=env,
                                      haltOnFailure=False,
                                      command=['make',
                                               '-f', get_halide_source_path('Makefile'),
@@ -1138,7 +1139,7 @@ def create_halide_make_factory(builder_type):
 
 def create_halide_cmake_factory(builder_type):
     factory = BuildFactory()
-    get_msvc_config_steps(factory, builder_type)
+    add_env_setup_step(factory, builder_type)
     add_get_halide_source_steps(factory, builder_type)
     add_halide_cmake_build_steps(factory, builder_type)
     add_halide_cmake_test_steps(factory, builder_type)
@@ -1249,7 +1250,7 @@ def create_halide_scheduler(llvm_branch):
 
 def create_llvm_cmake_factory(builder_type):
     factory = BuildFactory()
-    get_msvc_config_steps(factory, builder_type)
+    add_env_setup_step(factory, builder_type)
     add_get_llvm_source_steps(factory, builder_type)
 
     clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_TRUNK_BRANCH)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -255,7 +255,7 @@ class BuilderType:
 
 def get_builddir_subpath(subpath):
     # Normalize paths to use forward slashes.
-    return Transform(lambda x: x.replace('\\', '/'), Interpolate('%(prop:builddir)s/{subpath}'))
+    return Transform(lambda x: x.replace('\\', '/'), Interpolate(f'%(prop:builddir)s/{subpath}'))
 
 
 # TODO: make private to the LLVM code

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -475,7 +475,7 @@ def get_halide_cmake_definitions(builder_type, halide_target='host'):
     #     cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
 
     if builder_type.os == 'windows':
-        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = '%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake'
+        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = Interpolate('%(prop:VCPKG_ROOT)s/scripts/buildsystems/vcpkg.cmake')
 
     return cmake_definitions
 
@@ -591,7 +591,7 @@ def add_env_setup_step(factory, builder_type):
         env['METAL_DEVICE_WRAPPER_TYPE'] = '1'
 
     if builder_type.os == 'windows':
-        env['VCPKG_ROOT'] = Transform(lambda x: x.replace('\\', '/'), Property('VCPKG_ROOT', default='C:/vcpkg'))
+        env['VCPKG_ROOT'] = Property('VCPKG_ROOT', default='C:/vcpkg')
 
         # Current NVidia drivers on our Windows buildbots can corrupt their own
         # cache, leading to many spurious failures. Disable the cache

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -14,7 +14,7 @@ from buildbot.changes.gitpoller import GitPoller
 from buildbot.config import BuilderConfig
 from buildbot.locks import WorkerLock
 from buildbot.process.factory import BuildFactory
-from buildbot.process.properties import Interpolate, Property, renderer
+from buildbot.process.properties import Interpolate, Property, renderer, Transform
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.github import GitHubStatusPush
 from buildbot.reporters.message import MessageFormatterRenderable
@@ -27,7 +27,7 @@ from buildbot.steps.shell import SetPropertyFromCommand, ShellCommand
 from buildbot.steps.source.git import Git
 from buildbot.steps.source.github import GitHub
 from buildbot.steps.transfer import FileUpload
-from buildbot.steps.worker import MakeDirectory
+from buildbot.steps.worker import MakeDirectory, SetPropertiesFromEnv
 from buildbot.steps.worker import RemoveDirectory
 from buildbot.worker import Worker
 from buildbot.www.auth import UserPasswordAuth
@@ -594,20 +594,22 @@ def add_env_setup_step(factory, builder_type):
         'LD': ld,
     }
 
+    factory.addStep(SetPropertiesFromEnv(name='Read worker environment',
+                                         variables=['VCPKG_ROOT', 'LD_LIBRARY_PATH', 'HL_HEXAGON_TOOLS']))
+
     if builder_type.handles_hexagon():
         # Environment variables for testing Hexagon DSP
         # Can't use get_halide_source_path() here because Interpolate doesn't work properly
-        hexagon_remote_bin = os.path.join('${PWD}/worker',
-                                          builder_type.builder_label(),
-                                          'halide-source/src/runtime/hexagon_remote/bin')
+        hexagon_remote_bin = get_halide_source_path('src', 'runtime', 'hexagon_remote', 'bin')
+
         # Assume that HL_HEXAGON_TOOLS points to the correct directory
         # (it might not be /usr/local/hexagon)
         # env['HL_HEXAGON_TOOLS'] = '/usr/local/hexagon'
-        env['HL_HEXAGON_SIM_REMOTE'] = os.path.join(hexagon_remote_bin, 'v62/hexagon_sim_remote')
+        env['HL_HEXAGON_SIM_REMOTE'] = Transform(os.path.join, hexagon_remote_bin, 'v62', 'hexagon_sim_remote')
         env['HL_HEXAGON_SIM_CYCLES'] = '1'
-        env['LD_LIBRARY_PATH'] = ':'.join(['${LD_LIBRARY_PATH}',
-                                           os.path.join(hexagon_remote_bin, 'host'),
-                                           '${HL_HEXAGON_TOOLS}/lib/iss'])
+        env['LD_LIBRARY_PATH'] = [Property('LD_LIBRARY_PATH'),
+                                  Transform(os.path.join, hexagon_remote_bin, 'host'),
+                                  Interpolate('%(prop:HL_HEXAGON_TOOLS)s/lib/iss')]
 
     if builder_type.os == 'osx':
         # Environment variable for turning on Metal API validation
@@ -615,7 +617,7 @@ def add_env_setup_step(factory, builder_type):
         env['METAL_DEVICE_WRAPPER_TYPE'] = '1'
 
     if builder_type.os == 'windows':
-        env['VCPKG_ROOT'] = 'C:/vcpkg'
+        env['VCPKG_ROOT'] = Property('VCPKG_ROOT', default='C:/vcpkg')
 
         # Current NVidia drivers on our Windows buildbots can corrupt their own
         # cache, leading to many spurious failures. Disable the cache

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -255,7 +255,7 @@ class BuilderType:
 
 def get_builddir_subpath(subpath):
     # Normalize paths to use forward slashes.
-    return Transform(lambda x: x.replace('\\', '/'), f'%(prop:builddir)s/{subpath}')
+    return Transform(lambda x: x.replace('\\', '/'), Interpolate('%(prop:builddir)s/{subpath}'))
 
 
 # TODO: make private to the LLVM code

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1223,6 +1223,7 @@ def create_halide_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_testbranch]
     if builders:
+        # NOT SingleBranchScheduler, because this can process changes from many branches (all PRs)
         yield AnyBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
             codebases=['halide'],

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -475,7 +475,7 @@ def get_halide_cmake_definitions(builder_type, halide_target='host'):
     #     cmake_definitions['Python3_ROOT_DIR'] = r'C:/Program Files (x86)/Python38-32'
 
     if builder_type.os == 'windows':
-        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = '${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake'
+        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = Interpolate('%(prop:VCPKG_ROOT)s/scripts/buildsystems/vcpkg.cmake')
 
     return cmake_definitions
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1207,7 +1207,7 @@ def create_halide_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_main]
     if builders:
-        yield SingleBranchScheduler(
+        yield AnyBranchScheduler(
             name='halide-' + to_name(llvm_branch),
             codebases=['halide'],
             change_filter=ChangeFilter(category=None, codebase='halide', branch='master'),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -625,7 +625,9 @@ def add_env_setup_step(factory, builder_type):
         # We don't ever want an Abort, Rerty, Ignore dialog in our tests
         env['HL_DISABLE_WINDOWS_ABORT_DIALOG'] = '1'
 
-    factory.addStep(SetProperty(property='env', value=extend_property('env', **env)))
+    factory.addStep(SetProperty(name='Initialize environment',
+                                property='env',
+                                value=extend_property('env', **env)))
 
 
 def get_build_parallelism(builder_type):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1232,7 +1232,7 @@ def create_halide_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_testbranch]
     if builders:
-        yield schedulers.SingleBranchScheduler(
+        yield schedulers.AnyBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
             codebases=['halide'],
             # use negative lookahead to exclude master, but capture everything else

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -253,32 +253,9 @@ class BuilderType:
         return self.halide_target()
 
 
-class InterpolateAndFixSlashes(Interpolate):
-    """Interpolate followed by replacing \\ with /
-    """
-
-    def __init__(self, fmtstring, *args, **kwargs):
-        Interpolate.__init__(self, fmtstring, *args, **kwargs)
-
-    def _sub(self, s):
-        return s.replace('\\', '/')
-
-    def getRenderingFor(self, props):
-        props = props.getProperties()
-        if self.args:
-            d = props.render(self.args)
-            d.addCallback(lambda args:
-                          self._sub(self.fmtstring % tuple(args)))
-            return d
-        else:
-            d = props.render(self.interpolations)
-            d.addCallback(lambda res:
-                          self._sub(self.fmtstring % res))
-            return d
-
-
 def get_builddir_subpath(subpath):
-    return InterpolateAndFixSlashes('%(prop:builddir)s/' + subpath)
+    # Normalize paths to use forward slashes.
+    return Transform(lambda x: x.replace('\\', '/'), f'%(prop:builddir)s/{subpath}')
 
 
 # TODO: make private to the LLVM code
@@ -599,12 +576,9 @@ def add_env_setup_step(factory, builder_type):
 
     if builder_type.handles_hexagon():
         # Environment variables for testing Hexagon DSP
-        # Can't use get_halide_source_path() here because Interpolate doesn't work properly
         hexagon_remote_bin = get_halide_source_path('src', 'runtime', 'hexagon_remote', 'bin')
 
-        # Assume that HL_HEXAGON_TOOLS points to the correct directory
-        # (it might not be /usr/local/hexagon)
-        # env['HL_HEXAGON_TOOLS'] = '/usr/local/hexagon'
+        # Assume that HL_HEXAGON_TOOLS points to the correct directory (it might not be /usr/local/hexagon)
         env['HL_HEXAGON_SIM_REMOTE'] = Transform(os.path.join, hexagon_remote_bin, 'v62', 'hexagon_sim_remote')
         env['HL_HEXAGON_SIM_CYCLES'] = '1'
         env['LD_LIBRARY_PATH'] = [Property('LD_LIBRARY_PATH'),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -547,7 +547,7 @@ def extend_property(dict_name, **kwargs):
     @util.renderer
     def render(props):
         table = props.getProperty(dict_name, default={})
-        table.extend(**kwargs)
+        table.update(kwargs)
         return table
 
     return render

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -8,14 +8,19 @@ from collections import defaultdict, namedtuple
 from enum import Enum
 from pathlib import Path
 
+import buildbot.www.authz.endpointmatchers as ems
+from buildbot.changes.filter import ChangeFilter
 from buildbot.changes.gitpoller import GitPoller
 from buildbot.config import BuilderConfig
-from buildbot.plugins import schedulers, util
+from buildbot.locks import WorkerLock
 from buildbot.process.factory import BuildFactory
 from buildbot.process.properties import Interpolate, Property, renderer
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.github import GitHubStatusPush
 from buildbot.reporters.message import MessageFormatterRenderable
+from buildbot.schedulers.basic import SingleBranchScheduler, AnyBranchScheduler
+from buildbot.schedulers.forcesched import ForceScheduler
+from buildbot.schedulers.timed import Nightly
 from buildbot.steps.cmake import CMake
 from buildbot.steps.master import MasterShellCommand, SetProperty
 from buildbot.steps.shell import SetPropertyFromCommand, ShellCommand
@@ -25,6 +30,9 @@ from buildbot.steps.transfer import FileUpload
 from buildbot.steps.worker import MakeDirectory
 from buildbot.steps.worker import RemoveDirectory
 from buildbot.worker import Worker
+from buildbot.www.auth import UserPasswordAuth
+from buildbot.www.authz import Authz
+from buildbot.www.authz.roles import RolesFromUsername
 from buildbot.www.hooks.github import GitHubEventHandler
 
 # This is the dictionary that the buildmaster pays attention to. We also use
@@ -96,7 +104,7 @@ c['workers'] = [Worker(n, WORKER_SECRET, max_builds=cfg.max_builds) for n, cfg i
 
 # Compute-intensive build steps will grab this lock in reader
 # mode. The performance test will grab it in exclusive mode.
-performance_lock = util.WorkerLock("performance_lock", maxCount=9999)
+performance_lock = WorkerLock("performance_lock", maxCount=9999)
 
 # When building the LLVM nightlies, we can sync & build LLVM independently
 # from other work, but when we update the install directory, we need to ensure
@@ -106,7 +114,7 @@ performance_lock = util.WorkerLock("performance_lock", maxCount=9999)
 # but this isn't much harder to do.)
 llvm_build_locks = {}
 for llvm_branch in _LLVM_BRANCHES:
-    llvm_build_locks[llvm_branch] = util.WorkerLock("llvm_install_lock_%s" % to_name(llvm_branch), maxCount=9999)
+    llvm_build_locks[llvm_branch] = WorkerLock("llvm_install_lock_%s" % to_name(llvm_branch), maxCount=9999)
 
 # CHANGESOURCES
 
@@ -544,7 +552,7 @@ def get_llvm_cmake_definitions(builder_type):
 
 
 def extend_property(dict_name, **kwargs):
-    @util.renderer
+    @renderer
     def render(props):
         table = props.getProperty(dict_name, default={})
         table.update(kwargs)
@@ -1216,14 +1224,14 @@ def create_halide_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_main]
     if builders:
-        yield schedulers.SingleBranchScheduler(
+        yield SingleBranchScheduler(
             name='halide-' + to_name(llvm_branch),
             codebases=['halide'],
-            change_filter=util.ChangeFilter(category=None, codebase='halide', branch='master'),
+            change_filter=ChangeFilter(category=None, codebase='halide', branch='master'),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 
-        yield schedulers.ForceScheduler(
+        yield ForceScheduler(
             name='force-main-' + to_name(llvm_branch),
             builderNames=builders,
             codebases=['halide'])
@@ -1232,15 +1240,15 @@ def create_halide_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.halide_testbranch]
     if builders:
-        yield schedulers.AnyBranchScheduler(
+        yield AnyBranchScheduler(
             name='halide-testbranch-' + to_name(llvm_branch),
             codebases=['halide'],
             # use negative lookahead to exclude master, but capture everything else
-            change_filter=util.ChangeFilter(category='pull', codebase='halide', branch_re='^(?!master$).*$'),
+            change_filter=ChangeFilter(category='pull', codebase='halide', branch_re='^(?!master$).*$'),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builders)
 
-        yield schedulers.ForceScheduler(
+        yield ForceScheduler(
             name='force-testbranch-' + to_name(llvm_branch),
             builderNames=builders,
             codebases=['halide'])
@@ -1290,16 +1298,16 @@ def create_llvm_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.llvm_nightly]
     # Start every day at midnight Pacific; our buildbots use UTC for cron, so that's 8AM
-    yield schedulers.Nightly(
+    yield Nightly(
         name='llvm-nightly-' + to_name(llvm_branch),
         codebases=['llvm'],
         builderNames=builders,
-        change_filter=util.ChangeFilter(codebase='llvm'),
+        change_filter=ChangeFilter(codebase='llvm'),
         hour=8,
         minute=0)
 
     for b in builders:
-        yield schedulers.ForceScheduler(
+        yield ForceScheduler(
             name='force-llvm-nightly-%s' % b.replace('/', '_'),
             codebases=['llvm'],
             builderNames=[b])
@@ -1406,15 +1414,15 @@ class SafeGitHubEventHandler(GitHubEventHandler):
 # 'port' must match the value configured into the buildworkers (with their --master option)
 c['protocols'] = {'pb': {'port': 9990}}
 
-authz = util.Authz(
-    allowRules=[util.ForceBuildEndpointMatcher(role="admins"),
-                util.StopBuildEndpointMatcher(role="admins"),
-                util.RebuildBuildEndpointMatcher(role="admins"),
-                util.EnableSchedulerEndpointMatcher(role="admins")],
-    roleMatchers=[util.RolesFromUsername(roles=["admins"], usernames=["halidenightly"])])
+authz = Authz(
+    allowRules=[ems.ForceBuildEndpointMatcher(role="admins"),
+                ems.StopBuildEndpointMatcher(role="admins"),
+                ems.RebuildBuildEndpointMatcher(role="admins"),
+                ems.EnableSchedulerEndpointMatcher(role="admins")],
+    roleMatchers=[RolesFromUsername(roles=["admins"], usernames=["halidenightly"])])
 
 c['www'] = dict(
-    auth=util.UserPasswordAuth({'halidenightly': WWW_PASSWORD}),
+    auth=UserPasswordAuth({'halidenightly': WWW_PASSWORD}),
     authz=authz,
     port=8012,
     change_hook_dialects={


### PR DESCRIPTION
I started trying to make changes to create and activate Python virtual environments as part of the builds, but I discovered a few things while reading the docs I want to get merged first.

1. Related to the virtualenv goal, we now store environment variables in a dictionary property named `env`. Rather than having dozens of `_HALIDE_VCVAR` properties, they're just all wrapped up together into this one. This will be useful for doing the same environment capturing / merging for virtualenv. You can see what that looks like here: https://buildbot.alexreinking.com/#/builders/47/builds/1
2. Using `SingleBranchScheduler` with a change filter that can accept multiple different branches (like our testbranch scheduler) is _documented as undefined behavior_! I'm sure this is responsible for tons of the flaking we've seen. Replacing it with `AnyBranchScheduler` ought to fix it.
3. Drop `push` events that will never get built (ie. those that are not to `master` or `release/N.x`) so they don't even appear in the web interface as a detected change.
---
The changes to the hexagon environment variables will need testing, but I can confirm a similar process works for VCPKG_ROOT on my master / worker-desktop.