### PR TITLE
Disable wasm testing entirely for now

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -901,19 +901,17 @@ def get_test_labels(builder_type):
         # Also test hexagon using the simulator
         targets['host-hvx'].extend(['correctness', 'generator', 'apps'])
 
-    if builder_type.handles_wasm():
-        # targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
-        #     ['internal', 'correctness', 'generator', 'error', 'warning'])
-        # # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
-        # # so only test Generator here
-        # targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int-wasm_threads'].extend(
-        #     ['generator'])
+    # TODO: As of Jan 25 2021, top-of-tree LLVM 12 and emcc (2.0.12) disagree about the valid formats
+    # of wasm object files, with the result that trying to aot-link crashes (!) emcc. Disabling
+    # all wasm testing until emcc 2.0.13 is released.
 
-        # TODO: As ofJan 22 2021, top-of-tree LLVM 12 and emcc (2.0.12) disagree about the valid formats
-        # of wasm object files, with the result that trying to aot-link crashes (!) emcc. Disabling
-        # the generator targets temporarily until they can sort out their disagreement.
-        targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
-            ['internal', 'correctness', 'error', 'warning'])
+    # if builder_type.handles_wasm():
+    #     targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
+    #         ['internal', 'correctness', 'generator', 'error', 'warning'])
+    #     # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
+    #     # so only test Generator here
+    #     targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int-wasm_threads'].extend(
+    #         ['generator'])
 
     return targets
 


### PR DESCRIPTION
We need emcc 2.0.13 to be released, which is supposed to be ~in a few days