### PR TITLE
Improve LLVM buildbot rules

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -139,7 +139,9 @@ performance_lock = WorkerLock("performance_lock", maxCount=9999)
 # but this isn't much harder to do.)
 llvm_build_locks = {}
 for llvm_branch, info in LLVM_BRANCHES.items():
-    llvm_build_locks[llvm_branch] = WorkerLock(f'llvm_install_lock_{info.version.major}', maxCount=9999)
+    for bits in [32, 64]:
+        llvm_build_locks[llvm_branch + str(bits)] = WorkerLock(
+            f'llvm_install_lock_{info.version.major}_{bits}', maxCount=9999)
 
 # CHANGESOURCES
 
@@ -617,6 +619,9 @@ def get_llvm_cmake_definitions(builder_type):
     if builder_type.os == 'osx':
         definitions['LLVM_ENABLE_SUPPORT_XCODE_SIGNPOSTS'] = 'FORCE_OFF'
 
+    if builder_type.has_ccache():
+        definitions['LLVM_CCACHE_BUILD'] = 'ON'
+
     return definitions
 
 
@@ -630,7 +635,7 @@ def extend_property(dict_name, **kwargs):
     return render
 
 
-def add_env_setup_step(factory, builder_type):
+def add_env_setup_step(factory, builder_type, enable_ccache=False):
     if builder_type.os == 'windows':
         # do this first because the SetPropertyFromCommand step isn't smart enough to merge
         get_msvc_config_steps(factory, builder_type)
@@ -643,11 +648,11 @@ def add_env_setup_step(factory, builder_type):
     cc = 'cc'
     ld = 'ld'
 
-    if builder_type.arch == 'x86' and builder_type.os == 'linux':
+    if builder_type.os == 'linux':
         cc = 'gcc-7'
         cxx = 'g++-7'
         ld = 'ld'
-        if builder_type.bits == 32:
+        if builder_type.arch == 'x86' and builder_type.bits == 32:
             cxx += ' -m32'
             cc += ' -m32'
             ld += ' -melf_i386'
@@ -655,7 +660,9 @@ def add_env_setup_step(factory, builder_type):
         cxx = 'cl.exe'
         cc = 'cl.exe'
 
-    if builder_type.has_ccache():
+    # This is only necessary (or desirable) for make-based builds of Halide;
+    # CMake-based builds handle it via Halide_CCACHE_BUILD and/or LLVM_CCACHE_BUILD
+    if enable_ccache and builder_type.has_ccache():
         cxx = 'ccache ' + cxx
         cc = 'ccache ' + cc
 
@@ -1131,7 +1138,7 @@ def create_halide_make_factory(builder_type):
     build_dir = get_halide_build_path()
 
     factory = BuildFactory()
-    add_env_setup_step(factory, builder_type)
+    add_env_setup_step(factory, builder_type, enable_ccache=True)
 
     # It's never necessary to use get_msvc_config_steps() for Make,
     # since we never use Make with MSVC
@@ -1247,7 +1254,7 @@ def create_halide_builder(arch, bits, os, halide_branch, llvm_branch, purpose, b
                             # (We could probably get by with access during only a subset of
                             # our steps, but there doesn't appear to be a way to group
                             # lock requests across multiple-but-not-all-steps in a Build.)
-                            locks=[llvm_build_locks[llvm_branch].access('counting')],
+                            locks=[llvm_build_locks[llvm_branch + str(bits)].access('counting')],
                             tags=builder_type.builder_tags())
     builder.builder_type = builder_type
     return builder
@@ -1382,7 +1389,7 @@ def create_llvm_builders():
                                         # but we'd have to finesse some details like removing
                                         # the old install directory within the lock, and this
                                         # is much simpler.)
-                                        locks=[llvm_build_locks[llvm_branch].access('exclusive')],
+                                        locks=[llvm_build_locks[llvm_branch + str(bits)].access('exclusive')],
                                         tags=builder_type.builder_tags())
                 builder.builder_type = builder_type
                 yield builder


### PR DESCRIPTION
- set LLVM_CCACHE_BUILD=ON for builders with ccache
- revise llvm_build_locks to include the 'bitness' of LLVM; this allows 32 and 64 bit builds to proceed at the same time (formerly they were locked out even if the system had enough capacity)
- Only prepend 'ccache' to the compiler name when doing make builds, and only for Halide (not for LLVM)
- revise the Linux compiler choice to specify gcc-7 everywhere, not just on x86 (gcc-7 is our preferred compiler on armlinux too)