### PR TITLE
Ensure that PRs against Halide main are compiled vs all supported LLVMs

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1274,9 +1274,10 @@ def create_halide_builders():
     yield create_halide_builder('x86', 32, 'linux', HALIDE_MAIN, LLVM_MAIN, Purpose.halide_testbranch, BuildSystem.make)
     yield create_halide_builder('x86', 64, 'osx', HALIDE_MAIN, LLVM_MAIN, Purpose.halide_testbranch, BuildSystem.make)
 
-    # Test pull requests for Halide master against the current and previous LLVM, for at least one target.
+    # Test pull requests for Halide master against all the LLVM versions we still support, for at least one target.
     for llvm_branch in LLVM_BRANCHES:
-        if abs(LLVM_BRANCHES[llvm_branch].version.major - LLVM_BRANCHES[LLVM_MAIN].version.major) in [1, 2]:
+        # We already handled LLVM for testbranches against main in the loop above.
+        if llvm_branch != LLVM_MAIN:
             yield create_halide_builder('x86', 64, 'linux', HALIDE_MAIN, llvm_branch, Purpose.halide_testbranch)
 
 


### PR DESCRIPTION
Halide policy is (still) that our main branch should be usable against $LLVM_RELEASE-1, which currently means LLVM10 thru 13 (inclusive). Recent changes to the Halide buildbots cause Halide PRs to only get tested against 12 and 13.

This changes so that PRs against Halide main get at least one compile-and-test against all LLVMs we support.

(Note that this only affects PRs, not periodic compiles/packages of Halide main branch; the latter are still targeting only LLVM 12 and 13.)