### PR TITLE
macOS ccache

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ Finally, start the master!
 $ buildbot start master
 ```
 
+# Worker configuration
+
+## Worker dependencies
+
+(TODO: flesh this out)
+
+The macOS and Linux buildbots expect to have ccache installed. It is available through homebrew or APT. After
+installing, one should run the following commands:
+
+```console
+$ ccache --set-config=sloppiness=pch_defines,time_macros
+$ ccache -M 100G  # or smaller, depending on disk size
+```
+
+The first command allows CCache to work in the presence of precompiled headers. The second sets the cache size to
+something very large (100GB in this case).
+
 ## Starting a worker
 
 The master recognizes workers by their reported names, eg. `linux-worker-4` or `win-worker-1`. To launch the buildbot

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -18,7 +18,7 @@ from buildbot.process.properties import Interpolate, Property, renderer, Transfo
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.github import GitHubStatusPush
 from buildbot.reporters.message import MessageFormatterRenderable
-from buildbot.schedulers.basic import SingleBranchScheduler, AnyBranchScheduler
+from buildbot.schedulers.basic import AnyBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.steps.cmake import CMake
@@ -208,13 +208,16 @@ class BuilderType:
     def handles_wasm(self):
         return (self.arch == 'x86'
                 and self.bits == 64
-                and (self.os == 'linux' or self.os == 'osx')
+                and self.os in ['osx', 'linux']
                 and self.llvm_branch == LLVM_TRUNK_BRANCH)
 
     def has_nvidia(self):
         return (self.arch == 'x86'
                 and self.bits == 64
-                and (self.os == 'linux' or self.os == 'windows'))
+                and self.os in ['windows', 'linux'])
+
+    def has_ccache(self):
+        return self.os in ['osx', 'linux']
 
     def halide_target(self):
         return '%s-%d-%s' % (self.arch, self.bits, self.os)
@@ -463,9 +466,7 @@ def get_halide_cmake_definitions(builder_type, halide_target='host'):
         'WITH_PYTHON_BINDINGS': 'ON' if builder_type.handles_python() else 'OFF'
     }
 
-    # The linux and arm linux buildbots have ccache installed
-    # (TODO: can install on mac if we update XCode there)
-    if builder_type.os == 'linux':
+    if builder_type.has_ccache():
         cmake_definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
         cmake_definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
 
@@ -559,9 +560,7 @@ def add_env_setup_step(factory, builder_type):
         cxx = 'cl.exe'
         cc = 'cl.exe'
 
-    # The linux and arm linux buildbots have ccache installed
-    # (TODO: can install on mac if we update XCode there)
-    if builder_type.os == 'linux':
+    if builder_type.has_ccache():
         cxx = 'ccache ' + cxx
         cc = 'ccache ' + cc
 


### PR DESCRIPTION
Enables ccache on macOS and moves logic for determining whether to use ccache into the builder type.