### PR TITLE
Update paths for halide/Halide#5976

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -906,10 +906,10 @@ def add_halide_cmake_package_steps(factory, builder_type):
             arch = 'ARM' if builder_type.bits == 32 else 'ARM64'
         else:
             arch = 'Win32' if builder_type.bits == 32 else 'x64'
-        cmd = [get_halide_source_path('tools/package-windows.bat'), source_dir, build_dir, arch]
+        cmd = [get_halide_source_path('packaging/zip/package.bat'), source_dir, build_dir, arch]
     else:
         build_dir = get_halide_build_path()
-        cmd = [get_halide_source_path('tools/package-unix.sh'), source_dir, build_dir]
+        cmd = [get_halide_source_path('packaging/tgz/package.sh'), source_dir, build_dir]
 
     factory.addStep(
         ShellCommand(name='Package Halide',


### PR DESCRIPTION
halide/Halide#5976 changes the paths to the package scripts from `tools/package-{unix,windows}.{sh,bat}` to `packaging/{tgz,zip}/package.{sh,bat}`. This calls the right scripts after the change.