### PR TITLE
Make script more dumb-text-editor friendly

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -71,10 +71,10 @@ LLVM_RELEASE_12 = 'release_12'
 LLVM_RELEASE_11 = 'release_11'
 LLVM_RELEASE_10 = 'release_10'
 
-LLVM = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(13, 0, 0)),
-        LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
-        LLVM_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
-        LLVM_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
+LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(13, 0, 0)),
+                 LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
+                 LLVM_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
+                 LLVM_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
 
 # At any given time, Halide has a main branch, which supports (at least)
 # the LLVM main branch and the most recent release branch (and maybe one older).
@@ -93,9 +93,9 @@ HALIDE_RELEASE_10 = 'release_10'
 
 _HALIDE_RELEASES = [HALIDE_RELEASE_11, HALIDE_RELEASE_10]
 
-HALIDE = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(12, 0, 0)),
-          HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 0)),
-          HALIDE_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
+HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(12, 0, 0)),
+                   HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 0)),
+                   HALIDE_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
 
 # WORKERS
 
@@ -137,7 +137,7 @@ performance_lock = WorkerLock("performance_lock", maxCount=9999)
 # we could probably just get by with a single lock for *any* llvm install,
 # but this isn't much harder to do.)
 llvm_build_locks = {}
-for llvm_branch, info in LLVM.items():
+for llvm_branch, info in LLVM_BRANCHES.items():
     llvm_build_locks[llvm_branch] = WorkerLock(f'llvm_install_lock_{info.version.major}', maxCount=9999)
 
 # CHANGESOURCES
@@ -149,7 +149,7 @@ c['change_source'] = [
     GitPoller(
         repourl='https://github.com/llvm/llvm-project.git',
         workdir='gitpoller-llvm-workdir',
-        branch=LLVM[LLVM_MAIN].ref,
+        branch=LLVM_BRANCHES[LLVM_MAIN].ref,
         pollInterval=60 * 60 * 24,  # Only check llvm once every 24 hours
         pollAtLaunch=True)
 ]
@@ -213,7 +213,7 @@ class BuilderType:
         assert arch in ['arm', 'x86']
         assert bits in [32, 64]
         assert os in ['linux', 'windows', 'osx']
-        assert llvm_branch in LLVM, f'{llvm_branch} not recognized'
+        assert llvm_branch in LLVM_BRANCHES, f'{llvm_branch} not recognized'
 
         self.arch = arch
         self.bits = bits
@@ -225,11 +225,12 @@ class BuilderType:
 
         if self.halide_branch:
             assert self.purpose != Purpose.llvm_nightly
-            assert self.halide_branch in HALIDE, f'unknown branch {self.halide_branch}'
+            assert self.halide_branch in HALIDE_BRANCHES, f'unknown branch {self.halide_branch}'
             assert (self.purpose == Purpose.halide_testbranch or  # if not testbranch...
-                    HALIDE[self.halide_branch].version.major == LLVM[self.llvm_branch].version.major or
-                    (HALIDE[self.halide_branch].version.major == 12 and \
-                     LLVM[self.llvm_branch].version.major == 13))  # TODO: yuck
+                    HALIDE_BRANCHES[self.halide_branch].version.major == \
+                    LLVM_BRANCHES[self.llvm_branch].version.major or
+                    (HALIDE_BRANCHES[self.halide_branch].version.major == 12 and \
+                     LLVM_BRANCHES[self.llvm_branch].version.major == 13))  # TODO: yuck
         else:
             assert self.purpose == Purpose.llvm_nightly
 
@@ -266,7 +267,7 @@ class BuilderType:
         return '%s-%d-%s' % (self.arch, self.bits, self.os)
 
     def llvm_builder_label(self):
-        return 'llvm-%s-%s' % (LLVM[self.llvm_branch].version.major, self.halide_target())
+        return 'llvm-%s-%s' % (LLVM_BRANCHES[self.llvm_branch].version.major, self.halide_target())
 
     def halide_builder_label(self):
         # This currently tries to (somewhat) mimic the existing label pattern,
@@ -279,7 +280,7 @@ class BuilderType:
         if self.halide_branch == HALIDE_MAIN:
             # Halide master is built against multiple LLVM versions,
             # so append that here for clarity
-            a.append(f'llvm{LLVM[self.llvm_branch].version.major}')
+            a.append(f'llvm{LLVM_BRANCHES[self.llvm_branch].version.major}')
         a.append(self.halide_target())
         a.append(self.buildsystem.name)
         return '-'.join(a)
@@ -342,7 +343,7 @@ def add_get_halide_source_steps(factory, builder_type):
                            codebase='halide',
                            workdir=get_halide_source_path(),
                            repourl='git://github.com/halide/Halide.git',
-                           branch=HALIDE[builder_type.halide_branch].ref,
+                           branch=HALIDE_BRANCHES[builder_type.halide_branch].ref,
                            mode='incremental'))
 
 
@@ -378,12 +379,12 @@ def add_get_llvm_source_steps(factory, builder_type):
                     f"sed -i 's/#ifdef HAVE_STD_IS_TRIVIALLY_COPYABLE/#if 0/g' {type_traits_h} || " +
                     "true"))
     else:
