### PR TITLE
Restore wasm testing

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -932,17 +932,13 @@ def get_test_labels(builder_type):
         # Also test hexagon using the simulator
         targets['host-hvx'].extend(['correctness', 'generator', 'apps'])
 
-    # TODO: As of Jan 25 2021, top-of-tree LLVM 12 and emcc (2.0.12) disagree about the valid formats
-    # of wasm object files, with the result that trying to aot-link crashes (!) emcc. Disabling
-    # all wasm testing until emcc 2.0.13 is released.
-
-    # if builder_type.handles_wasm():
-    #     targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
-    #         ['internal', 'correctness', 'generator', 'error', 'warning'])
-    #     # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
-    #     # so only test Generator here
-    #     targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int-wasm_threads'].extend(
-    #         ['generator'])
+    if builder_type.handles_wasm():
+        targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(
+            ['internal', 'correctness', 'generator', 'error', 'warning'])
+        # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
+        # so only test Generator here
+        targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int-wasm_threads'].extend(
+            ['generator'])
 
     return targets
 


### PR DESCRIPTION
emcc 2.0.13 has been released (and installed on buildbots) so we should be good to re-enable now