### PR TITLE
Dramatically cut down Make testing

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1185,7 +1185,7 @@ def create_halide_make_factory(builder_type):
                                     dir=build_dir))
 
     target_label_pairs = [('host', 'build_tests')]
-    for halide_target, labels_for_target in get_test_labels(builder_type):
+    for halide_target, labels_for_target in get_test_labels(builder_type).items():
 
         # For Make we skip every target that isn't plain 'host'
         if halide_target != 'host':

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1184,38 +1184,16 @@ def create_halide_make_factory(builder_type):
                                     locks=[performance_lock.access('counting')],
                                     dir=build_dir))
 
-    targets = [('build_tests', 'host')]
+    target_label_pairs = [('host', 'build_tests')]
+    for halide_target, labels_for_target in get_test_labels(builder_type):
 
-    labels = get_test_labels(builder_type)
-
-    # We don't test apps/hannk with the Makefile, only with CMake
-    if 'hannk' in labels:
-        labels.remove('hannk')
-
-    for halide_target in list(labels.keys()):
-
-        # We deliberately skip some tests under Make, if it is highly
-        # likely to be redundant to testing done under CMake.
-        _features_to_skip = [
-            # wasm only builds under CMake
-            "wasm",
-            # GPU tests are also done under CMake and are unlikely to differ here
-            "cuda",
-            "d3d12compute",
-            "metal",
-            "opencl",
-            # HVX tests are also done under CMake and are unlikely to differ here
-            "hvx"
-        ]
-
-        if any([f in halide_target for f in _features_to_skip]):
+        # For Make we skip every target that isn't plain 'host'
+        if halide_target != 'host':
             continue
 
+        # performance requires exclusive machine access and isn't worth it for Make
         _labels_to_skip = [
-            "error",
             "performance",
-            "tutorial",
-            "warning",
         ]
         if not builder_type.handles_python():
             _labels_to_skip += [
@@ -1224,29 +1202,29 @@ def create_halide_make_factory(builder_type):
                 'apps'
             ]
 
-        for label in labels[halide_target]:
-            if any([L in label for L in _labels_to_skip]):
+        for label in labels_for_target:
+            if label in _labels_to_skip:
                 continue
-            targets.append((label, halide_target))
+            target_label_pairs.append((halide_target, label))
 
-    for (target, halide_target) in targets:
+    for halide_target, label in target_label_pairs:
         env = extend_property('env',
                               LLVM_CONFIG=get_llvm_install_path(builder_type, 'bin/llvm-config'),
                               HL_TARGET=halide_target,
                               HL_JIT_TARGET=halide_target)
 
-        if is_time_critical_test(target):
+        if is_time_critical_test(label):
             p = 1
             lock_mode = 'exclusive'
         else:
             p = make_threads
             lock_mode = 'counting'
 
-        if target != 'build_tests':
-            target = 'test_%s' % target
+        if label != 'build_tests':
+            label = 'test_%s' % label
 
-        factory.addStep(ShellCommand(name='make ' + target,
-                                     description=target + ' ' + halide_target,
+        factory.addStep(ShellCommand(name='make ' + label,
+                                     description=label + ' ' + halide_target,
                                      locks=[performance_lock.access(lock_mode)],
                                      workdir=build_dir,
                                      env=env,
@@ -1254,7 +1232,7 @@ def create_halide_make_factory(builder_type):
                                      command=['make',
                                               '-f', get_halide_source_path('Makefile'),
                                               '-j', p,
-                                              target],
+                                              label],
                                      timeout=3600))
     return factory
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1194,28 +1194,39 @@ def create_halide_make_factory(builder_type):
 
     for halide_target in list(labels.keys()):
 
-        # Make can't build/test WebAssembly via Make (only via CMake)
-        if "wasm" in halide_target:
+        # We deliberately skip some tests under Make, if it is highly
+        # likely to be redundant to testing done under CMake.
+        _features_to_skip = [
+            # wasm only builds under CMake
+            "wasm",
+            # GPU tests are also done under CMake and are unlikely to differ here
+            "cuda",
+            "d3d12compute",
+            "metal",
+            "opencl",
+            # HVX tests are also done under CMake and are unlikely to differ here
+            "hvx"
+        ]
+
+        if any([f in halide_target for f in _features_to_skip]):
             continue
 
-        for label in labels[halide_target]:
-            if not builder_type.handles_python():
-                if 'python' in label:
-                    continue
+        _labels_to_skip = [
+            "error",
+            "performance",
+            "tutorial",
+            "warning",
+        ]
+        if not builder_type.handles_python():
+            _labels_to_skip += [
+                'python',
                 # TODO: some of the apps require python, so we must skip them for now also
-                if 'apps' in label:
-                    continue
+                'apps'
+            ]
 
-            if builder_type.arch == 'arm' or builder_type.bits == 32:
-                # TODO: disable test_tutorial on arm and 32-bit builds as well
-                # (we really only need to disable lessons 12 & 19
-                # but the Makefile doesn't allow for that granularity)
-                #
-                # https://github.com/halide/Halide/issues/5144
-                # https://github.com/halide/Halide/issues/5224
-                if 'tutorial' in label:
-                    continue
-
+        for label in labels[halide_target]:
+            if any([L in label for L in _labels_to_skip]):
+                continue
             targets.append((label, halide_target))
 
     for (target, halide_target) in targets:


### PR DESCRIPTION
Avoid redundant testing for Make builds, on the assumption that CMake handles most of them:
- Skip all GPU and HVX testing
- Skip the error, warning, performance, and tutorials (basically, just correctness and generator)
- Continue to skip python & apps where we used to
- Continue to skip wasm for Make entirely