### PR TITLE
Define NODE_JS_EXECUTABLE based on an env var

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -711,7 +711,10 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
     # TODO: HALIDE_NODE_JS_PATH is only necessary until EMSDK updates their built-in version of Node
     # to v16.13+; when that is done, remove HALIDE_NODE_JS_PATH here and on the workers.
     factory.addStep(SetPropertiesFromEnv(name='Read worker environment',
-                                         variables=['VCPKG_ROOT', 'LD_LIBRARY_PATH', 'HL_HEXAGON_TOOLS', 'HALIDE_NODE_JS_PATH']))
+                                         variables=['VCPKG_ROOT',
+                                                    'LD_LIBRARY_PATH',
+                                                    'HL_HEXAGON_TOOLS',
+                                                    'HALIDE_NODE_JS_PATH']))
 
     vcpkg_root = Property('VCPKG_ROOT', default=None)
 


### PR DESCRIPTION
This is necessary for https://github.com/halide/Halide/pull/6356 to land -- if we are building/testing wasm, we need to set NODE_JS_EXECUTABLE properly; this patch does so based on an env var ('HALIDE_NODE_JS_PATH') which is assumed to be defined on the relevant wokers.