### PR TITLE
Add worker-parallelism to worker table

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -599,7 +599,7 @@ def get_halide_cmake_definitions(builder_type, halide_target='host'):
 def get_cmake_build_command(builder_type, build_dir, targets=None):
     cmd = ['ninja',
            '-C', build_dir,
-           '-j', get_build_parallelism(builder_type)]
+           '-j', Property('WORKER_BUILD_PARALLELISM')]
     if targets:
         cmd += targets
 
@@ -610,7 +610,7 @@ def get_cmake_build_command(builder_type, build_dir, targets=None):
     # cmd = ['cmake',
     #        '--build', build_dir,
     #        '--config', 'Release',
-    #        '-j', get_build_parallelism(builder_type)]
+    #        '-j', Property('WORKER_BUILD_PARALLELISM')]
     # if target:
     #     cmd.extend(['--target', target])
 
@@ -740,10 +740,6 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
         properties=dict(
             env=extend_property('env', **env),
             VCPKG_ROOT=vcpkg_root)))
-
-
-def get_build_parallelism(builder_type):
-    return Property('WORKER_BUILD_PARALLELISM')
 
 
 @renderer
@@ -979,7 +975,7 @@ def is_time_critical_test(test):
 
 
 def add_halide_cmake_test_steps(factory, builder_type):
-    parallelism = get_build_parallelism(builder_type)
+    parallelism = Property('WORKER_BUILD_PARALLELISM')
 
     labels = get_test_labels(builder_type)
 
@@ -1144,7 +1140,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
 def create_halide_make_factory(builder_type):
     assert builder_type.os != 'windows'
 
-    make_threads = get_build_parallelism(builder_type)
+    make_threads = Property('WORKER_BUILD_PARALLELISM')
     build_dir = get_halide_build_path()
 
     factory = BuildFactory()

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -105,6 +105,10 @@ WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'j', 'arch', 'bits', 'o
 # For machines with max_builds=1, using nproc+2 cores for building is the conventional choise
 # (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which
 # is definitely not what we want.
+#
+# Note that `nproc` isn't available on osx (unless you install with brew); you can use `sysctl -n hw.ncpu` instead.
+#
+# Note that `nproc` isn't usually available on windows, but we rely on running in the git-bash shell.
 _NPROC_PLUS_2 = '$(($(nproc)+2))'
 
 _WORKERS = [

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -105,7 +105,8 @@ WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'j', 'arch', 'bits', 'o
 # For machines with max_builds=1, using nproc+2 cores for building is the conventional choice
 # (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which
 # is definitely not what we want.
-_NPROC_PLUS_2 = (int(Interpolate('%(worker:numcpus)s')) + 2)
+_NPROC_PLUS_2 = Transform(lambda x: f'{int(x)+2}', Interpolate("%(worker:numcpus)s"))
+
 
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -102,14 +102,10 @@ HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(12
 # Can use Python 3.7 dataclasses instead, if we choose to upgrade to that.
 WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'j', 'arch', 'bits', 'os'])
 
-# For machines with max_builds=1, using nproc+2 cores for building is the conventional choise
+# For machines with max_builds=1, using nproc+2 cores for building is the conventional choice
 # (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which
 # is definitely not what we want.
-#
-# Note that `nproc` isn't available on osx (unless you install with brew); you can use `sysctl -n hw.ncpu` instead.
-#
-# Note that `nproc` isn't usually available on windows, but we rely on running in the git-bash shell.
-_NPROC_PLUS_2 = '$(($(nproc)+2))'
+_NPROC_PLUS_2 = '$((int(%(worker:numcpus)s)+2))'
 
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -102,29 +102,32 @@ HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(12
 # Can use Python 3.7 dataclasses instead, if we choose to upgrade to that.
 WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'arch', 'bits', 'os'])
 
