### PR TITLE
Use nproc, not nproc+2, on arm32 bots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -107,17 +107,19 @@ WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'j', 'arch', 'bits', 'o
 # is definitely not what we want.
 _NPROC_PLUS_2 = Transform(lambda x: f'{int(x)+2}', Interpolate("%(worker:numcpus)s"))
 
+# Using nproc+2 on the arm32 builds causes internal errors in gcc-armeabihf. Let's just use nproc.
+_NPROC = Interpolate("%(worker:numcpus)s")
 
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
     ('linux-worker-4', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
     ('mac-worker-1', WorkerConfig(max_builds=2, j=8, arch='x86', bits=[64], os='osx')),
     ('mac-arm-worker-1', WorkerConfig(max_builds=2, j=8, arch='arm', bits=[64], os='osx')),
-    ('arm32-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
-    ('arm32-linux-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
+    ('arm32-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC, arch='arm', bits=[32], os='linux')),
+    ('arm32-linux-worker-2', WorkerConfig(max_builds=1, j=_NPROC, arch='arm', bits=[32], os='linux')),
     ('arm64-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[64], os='linux')),
     ('arm64-linux-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[64], os='linux')),
-    ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='arm', bits=[32], os='linux')),
+    ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC, arch='arm', bits=[32], os='linux')),
     ('win-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
     ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
@@ -631,6 +633,13 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_ENABLE_TERMINFO': 'OFF',
         'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC;WebAssembly',
     }
+
+    # Some versions of GCC will flood the output with useless warnings about
+    # "parameter passing for argument of type foo changed in GCC 7.1" unless
+    # we disable this warning. This isn't *essential*, but it makes looking at the
+    # LLVM build logs much less noisy.
+    if builder_type.os != 'windows':
+        definitions['CMAKE_CXX_FLAGS'] = '-Wno-psabi'
 
     if builder_type.arch == 'arm' and builder_type.bits == 32 and builder_type.os == 'linux':
         # LLVM doesn't provide a toolchain file, and we can't/don't-want-to rely on the

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -102,13 +102,13 @@ HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(12
 # Can use Python 3.7 dataclasses instead, if we choose to upgrade to that.
 WorkerConfig = namedtuple('WorkerConfig', ['max_builds', 'j', 'arch', 'bits', 'os'])
 
+# Using nproc+2 on the arm32 builds causes internal errors in gcc-armeabihf. Let's just use nproc.
+_NPROC = Interpolate("%(worker:numcpus)s")
+
 # For machines with max_builds=1, using nproc+2 cores for building is the conventional choice
 # (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which
 # is definitely not what we want.
-_NPROC_PLUS_2 = Transform(lambda x: f'{int(x)+2}', Interpolate("%(worker:numcpus)s"))
-
-# Using nproc+2 on the arm32 builds causes internal errors in gcc-armeabihf. Let's just use nproc.
-_NPROC = Interpolate("%(worker:numcpus)s")
+_NPROC_PLUS_2 = Transform(lambda x: f'{int(x)+2}', _NPROC)
 
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -634,13 +634,6 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Mips;Hexagon;PowerPC;WebAssembly',
     }
 
-    # Some versions of GCC will flood the output with useless warnings about
-    # "parameter passing for argument of type foo changed in GCC 7.1" unless
-    # we disable this warning. This isn't *essential*, but it makes looking at the
-    # LLVM build logs much less noisy.
-    if builder_type.os != 'windows':
-        definitions['CMAKE_CXX_FLAGS'] = '-Wno-psabi'
-
     if builder_type.arch == 'arm' and builder_type.bits == 32 and builder_type.os == 'linux':
         # LLVM doesn't provide a toolchain file, and we can't/don't-want-to rely on the
         # one from Halide, so we'll rely on one that the buildbot downloads to each worker.


### PR DESCRIPTION
the gcc-armeabihf compiler is crashing during LLVM builds; the increase in task usage is the only likely recent change, so let's crank this down on the assumption that this is too much parallel work for these systems to deal with