### PR TITLE
Downgrade rpi4 to max_builds=1

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -115,8 +115,8 @@ _WORKERS = [
     ('arm64-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[64], os='linux')),
     ('arm64-linux-worker-2', WorkerConfig(max_builds=1, arch='arm', bits=[64], os='linux')),
     # TODO: this bot is configured to handle both arm64 and arm32 builds. For now, just running arm32.
-    # ('rpi4-linux-worker-1', WorkerConfig(max_builds=2, arch='arm', bits=[32, 64], os='linux')),
-    ('rpi4-linux-worker-1', WorkerConfig(max_builds=2, arch='arm', bits=[32], os='linux')),
+    # ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[32, 64], os='linux')),
+    ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[32], os='linux')),
     ('win-worker-1', WorkerConfig(max_builds=1, arch='x86', bits=[32, 64], os='windows')),
     ('win-worker-2', WorkerConfig(max_builds=1, arch='x86', bits=[32, 64], os='windows')),
 ]


### PR DESCRIPTION
I had hoped it would be faster-enough that the Jetson boards to support max_builds=2, but so far, compile speed seems roughly on-par, so multiple builds are unreasonably slow. Let's downgrade to max_builds=1 and see how it foes.