### PR TITLE
Lint Python code with Flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+filename = *.py, *.cfg, *.tac
+exclude = venv, worker_heartbeat.py
+max-line-length = 120
+ignore =
+# Import shadowed by loop variable (os)
+    F402
+# Line break before/after binary operator
+    W503
+    W504

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,24 @@
+name: Python Linter
+on:
+  push:
+    paths:
+      - "**.py"
+      - "**.cfg"
+      - "**.tac"
+jobs:
+  lint:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Set up flake8 annotations
+        uses: rbialon/flake8-annotations@v1
+      - name: Run flake8
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8
+          flake8 .

--- a/master/buildbot.tac
+++ b/master/buildbot.tac
@@ -3,8 +3,8 @@ from pathlib import Path
 
 from buildbot.master import BuildMaster
 from twisted.application import service
-from twisted.python.logfile import LogFile
 from twisted.python.log import ILogObserver, FileLogObserver
+from twisted.python.logfile import LogFile
 
 basedir = str(Path(__file__).parent.resolve())
 rotateLength = 10000000
@@ -27,4 +27,3 @@ m = BuildMaster(basedir, configfile, umask)
 m.setServiceParent(application)
 m.log_rotation.rotateLength = rotateLength
 m.log_rotation.maxRotatedFiles = maxRotatedFiles
-

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -872,7 +872,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
 
     source_dir = get_halide_source_path()
     build_dir = get_halide_build_path()
-    install_dir = get_halide_install_path()
+    install_dir = get_halide_install_path()  # NOQA
 
     # Since we need to do at least a partial rebuild for each different target,
     # we want to group things by target. Do host first, followed by a key-sorted


### PR DESCRIPTION
Add a GHA option to lint our Python code with Flake 8 so we don't get bitten by weird scoping rules as in #133 