### PR TITLE
test_python() should be true for arm-64-osx

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -239,7 +239,13 @@ class BuilderType:
     # and supporting 32-bit Python on our 64-bit buildbots is painful
     # (and usage of the python bindings on 32-bit hosts is unlikely anyway)
     def handles_python(self):
-        return self.arch != 'arm' and self.bits != 32
+        if self.bits == 32:
+            return False
+
+        if self.arch == 'arm' and self.os == 'linux':
+            return False
+
+        return True
 
     def handles_hexagon(self):
         return (self.arch == 'x86'


### PR DESCRIPTION
We want to disallow all 32 bit targets, and all arm-linux targets, but the logic also disallowed all arm, period