### PR TITLE
Activate EMSDK just for steps that need it

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -944,7 +944,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
         # wasm targets must ensure that the EMSDK (emcc, etc) are added to the
         # active env.
         if halide_target.startswith("wasm-"):
-            env = merge_renderable(env, Property('emsdk_env'))
+            env = merge_renderable(env, Property('emsdk_env', default={}))
 
         factory.addStep(
             CMake(name='Reconfigure for Halide_TARGET=%s' % halide_target,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -206,9 +206,12 @@ class BuilderType:
                 and self.llvm_branch == LLVM_TRUNK_BRANCH)
 
     def handles_wasm(self):
+        # Note that the Linux bots will also 'handle' wasm, but we are going to test
+        # only on OSX for now as it's currently our fastest bot, and also tends to be
+        # less loaded than the Linux bots.
         return (self.arch == 'x86'
                 and self.bits == 64
-                and (self.os == 'linux' or self.os == 'osx')
+                and self.os == 'osx'
                 and self.llvm_branch == LLVM_TRUNK_BRANCH)
 
     def has_nvidia(self):
@@ -422,6 +425,50 @@ def get_msvc_config_steps(factory, builder_type):
                                extract_fn=save_interesting_env_vars))
 
 
+EMSDK_ENV_VARS = [
+    "EM_CACHE",
+    "EM_CONFIG",
+    "EMSDK",
+    "EMSDK_NODE",
+    "EMSDK_PYTHON",
+    "PATH",
+]
+
+def get_emsdk_config_steps(factory, builder_type):
+    if not builder_type.handles_wasm():
+        print("WARNING: should not call get_emsdk_config_steps() for builds that cannot handle WASM")
+        return
+
+    def save_interesting_env_vars(rc, stdout, stderr):
+        d = {}
+        for line in stdout.split('\n'):
+            match = re.match("^([a-zA-Z0-9_-]+) = (.*)$", line.strip())
+            if match:
+                key = match.group(1).upper()
+                value = match.group(2)
+                if key in [EMSDK_ENV_VARS]:
+                    d[key] = value
+        print("emsdk env: ", d)
+        return {'emsdk_env': d}
+
+    factory.addStep(
+        SetPropertyFromCommand(name='Run emsdk_env',
+                               description='Run emsdk_env',
+                               locks=[performance_lock.access('counting')],
+                               haltOnFailure=True,
+                               env=Property('env'),
+                               command="source ${EMSDK}/emsdk_env.sh",
+                               extract_fn=save_interesting_env_vars))
+
+def extend_with_emsdk_config(env):
+    @renderer
+    def render(props):
+        emsdk_env = props.getProperty('emsdk_env', default={})
+        env.update(emsdk_env)
+        return env
+
+    return render
+
 @renderer
 def get_distrib_name(props, version, target, ext):
     # Note that this property is a dict for multi-codebase builds,
@@ -542,6 +589,10 @@ def add_env_setup_step(factory, builder_type):
     if builder_type.os == 'windows':
         # do this first because the SetPropertyFromCommand step isn't smart enough to merge
         get_msvc_config_steps(factory, builder_type)
+
+    # Snag the env vars for the EMSDK. (Note that these are saved in 'emsdk_env' rather than 'env').
+    if builder_type.handles_wasm():
+        get_emsdk_config_steps(factory, builder_type)
 
     cxx = 'c++'
     cc = 'cc'
@@ -845,11 +896,7 @@ def get_test_labels(builder_type):
         # Also test hexagon using the simulator
         targets['host-hvx'].extend(['correctness', 'generator', 'apps'])
 
-    # Note that the Linux bots will also 'handle' wasm, but we are going to test
-    # only on OSX for now as it's currently our fastest bot, and also tends to be
-    # less loaded than the Linux bots.
-    if builder_type.handles_wasm() and builder_type.os == 'osx':
-        # Test WASM usage (only on LLVM trunk)
+    if builder_type.handles_wasm():
         targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
             ['internal', 'correctness', 'generator', 'error', 'warning'])
         # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
@@ -888,6 +935,11 @@ def add_halide_cmake_test_steps(factory, builder_type):
         # (must specify -DHalide_TARGET to CMake instead)
         # env['HL_TARGET'] = halide_target
         env = extend_property('env', HL_JIT_TARGET=halide_target)
