### PR TITLE
Pass arm32 toolchain when packaging for arm-32-linux

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -898,11 +898,12 @@ def add_halide_cmake_package_steps(factory, builder_type):
             workdir=get_halide_build_path(),
             props=['CMAKE_PROJECT_VERSION']))
 
-    env = extend_property('env',
-                          Clang_DIR=get_llvm_install_path(builder_type, 'lib/cmake/clang'),
-                          LLD_DIR=get_llvm_install_path(builder_type, 'lib/cmake/lld'),
-                          LLVM_DIR=get_llvm_install_path(builder_type, 'lib/cmake/llvm'),
-                          Halide_VERSION=Property('CMAKE_PROJECT_VERSION'))
+    extra_env = dict(
+        Clang_DIR=get_llvm_install_path(builder_type, 'lib/cmake/clang'),
+        LLD_DIR=get_llvm_install_path(builder_type, 'lib/cmake/lld'),
+        LLVM_DIR=get_llvm_install_path(builder_type, 'lib/cmake/llvm'),
+        Halide_VERSION=Property('CMAKE_PROJECT_VERSION')
+    )
 
     if builder_type.os == 'windows':
         # TODO: on Windows, we can't use Ninja for packaging (as we do everywhere
@@ -920,12 +921,14 @@ def add_halide_cmake_package_steps(factory, builder_type):
     else:
         build_dir = get_halide_build_path()
         cmd = [get_halide_source_path('packaging/tgz/package.sh'), source_dir, build_dir]
+        if builder_type.arch == 'arm' and builder_type.bits == 32 and builder_type.os == 'linux':
+            extra_env['CMAKE_TOOLCHAIN_FILE'] = get_halide_source_path('cmake', 'toolchain.linux-arm32.cmake')
 
     factory.addStep(
         ShellCommand(name='Package Halide',
                      description='Package Halide',
                      workdir=build_dir,
-                     env=env,
+                     env=extend_property('env', **extra_env),
                      locks=[performance_lock.access('counting')],
                      haltOnFailure=True,
                      command=cmd))


### PR DESCRIPTION
Passes `CMAKE_TOOLCHAIN_FILE` to `tgz/package.sh` on arm-32-linux. Depends on halide/Halide#6048