### PR TITLE
Update Halide 12 to use LLVM 12.0.1

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -74,7 +74,7 @@ LLVM_RELEASE_10 = 'release_10'
 
 LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(14, 0, 0)),
                  LLVM_RELEASE_13: VersionedBranch(ref='release/13.x', version=Version(13, 0, 0)),
-                 LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
+                 LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 1)),
                  LLVM_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
                  LLVM_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
 
@@ -99,7 +99,7 @@ _HALIDE_RELEASES = [HALIDE_RELEASE_12, HALIDE_RELEASE_11, HALIDE_RELEASE_10]
 
 # TODO: HALIDE_MAIN is currently being built against LLVM main (aka 14), but should switch to LLVM13 soon.
 HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(13, 0, 0)),
-                   HALIDE_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
+                   HALIDE_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 1)),
                    HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
                    HALIDE_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
 


### PR DESCRIPTION
LLVM 12.0.1 was released in July 2021