+# For machines with max_builds=1, using nproc+2 cores for building is the conventional choise
+# (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which
+# is definitely not what we want.
+_NPROC_PLUS_2 = '$(($(nproc)+2))'
+
 _WORKERS = [
-    ('linux-worker-1', WorkerConfig(max_builds=4, arch='x86', bits=[32, 64], os='linux')),
-    # Disable linuxbot 2 and 3 for now, since they are *much* slower than 1 and 4
-    # ('linux-worker-2', WorkerConfig(max_builds=2, arch='x86', bits=[32, 64], os='linux')),
-    # ('linux-worker-3', WorkerConfig(max_builds=2, arch='x86', bits=[32, 64], os='linux')),
-    ('linux-worker-4', WorkerConfig(max_builds=4, arch='x86', bits=[32, 64], os='linux')),
-    ('mac-worker-1', WorkerConfig(max_builds=2, arch='x86', bits=[64], os='osx')),
-    ('mac-arm-worker-1', WorkerConfig(max_builds=2, arch='arm', bits=[64], os='osx')),
-    ('arm32-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[32], os='linux')),
-    ('arm32-linux-worker-2', WorkerConfig(max_builds=1, arch='arm', bits=[32], os='linux')),
-    ('arm64-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[64], os='linux')),
-    ('arm64-linux-worker-2', WorkerConfig(max_builds=1, arch='arm', bits=[64], os='linux')),
-    # TODO: this bot is configured to handle both arm64 and arm32 builds. For now, just running arm32.
-    # ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[32, 64], os='linux')),
-    ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, arch='arm', bits=[32], os='linux')),
-    ('win-worker-1', WorkerConfig(max_builds=1, arch='x86', bits=[32, 64], os='windows')),
-    ('win-worker-2', WorkerConfig(max_builds=1, arch='x86', bits=[32, 64], os='windows')),
+    ('linux-worker-1', WorkerConfig(max_builds=4, build_parallelism=8, arch='x86', bits=[32, 64], os='linux')),
+    ('linux-worker-4', WorkerConfig(max_builds=4, build_parallelism=8, arch='x86', bits=[32, 64], os='linux')),
+    ('mac-worker-1', WorkerConfig(max_builds=2, build_parallelism=8, arch='x86', bits=[64], os='osx')),
+    ('mac-arm-worker-1', WorkerConfig(max_builds=2, build_parallelism=8, arch='arm', bits=[64], os='osx')),
+    ('arm32-linux-worker-1', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
+    ('arm32-linux-worker-2', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
+    ('arm64-linux-worker-1', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[64], os='linux')),
+    ('arm64-linux-worker-2', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[64], os='linux')),
+    ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
+    ('win-worker-1', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    ('win-worker-2', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
 
 # The 'workers' list defines the set of recognized buildworkers. Each element is
 # a Worker object, specifying a unique worker name and password.  The same
 # worker name and password must be configured on the worker.
-c['workers'] = [Worker(n, WORKER_SECRET, max_builds=cfg.max_builds) for n, cfg in _WORKERS]
+c['workers'] = [Worker(n,
+                       WORKER_SECRET,
+                       max_builds=cfg.max_builds,
+                       properties={'WORKER_BUILD_PARALLELISM': cfg.build_parallelism}) for n, cfg in _WORKERS]
 
 # LOCKS
 
@@ -740,27 +743,7 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
 
 
 def get_build_parallelism(builder_type):
-    # Standard wisdom is (nproc+2)
-    if builder_type.os == 'linux':
-        if builder_type.arch == 'x86':
-            # TODO: our Linux bots also have 12 cores; this seems maybe too high?
-            return 8
-        else:
-            assert builder_type.arch == 'arm'
-            return 2
-    elif builder_type.os == 'osx':
-        if builder_type.arch == 'x86':
-            # MacBot has 32GB and 6/12 core Xeon. We allow two builds at
-            # once so set threads = (12/2)+2 == 8
-            return 8
-        else:
-            # MacArmBot has an M1. Let's try 8?
-            return 8
-    elif builder_type.os == 'windows':
-        # WinBots have 6/12 cores but are very slow.
-        return 4
-    else:
-        assert False
+    return Interpolate("%(prop:WORKER_BUILD_PARALLELISM)s")
 
 
 @renderer

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -105,7 +105,7 @@ WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'j', 'arch', 'bits', 'o
 # For machines with max_builds=1, using nproc+2 cores for building is the conventional choice
 # (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which
 # is definitely not what we want.
-_NPROC_PLUS_2 = '$((int(%(worker:numcpus)s)+2))'
+_NPROC_PLUS_2 = Interpolate('$((int(%(worker:numcpus)s)+2))')
 
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
@@ -743,7 +743,7 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
 
 
 def get_build_parallelism(builder_type):
-    return Interpolate("%(prop:WORKER_BUILD_PARALLELISM)s")
+    return Property('WORKER_BUILD_PARALLELISM')
 
 
 @renderer

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -105,7 +105,7 @@ WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'j', 'arch', 'bits', 'o
 # For machines with max_builds=1, using nproc+2 cores for building is the conventional choice
 # (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which
 # is definitely not what we want.
-_NPROC_PLUS_2 = Interpolate('$((int(%(worker:numcpus)s)+2))')
+_NPROC_PLUS_2 = (int(Interpolate('%(worker:numcpus)s')) + 2)
 
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -108,17 +108,17 @@ WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'arch', 'bits', 'os'])
 _NPROC_PLUS_2 = '$(($(nproc)+2))'
 
 _WORKERS = [
-    ('linux-worker-1', WorkerConfig(max_builds=4, build_parallelism=8, arch='x86', bits=[32, 64], os='linux')),
-    ('linux-worker-4', WorkerConfig(max_builds=4, build_parallelism=8, arch='x86', bits=[32, 64], os='linux')),
-    ('mac-worker-1', WorkerConfig(max_builds=2, build_parallelism=8, arch='x86', bits=[64], os='osx')),
-    ('mac-arm-worker-1', WorkerConfig(max_builds=2, build_parallelism=8, arch='arm', bits=[64], os='osx')),
-    ('arm32-linux-worker-1', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
-    ('arm32-linux-worker-2', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
-    ('arm64-linux-worker-1', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[64], os='linux')),
-    ('arm64-linux-worker-2', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[64], os='linux')),
-    ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
-    ('win-worker-1', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
-    ('win-worker-2', WorkerConfig(max_builds=1, build_parallelism=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
+    ('linux-worker-4', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
+    ('mac-worker-1', WorkerConfig(max_builds=2, j=8, arch='x86', bits=[64], os='osx')),
+    ('mac-arm-worker-1', WorkerConfig(max_builds=2, j=8, arch='arm', bits=[64], os='osx')),
+    ('arm32-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
+    ('arm32-linux-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
+    ('arm64-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[64], os='linux')),
+    ('arm64-linux-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[64], os='linux')),
+    ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
+    ('win-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
 
 # The 'workers' list defines the set of recognized buildworkers. Each element is
@@ -127,7 +127,7 @@ _WORKERS = [
 c['workers'] = [Worker(n,
                        WORKER_SECRET,
                        max_builds=cfg.max_builds,
-                       properties={'WORKER_BUILD_PARALLELISM': cfg.build_parallelism}) for n, cfg in _WORKERS]
+                       properties={'WORKER_BUILD_PARALLELISM': cfg.j}) for n, cfg in _WORKERS]
 
 # LOCKS
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -100,7 +100,7 @@ HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(12
 # WORKERS
 
 # Can use Python 3.7 dataclasses instead, if we choose to upgrade to that.
-WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'arch', 'bits', 'os'])
+WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'j', 'arch', 'bits', 'os'])
 
 # For machines with max_builds=1, using nproc+2 cores for building is the conventional choise
 # (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which


### PR DESCRIPTION
The idea here is:
- Add a recommended build-and-test parallelism to the WorkerConfig table
- Turn that into a worker Property
- Instead of guessing `-j` arguments based on buildertype, use the Worker Property directly

This should allow for better build utilization on the bots that have max_build=1.

Not sure if I got the Interpolate stuff right.