-        factory.addStep(Git(name=f'Get LLVM {LLVM[builder_type.llvm_branch].version.major}',
+        factory.addStep(Git(name=f'Get LLVM {LLVM_BRANCHES[builder_type.llvm_branch].version.major}',
                             locks=[performance_lock.access('counting')],
                             codebase='llvm',
                             workdir=get_llvm_source_path(),
                             repourl='https://github.com/llvm/llvm-project.git',
-                            branch=LLVM[builder_type.llvm_branch].ref,
+                            branch=LLVM_BRANCHES[builder_type.llvm_branch].ref,
                             mode='incremental'))
 
 
@@ -732,7 +733,7 @@ def get_llvm_latest_commit(props):
 def add_llvm_steps(factory, builder_type, clean_rebuild):
     build_dir = get_llvm_build_path()
     install_dir = get_llvm_install_path(builder_type)
-    llvm_name = str(LLVM[builder_type.llvm_branch].version.major)
+    llvm_name = str(LLVM_BRANCHES[builder_type.llvm_branch].version.major)
 
     if clean_rebuild:
         factory.addStep(RemoveDirectory(name="Remove LLVM %s Build Dir" % llvm_name,
@@ -1255,7 +1256,7 @@ def create_halide_builders():
     for arch, bits, os in get_interesting_halide_targets():
         # Create builders for build + package of Halide master + release branches
         # (but only against their 'native' LLVM versions)
-        for halide_branch in HALIDE:
+        for halide_branch in HALIDE_BRANCHES:
             for llvm_branch in llvm_branches_for_halide_branch(halide_branch):
                 yield create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_main)
 
@@ -1274,14 +1275,14 @@ def create_halide_builders():
     yield create_halide_builder('x86', 64, 'osx', HALIDE_MAIN, LLVM_MAIN, Purpose.halide_testbranch, BuildSystem.make)
 
     # Test pull requests for Halide master against the current and previous LLVM, for at least one target.
-    for llvm_branch in LLVM:
-        if abs(LLVM[llvm_branch].version.major - LLVM[LLVM_MAIN].version.major) in [1, 2]:
+    for llvm_branch in LLVM_BRANCHES:
+        if abs(LLVM_BRANCHES[llvm_branch].version.major - LLVM_BRANCHES[LLVM_MAIN].version.major) in [1, 2]:
             yield create_halide_builder('x86', 64, 'linux', HALIDE_MAIN, llvm_branch, Purpose.halide_testbranch)
 
 
 def create_halide_scheduler(halide_branch):
     def is_halide_base_branch(br):
-        return any(br == hl.ref for hl in HALIDE.values())
+        return any(br == hl.ref for hl in HALIDE_BRANCHES.values())
 
     def is_halide_pr_branch(br):
         # If it's not one of the well-known branches, assume it's a pull request
@@ -1289,7 +1290,7 @@ def create_halide_scheduler(halide_branch):
 
     def github_base_branch_matches(change):
         ref = change.properties.getProperty('basename')
-        return ref == HALIDE[halide_branch].ref
+        return ref == HALIDE_BRANCHES[halide_branch].ref
 
     # ----- main
     builders = [b for b in c['builders']
@@ -1299,7 +1300,7 @@ def create_halide_scheduler(halide_branch):
         yield AnyBranchScheduler(
             name='halide-package-' + halide_branch,
             codebases=['halide'],
-            change_filter=ChangeFilter(category=None, codebase='halide', branch=HALIDE[halide_branch].ref),
+            change_filter=ChangeFilter(category=None, codebase='halide', branch=HALIDE_BRANCHES[halide_branch].ref),
             treeStableTimer=60 * 5,  # seconds
             builderNames=builder_names)
 
@@ -1351,7 +1352,7 @@ def create_llvm_builders():
         # Note that we want these Builders to run on *every* eligible worker;
         # the goal is to ensure that all LLVM builds are updated locally
         # on all of the workers.
-        for llvm_branch in LLVM:
+        for llvm_branch in LLVM_BRANCHES:
             builder_type = BuilderType(arch, bits, os, None, llvm_branch, Purpose.llvm_nightly)
             for w in builder_type.get_worker_names():
                 # Note that we need the builder name to be unique across workers,
@@ -1380,7 +1381,7 @@ def create_llvm_scheduler(llvm_branch):
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.llvm_nightly]
     # Start every day at midnight Pacific; our buildbots use UTC for cron, so that's 8AM
     yield Nightly(
-        name=f'llvm-nightly-{LLVM[llvm_branch].version.major}',
+        name=f'llvm-nightly-{LLVM_BRANCHES[llvm_branch].version.major}',
         codebases=['llvm'],
         builderNames=builders,
         change_filter=ChangeFilter(codebase='llvm'),
@@ -1400,10 +1401,10 @@ def create_builders():
 
 
 def create_schedulers():
-    for llvm_branch in LLVM:
+    for llvm_branch in LLVM_BRANCHES:
         yield from create_llvm_scheduler(llvm_branch)
 
-    for halide_branch in HALIDE:
+    for halide_branch in HALIDE_BRANCHES:
         yield from create_halide_scheduler(halide_branch)
 
 


### PR DESCRIPTION
LLVM and HALIDE are too-generic names for data structures that are used frequently here; searching for usages of these in a plain text editor (vs Python-aware IDE) is tedious because the terms are used so often in comments, etc. Appended _BRANCHES to both of them to make this use case easier.