### PR TITLE
Update buildbot for LLVM main == v14

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -67,6 +67,7 @@ Version = namedtuple('Version', ['major', 'minor', 'patch'])
 VersionedBranch = namedtuple('VersionedBranch', ['ref', 'version'])
 
 LLVM_MAIN = 'main'
+LLVM_RELEASE_13 = 'release_13'
 LLVM_RELEASE_12 = 'release_12'
 LLVM_RELEASE_11 = 'release_11'
 LLVM_RELEASE_10 = 'release_10'

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -71,7 +71,8 @@ LLVM_RELEASE_12 = 'release_12'
 LLVM_RELEASE_11 = 'release_11'
 LLVM_RELEASE_10 = 'release_10'
 
-LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(13, 0, 0)),
+LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(14, 0, 0)),
+                 LLVM_RELEASE_13: VersionedBranch(ref='release/13.x', version=Version(13, 0, 0)),
                  LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
                  LLVM_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
                  LLVM_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
@@ -88,12 +89,14 @@ LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(13, 0, 0
 # (Note that there is a 'release/8.x' branch of Halide but we are going to ignore it here.)
 
 HALIDE_MAIN = 'main'
+HALIDE_RELEASE_13 = 'release_13'
 HALIDE_RELEASE_12 = 'release_12'
 HALIDE_RELEASE_11 = 'release_11'
 HALIDE_RELEASE_10 = 'release_10'
 
 _HALIDE_RELEASES = [HALIDE_RELEASE_12, HALIDE_RELEASE_11, HALIDE_RELEASE_10]
 
+# TODO: HALIDE_MAIN is currently being built against LLVM main (aka 14), but should switch to LLVM13 soon.
 HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(13, 0, 0)),
                    HALIDE_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
                    HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
@@ -102,12 +105,12 @@ HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(13
 # Given a halide branch, return the 'native' llvm version we expect to use with it.
 # For halide release branches, this is the corresponding llvm release branch; for
 # halide main, it's llvm main.
-# TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_12, for now anyway
+# TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_13 + LLVM_RELEASE_12, for now anyway
 LLVM_FOR_HALIDE = {
-    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_12],
+    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_13, LLVM_RELEASE_12],
     HALIDE_RELEASE_12: [LLVM_RELEASE_12],
     HALIDE_RELEASE_11: [LLVM_RELEASE_11],
-    HALIDE_RELEASE_10: [HALIDE_RELEASE_10]
+    HALIDE_RELEASE_10: [LLVM_RELEASE_10]
 }
 
 # WORKERS
@@ -1481,11 +1484,11 @@ def prioritize_builders(buildmaster, builders):
         # releases. We care most about the most recently-released llvm so
         # that we have a full set of builds for releases, then llvm main
         # for bisection, then older llvm versions.
-        if builder_type.llvm_branch == LLVM_RELEASE_11:
+        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_11]:
             return 2
-        if builder_type.llvm_branch == LLVM_MAIN or builder_type.llvm_branch == LLVM_RELEASE_12:
+        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_MAIN]:
             return 3
-        if builder_type.llvm_branch == LLVM_RELEASE_10:
+        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_10]:
             return 4
         return 5
 


### PR DESCRIPTION
- Add LLVM_RELEASE_13, change LLVM_MAIN -> main
- Add HALIDE_RELEASE_13 and add it to the HALIDE_MAIN test matrix
- minor drive-by cleanups