### PR TITLE
Update LLVM_MAIN -> 13, add LLVM_RELEASE_12

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1345,6 +1345,11 @@ def create_llvm_cmake_factory(builder_type):
     add_get_llvm_source_steps(factory, builder_type)
 
     clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_MAIN)
+
+    # Temporary: force clean builds for LLVM12 as well, during transition period
+    if builder_type.llvm_branch == LLVM_RELEASE_12:
+        clean_llvm_rebuild = True
+
     add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
 
     return factory

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -227,7 +227,8 @@ class BuilderType:
             assert self.purpose != Purpose.llvm_nightly
             assert self.halide_branch in HALIDE, f'unknown branch {self.halide_branch}'
             assert (self.purpose == Purpose.halide_testbranch or  # if not testbranch...
-                    HALIDE[self.halide_branch].version.major == LLVM[self.llvm_branch].version.major)
+                    HALIDE[self.halide_branch].version.major == LLVM[self.llvm_branch].version.major or
+                    (HALIDE[self.halide_branch].version.major == 12 and LLVM[self.llvm_branch].version.major == 13))  # TODO: yuck
         else:
             assert self.purpose == Purpose.llvm_nightly
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -67,10 +67,12 @@ Version = namedtuple('Version', ['major', 'minor', 'patch'])
 VersionedBranch = namedtuple('VersionedBranch', ['ref', 'version'])
 
 LLVM_MAIN = 'main'
+LLVM_RELEASE_12 = 'release_12'
 LLVM_RELEASE_11 = 'release_11'
 LLVM_RELEASE_10 = 'release_10'
 
-LLVM = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(12, 0, 0)),
+LLVM = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(13, 0, 0)),
+        LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
         LLVM_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
         LLVM_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
 
@@ -1252,6 +1254,7 @@ def llvm_branch_for_halide_branch(halide_branch):
     # Given a halide branch, return the 'native' llvm version we expect to use with it.
     # For halide release branches, this is the corresponding llvm release branch; for
     # halide main, it's llvm main.
+    # TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_12, for now anyway
     return {HALIDE_MAIN: LLVM_MAIN,
             HALIDE_RELEASE_11: LLVM_RELEASE_11,
             HALIDE_RELEASE_10: HALIDE_RELEASE_10}.get(halide_branch)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -228,7 +228,8 @@ class BuilderType:
             assert self.halide_branch in HALIDE, f'unknown branch {self.halide_branch}'
             assert (self.purpose == Purpose.halide_testbranch or  # if not testbranch...
                     HALIDE[self.halide_branch].version.major == LLVM[self.llvm_branch].version.major or
-                    (HALIDE[self.halide_branch].version.major == 12 and LLVM[self.llvm_branch].version.major == 13))  # TODO: yuck
+                    (HALIDE[self.halide_branch].version.major == 12 and \
+                     LLVM[self.llvm_branch].version.major == 13))  # TODO: yuck
         else:
             assert self.purpose == Purpose.llvm_nightly
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1252,14 +1252,14 @@ def create_halide_builder(arch, bits, os, halide_branch, llvm_branch, purpose, b
     return builder
 
 
-def llvm_branch_for_halide_branch(halide_branch):
+def llvm_branches_for_halide_branch(halide_branch):
     # Given a halide branch, return the 'native' llvm version we expect to use with it.
     # For halide release branches, this is the corresponding llvm release branch; for
     # halide main, it's llvm main.
     # TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_12, for now anyway
-    return {HALIDE_MAIN: LLVM_MAIN,
-            HALIDE_RELEASE_11: LLVM_RELEASE_11,
-            HALIDE_RELEASE_10: HALIDE_RELEASE_10}.get(halide_branch)
+    return {HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_12],
+            HALIDE_RELEASE_11: [LLVM_RELEASE_11],
+            HALIDE_RELEASE_10: [HALIDE_RELEASE_10]}.get(halide_branch)
 
 
 def create_halide_builders():
@@ -1267,13 +1267,13 @@ def create_halide_builders():
         # Create builders for build + package of Halide master + release branches
         # (but only against their 'native' LLVM versions)
         for halide_branch in HALIDE:
-            llvm_branch = llvm_branch_for_halide_branch(halide_branch)
-            yield create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_main)
+            for llvm_branch in llvm_branches_for_halide_branch(halide_branch):
+                yield create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_main)
 
         # Create the builders for testing pull requests to releases.
         for halide_branch in _HALIDE_RELEASES:
-            llvm_branch = llvm_branch_for_halide_branch(halide_branch)
-            yield create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_testbranch)
+            for llvm_branch in llvm_branches_for_halide_branch(halide_branch):
+                yield create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_testbranch)
 
         # Create the builders for testing pull requests to main.
         yield create_halide_builder(arch, bits, os, HALIDE_MAIN, LLVM_MAIN, Purpose.halide_testbranch)


### PR DESCRIPTION
LLVM main branch is now 13, so update our versioning. Add LLVM_RELEASE_12 to the list of branches so that we build nightlies, but don't use it otherwise just yet.

(We really need to update the build rules to have HALIDE_MAIN test against both LLVM_12 and LLVM_MAIN, but that can wait for a bit while we get the buildbots unstuck)