### PR TITLE
prioritize_builders should explicitly handle LLVM12

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1437,7 +1437,7 @@ def prioritize_builders(buildmaster, builders):
         # for bisection, then older llvm versions.
         if builder_type.llvm_branch == LLVM_RELEASE_11:
             return 2
-        if builder_type.llvm_branch == LLVM_MAIN:
+        if builder_type.llvm_branch == LLVM_MAIN or builder_type.llvm_branch == LLVM_RELEASE_12:
             return 3
         if builder_type.llvm_branch == LLVM_RELEASE_10:
             return 4


### PR DESCRIPTION
LLVM12 was falling thru and returning the '5' case; this is ok, but (1) it should probably be treated the same as LLVM13 at this point and (2) it definitely shouldn't be omitted (ie, it's important enough to call out in the code).