### PR TITLE
Drop support for Halide 10 / LLVM 10

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -70,13 +70,11 @@ LLVM_MAIN = 'main'
 LLVM_RELEASE_13 = 'release_13'
 LLVM_RELEASE_12 = 'release_12'
 LLVM_RELEASE_11 = 'release_11'
-LLVM_RELEASE_10 = 'release_10'
 
 LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(14, 0, 0)),
                  LLVM_RELEASE_13: VersionedBranch(ref='release/13.x', version=Version(13, 0, 0)),
                  LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
-                 LLVM_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
-                 LLVM_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
+                 LLVM_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1))}
 
 # At any given time, Halide has a main branch, which supports (at least)
 # the LLVM main branch and the most recent release branch (and maybe one older).
@@ -87,21 +85,19 @@ LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(14, 0, 0
 #
 # Note that we deliberately chose branch names that match LLVM's conventions.
 #
-# (Note that there is a 'release/8.x' branch of Halide but we are going to ignore it here.)
+# (Note that there are older releases of Halide that we no longer bother to build/test regularly.)
 
 HALIDE_MAIN = 'main'
 HALIDE_RELEASE_13 = 'release_13'
 HALIDE_RELEASE_12 = 'release_12'
 HALIDE_RELEASE_11 = 'release_11'
-HALIDE_RELEASE_10 = 'release_10'
 
-_HALIDE_RELEASES = [HALIDE_RELEASE_12, HALIDE_RELEASE_11, HALIDE_RELEASE_10]
+_HALIDE_RELEASES = [HALIDE_RELEASE_12, HALIDE_RELEASE_11]
 
 # TODO: HALIDE_MAIN is currently being built against LLVM main (aka 14), but should switch to LLVM13 soon.
 HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(13, 0, 0)),
                    HALIDE_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 0)),
-                   HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1)),
-                   HALIDE_RELEASE_10: VersionedBranch(ref='release/10.x', version=Version(10, 0, 1))}
+                   HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1))}
 
 # Given a halide branch, return the 'native' llvm version we expect to use with it.
 # For halide release branches, this is the corresponding llvm release branch; for
@@ -111,7 +107,6 @@ LLVM_FOR_HALIDE = {
     HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_13, LLVM_RELEASE_12],
     HALIDE_RELEASE_12: [LLVM_RELEASE_12],
     HALIDE_RELEASE_11: [LLVM_RELEASE_11],
-    HALIDE_RELEASE_10: [LLVM_RELEASE_10]
 }
 
 # WORKERS
@@ -395,44 +390,13 @@ def add_get_halide_source_steps(factory, builder_type):
 
 
 def add_get_llvm_source_steps(factory, builder_type):
-    # LLVM 10 is broken under MSVC 16.7.x as of October 2020.
-    # Until a fix is backported, use the same grotesque hack that MS itself
-    # is using for vcpkg: https://github.com/microsoft/vcpkg/pull/12884
-    if builder_type.llvm_branch == LLVM_RELEASE_10 and builder_type.os == 'windows':
-        # The Git() step will include a `git reset --hard HEAD`,
-        # which means this file is reverted and re-patched every time,
-        # meaning we have to recompile (essentially) all of LLVM since
-        # the timestamp on this one file gets touched. Since this is an awful
-        # (and hopefully temporary) hack anyway, we'll just do our own thing for
-        # this case...
-        factory.addStep(ShellCommand(
-            name='Get LLVM 10 (special)',
-            locks=[performance_lock.access('counting')],
-            haltOnFailure=True,
-            workdir=get_llvm_source_path(),
-            command="git fetch -t https://github.com/llvm/llvm-project.git release/10.x --progress && " +
-                    "git checkout -B release/10.x"))
-
-        type_traits_h = 'llvm/include/llvm/Support/type_traits.h'
-        factory.addStep(ShellCommand(
-            name='Patch LLVM 10',
-            locks=[performance_lock.access('counting')],
-            haltOnFailure=True,
-            workdir=get_llvm_source_path(),
-            # - Emit as a string (rather than array) to avoid Buildbot escaping issues.
-            # - Use `grep && sed` approach to avoid sed changing the
-            # timestamp on an already-patched file.
-            command=f"grep HAVE_STD_IS_TRIVIALLY_COPYABLE {type_traits_h} && " +
-                    f"sed -i 's/#ifdef HAVE_STD_IS_TRIVIALLY_COPYABLE/#if 0/g' {type_traits_h} || " +
-                    "true"))
-    else:
-        factory.addStep(Git(name=f'Get LLVM {LLVM_BRANCHES[builder_type.llvm_branch].version.major}',
-                            locks=[performance_lock.access('counting')],
-                            codebase='llvm',
-                            workdir=get_llvm_source_path(),
-                            repourl='https://github.com/llvm/llvm-project.git',
-                            branch=LLVM_BRANCHES[builder_type.llvm_branch].ref,
-                            mode='incremental'))
+    factory.addStep(Git(name=f'Get LLVM {LLVM_BRANCHES[builder_type.llvm_branch].version.major}',
+                        locks=[performance_lock.access('counting')],
+                        codebase='llvm',
+                        workdir=get_llvm_source_path(),
+                        repourl='https://github.com/llvm/llvm-project.git',
+                        branch=LLVM_BRANCHES[builder_type.llvm_branch].ref,
+                        mode='incremental'))
 
     # Always download the toolchains, even on platforms we don't need 'em
     toolchains_dir = get_llvm_toolchains_path()
@@ -1489,8 +1453,7 @@ def prioritize_builders(buildmaster, builders):
             return 2
         if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_MAIN]:
             return 3
-        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_10]:
-            return 4
+        # For older releases, return 4
         return 5
 
     return list(sorted(builders, key=importance))

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1453,8 +1453,7 @@ def prioritize_builders(buildmaster, builders):
             return 2
         if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_MAIN]:
             return 3
-        # For older releases, return 4
-        return 5
+        return 4
 
     return list(sorted(builders, key=importance))
 


### PR DESCRIPTION
We don't want to have the buildbots have to build/test every legacy branch of Halide ever, so let's start now, dropping support for Halide 10 / LLVM 10.