### PR TITLE
Upgrade to buildbot 3.0

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -522,7 +522,8 @@ def get_emsdk_config_steps(factory, builder_type):
 
     def save_interesting_env_vars(rc, stdout, stderr):
         d = {}
-        for line in stdout.split('\n'):
+        output = stdout + '\n' + stderr
+        for line in output.split('\n'):
             match = re.match("^([a-zA-Z0-9_-]+) = (.*)$", line.strip())
             if match:
                 key = match.group(1).upper()
@@ -537,7 +538,7 @@ def get_emsdk_config_steps(factory, builder_type):
                                description='Run emsdk_env',
                                locks=[performance_lock.access('counting')],
                                haltOnFailure=True,
-                               env=Property('env'),
+                               env=Property('env', default={}),
                                command="source ${EMSDK}/emsdk_env.sh",
                                extract_fn=save_interesting_env_vars))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
-buildbot[bundle]~=2.10.0
-buildbot-worker~=2.10.0
-txrequests==0.9.6
-Twisted~=20.3.0
-# Pin sqlalchemy to avoid missing symbol errors
-sqlalchemy==1.3.23
+# Buildbot core
+buildbot[bundle]~=3.0
+buildbot-worker~=3.0
+txrequests
+
+# Version 3.4+ requires a Rust compiler (!?) to be installed on the host system
+cryptography<3.4
+
+# Platform-specific requirements
 pywin32==300; sys_platform == 'win32'


### PR DESCRIPTION
Not much needed to change. The emsdk stuff needed a fix (`emsdk_env.sh` prints to _stderr_, not _stdout_) and then there's the dependency nightmare that is the Python `cryptography` package.

It requires the freaking RUST COMPILER TO BE INSTALLED. If you're not one of the lucky systems to have a binary wheel available (x86 32-bit Linux apparently is not one of them), then you need to INSTALL RUST just for the sake of building that package. I set the constraint to the latest version that does _not_ need Rust. But oh my god, what a mess. Crypto libraries are not the kind of thing we want to hold back, generally speaking, so hopefully they'll add some more pre-built wheels to PyPI.