+
+        # wasm targets must ensure that the EMSDK (emcc, etc) are added to the
+        # active env.
+        if halide_target.startswith("wasm-"):
+            env = extend_with_emsdk_config(env)
 
         factory.addStep(
             CMake(name='Reconfigure for Halide_TARGET=%s' % halide_target,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1252,6 +1252,10 @@ def create_halide_builders():
     yield create_halide_builder('x86', 64, 'linux', LLVM_TRUNK_BRANCH, Purpose.halide_testbranch)
     yield create_halide_builder('x86', 64, 'linux', LLVM_TRUNK_BRANCH, Purpose.halide_testbranch, cmake=False)
 
+    # Be sure to schedule one testbranch for osx-on-trunk as well, since that's the only place
+    # we currently test WASM
+    yield create_halide_builder('x86', 64, 'osx', LLVM_TRUNK_BRANCH, Purpose.halide_testbranch)
+
     # Test against the 'old' llvm branch for pull requests, too (for at least one target)
     yield create_halide_builder('x86', 64, 'linux', LLVM_OLD_BRANCH, Purpose.halide_testbranch)
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -446,7 +446,7 @@ def get_emsdk_config_steps(factory, builder_type):
             if match:
                 key = match.group(1).upper()
                 value = match.group(2)
-                if key in [EMSDK_ENV_VARS]:
+                if key in EMSDK_ENV_VARS:
                     d[key] = value
         print("emsdk env: ", d)
         return {'emsdk_env': d}
@@ -460,12 +460,14 @@ def get_emsdk_config_steps(factory, builder_type):
                                command="source ${EMSDK}/emsdk_env.sh",
                                extract_fn=save_interesting_env_vars))
 
-def extend_with_emsdk_config(env):
+def merge_renderable(base, extn):
     @renderer
+    @defer.inlineCallbacks
     def render(props):
-        emsdk_env = props.getProperty('emsdk_env', default={})
-        env.update(emsdk_env)
-        return env
+        base = yield props.render(base)
+        extn = yield props.render(extn)
+        base.update(extn)
+        return base
 
     return render
 
@@ -939,7 +941,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
         # wasm targets must ensure that the EMSDK (emcc, etc) are added to the
         # active env.
         if halide_target.startswith("wasm-"):
-            env = extend_with_emsdk_config(env)
+            env = merge_renderable(env, Property('emsdk_env'))
 
         factory.addStep(
             CMake(name='Reconfigure for Halide_TARGET=%s' % halide_target,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -34,6 +34,7 @@ from buildbot.www.auth import UserPasswordAuth
 from buildbot.www.authz import Authz
 from buildbot.www.authz.roles import RolesFromUsername
 from buildbot.www.hooks.github import GitHubEventHandler
+from twisted.internet import defer
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -902,12 +902,18 @@ def get_test_labels(builder_type):
         targets['host-hvx'].extend(['correctness', 'generator', 'apps'])
 
     if builder_type.handles_wasm():
+        # targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
+        #     ['internal', 'correctness', 'generator', 'error', 'warning'])
+        # # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
+        # # so only test Generator here
+        # targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int-wasm_threads'].extend(
+        #     ['generator'])
+
+        # TODO: As ofJan 22 2021, top-of-tree LLVM 12 and emcc (2.0.12) disagree about the valid formats
+        # of wasm object files, with the result that trying to aot-link crashes (!) emcc. Disabling
+        # the generator targets temporarily until they can sort out their disagreement.
         targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
-            ['internal', 'correctness', 'generator', 'error', 'warning'])
-        # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
-        # so only test Generator here
-        targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int-wasm_threads'].extend(
-            ['generator'])
+            ['internal', 'correctness', 'error', 'warning'])
 
     return targets
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -438,6 +438,7 @@ EMSDK_ENV_VARS = [
     "PATH",
 ]
 
+
 def get_emsdk_config_steps(factory, builder_type):
     if not builder_type.handles_wasm():
         print("WARNING: should not call get_emsdk_config_steps() for builds that cannot handle WASM")
@@ -464,16 +465,18 @@ def get_emsdk_config_steps(factory, builder_type):
                                command="source ${EMSDK}/emsdk_env.sh",
                                extract_fn=save_interesting_env_vars))
 
+
 def merge_renderable(base, extn):
     @renderer
     @defer.inlineCallbacks
     def render(props):
-        base = yield props.render(base)
-        extn = yield props.render(extn)
-        base.update(extn)
-        return base
+        base_r = yield props.render(base)
+        extn_r = yield props.render(extn)
+        base_r.update(extn_r)
+        return base_r
 
     return render
+
 
 @renderer
 def get_distrib_name(props, version, target, ext):


### PR DESCRIPTION
Currently we assume that the EMSDK is ~always active on the buildbots that need it for building/testing WASM code. This is suboptimal because (among other things) it activates a different Python version, because of course it does.

This instead tries to capture the necessary env var settings, and activates them only for the tests that need them. (If this lands, the OSX buildbot should be reconfigured to no longer activate emsdk by default.)

`extend_with_emsdk_config()` is the part here I'm unsure about.