### PR TITLE
Add branch information for Halide 12.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -257,10 +257,10 @@ class BuilderType:
             assert self.purpose != Purpose.llvm_nightly
             assert self.halide_branch in HALIDE_BRANCHES, f'unknown branch {self.halide_branch}'
             assert (self.purpose == Purpose.halide_testbranch or  # if not testbranch...
-                    HALIDE_BRANCHES[self.halide_branch].version.major == \
+                    HALIDE_BRANCHES[self.halide_branch].version.major ==
                     LLVM_BRANCHES[self.llvm_branch].version.major or
-                    (HALIDE_BRANCHES[self.halide_branch].version.major == 12 and \
-                     LLVM_BRANCHES[self.llvm_branch].version.major == 13))  # TODO: yuck
+                    (HALIDE_BRANCHES[self.halide_branch].version.major == 13 and
+                     LLVM_BRANCHES[self.llvm_branch].version.major == 14))  # TODO: yuck
         else:
             assert self.purpose == Purpose.llvm_nightly
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -88,14 +88,28 @@ LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(13, 0, 0
 # (Note that there is a 'release/8.x' branch of Halide but we are going to ignore it here.)
 
 HALIDE_MAIN = 'main'
+HALIDE_RELEASE_12 = 'release_12'
 HALIDE_RELEASE_11 = 'release_11'
 HALIDE_RELEASE_10 = 'release_10'
 
-_HALIDE_RELEASES = [HALIDE_RELEASE_11, HALIDE_RELEASE_10]
+_HALIDE_RELEASES = [HALIDE_RELEASE_12, HALIDE_RELEASE_11, HALIDE_RELEASE_10]
 
-HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(12, 0, 0)),
-                   HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 0)),
+HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(13, 0, 0)),
+                   HALIDE_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
+                   HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
                    HALIDE_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
+
+
+def llvm_branches_for_halide_branch(halide_branch):
+    # Given a halide branch, return the 'native' llvm version we expect to use with it.
+    # For halide release branches, this is the corresponding llvm release branch; for
+    # halide main, it's llvm main.
+    # TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_12, for now anyway
+    return {HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_12],
+            HALIDE_RELEASE_12: [LLVM_RELEASE_12],
+            HALIDE_RELEASE_11: [LLVM_RELEASE_11],
+            HALIDE_RELEASE_10: [HALIDE_RELEASE_10]}.get(halide_branch)
+
 
 # WORKERS
 
@@ -108,7 +122,7 @@ _NPROC = Interpolate("%(worker:numcpus)s")
 # For machines with max_builds=1, using nproc+2 cores for building is the conventional choice
 # (and what ninja defaults to). Oddly, "ninja -j 0" means "use as many threads as you like" which
 # is definitely not what we want.
-_NPROC_PLUS_2 = Transform(lambda x: f'{int(x)+2}', _NPROC)
+_NPROC_PLUS_2 = Transform(lambda x: f'{int(x) + 2}', _NPROC)
 
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
@@ -1286,16 +1300,6 @@ def create_halide_builder(arch, bits, os, halide_branch, llvm_branch, purpose, b
                             tags=builder_type.builder_tags())
     builder.builder_type = builder_type
     return builder
-
-
-def llvm_branches_for_halide_branch(halide_branch):
-    # Given a halide branch, return the 'native' llvm version we expect to use with it.
-    # For halide release branches, this is the corresponding llvm release branch; for
-    # halide main, it's llvm main.
-    # TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_12, for now anyway
-    return {HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_12],
-            HALIDE_RELEASE_11: [LLVM_RELEASE_11],
-            HALIDE_RELEASE_10: [HALIDE_RELEASE_10]}.get(halide_branch)
 
 
 def create_halide_builders():

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -257,7 +257,7 @@ class BuilderType:
             assert self.purpose != Purpose.llvm_nightly
             assert self.halide_branch in HALIDE_BRANCHES, f'unknown branch {self.halide_branch}'
             assert (self.purpose == Purpose.halide_testbranch or  # if not testbranch...
-                    self.llvm_branch in LLVM_FOR_HALIDE[self.halide_branch])  # TODO: yuck
+                    self.llvm_branch in LLVM_FOR_HALIDE[self.halide_branch])
         else:
             assert self.purpose == Purpose.llvm_nightly
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -257,10 +257,7 @@ class BuilderType:
             assert self.purpose != Purpose.llvm_nightly
             assert self.halide_branch in HALIDE_BRANCHES, f'unknown branch {self.halide_branch}'
             assert (self.purpose == Purpose.halide_testbranch or  # if not testbranch...
-                    HALIDE_BRANCHES[self.halide_branch].version.major ==
-                    LLVM_BRANCHES[self.llvm_branch].version.major or
-                    (HALIDE_BRANCHES[self.halide_branch].version.major == 13 and
-                     LLVM_BRANCHES[self.llvm_branch].version.major == 14))  # TODO: yuck
+                    self.llvm_branch in LLVM_FOR_HALIDE[self.halide_branch])  # TODO: yuck
         else:
             assert self.purpose == Purpose.llvm_nightly
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -99,17 +99,16 @@ HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(13
                    HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
                    HALIDE_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
 
-
-def llvm_branches_for_halide_branch(halide_branch):
-    # Given a halide branch, return the 'native' llvm version we expect to use with it.
-    # For halide release branches, this is the corresponding llvm release branch; for
-    # halide main, it's llvm main.
-    # TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_12, for now anyway
-    return {HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_12],
-            HALIDE_RELEASE_12: [LLVM_RELEASE_12],
-            HALIDE_RELEASE_11: [LLVM_RELEASE_11],
-            HALIDE_RELEASE_10: [HALIDE_RELEASE_10]}.get(halide_branch)
-
+# Given a halide branch, return the 'native' llvm version we expect to use with it.
+# For halide release branches, this is the corresponding llvm release branch; for
+# halide main, it's llvm main.
+# TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_12, for now anyway
+LLVM_FOR_HALIDE = {
+    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_12],
+    HALIDE_RELEASE_12: [LLVM_RELEASE_12],
+    HALIDE_RELEASE_11: [LLVM_RELEASE_11],
+    HALIDE_RELEASE_10: [HALIDE_RELEASE_10]
+}
 
 # WORKERS
 
@@ -1307,12 +1306,12 @@ def create_halide_builders():
         # Create builders for build + package of Halide master + release branches
         # (but only against their 'native' LLVM versions)
         for halide_branch in HALIDE_BRANCHES:
-            for llvm_branch in llvm_branches_for_halide_branch(halide_branch):
+            for llvm_branch in LLVM_FOR_HALIDE[halide_branch]:
                 yield create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_main)
 
         # Create the builders for testing pull requests to releases.
         for halide_branch in _HALIDE_RELEASES:
-            for llvm_branch in llvm_branches_for_halide_branch(halide_branch):
+            for llvm_branch in LLVM_FOR_HALIDE[halide_branch]:
                 yield create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_testbranch)
 
         # Create the builders for testing pull requests to main.


### PR DESCRIPTION
Also replace LLVM-for-Halide function that was just a dictionary lookup with a global dictionary defined closer to the rest of the Halide branch information