### PR TITLE
Run test/performance on GPU/DSP targets

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -937,6 +937,21 @@ def add_halide_cmake_package_steps(factory, builder_type):
         groupfn=pkg_version_and_target))
 
 
+# Figure out which "non-cpu" (GPU, DSP, etc) targets this builder can handle.
+def get_gpu_dsp_targets(builder_type):
+    if builder_type.has_nvidia():
+        yield 'host-cuda'
+        yield 'host-opencl'
+        if builder_type.os == 'windows':
+            yield 'host-d3d12compute'
+
+    if builder_type.os == 'osx':
+        yield 'host-metal'
+
+    if builder_type.handles_hexagon():
+        yield 'host-hvx'
+
+
 # Return a dict with halide-targets as the keys, and a list of test-labels for each value.
 def get_test_labels(builder_type):
     targets = defaultdict(list)
@@ -961,20 +976,13 @@ def get_test_labels(builder_type):
         if builder_type.bits == 64:
             targets['%s-sse41' % t].extend(['correctness'])
 
+    # Test a subset of things on GPU/DSP targets, as appropriate
+    for t in get_gpu_dsp_targets(builder_type):
+        targets[t].extend(['correctness', 'generator', 'apps', 'performance'])
+
+    # Handle this special case separately
     if builder_type.has_nvidia():
-        targets['host-cuda'].extend(['correctness', 'generator', 'apps'])
-        targets['host-opencl'].extend(['correctness', 'generator', 'apps'])
         targets['host-cuda-opencl'].extend(['correctness_multi_gpu'])
-        if builder_type.os == 'windows':
-            targets['host-d3d12compute'].extend(['correctness', 'generator', 'apps'])
-
-    if builder_type.os == 'osx':
-        # test metal on OS X
-        targets['host-metal'].extend(['correctness', 'generator', 'apps'])
-
-    if builder_type.handles_hexagon():
-        # Also test hexagon using the simulator
-        targets['host-hvx'].extend(['correctness', 'generator', 'apps'])
 
     if builder_type.handles_wasm():
         targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int'].extend(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -938,18 +938,21 @@ def add_halide_cmake_package_steps(factory, builder_type):
 
 
 # Figure out which "non-cpu" (GPU, DSP, etc) targets this builder can handle.
+# Return (target, is_simulator)
 def get_gpu_dsp_targets(builder_type):
     if builder_type.has_nvidia():
-        yield 'host-cuda'
-        yield 'host-opencl'
+        yield 'host-cuda', false
+        yield 'host-opencl', false
         if builder_type.os == 'windows':
-            yield 'host-d3d12compute'
+            yield 'host-d3d12compute', false
 
     if builder_type.os == 'osx':
-        yield 'host-metal'
+        yield 'host-metal', false
 
     if builder_type.handles_hexagon():
-        yield 'host-hvx'
+        # All the buildbots use a simulator for HVX, so performance tests
+        # won't be useful
+        yield 'host-hvx', true
 
 
 # Return a dict with halide-targets as the keys, and a list of test-labels for each value.
@@ -977,8 +980,11 @@ def get_test_labels(builder_type):
             targets['%s-sse41' % t].extend(['correctness'])
 
     # Test a subset of things on GPU/DSP targets, as appropriate
-    for t in get_gpu_dsp_targets(builder_type):
-        targets[t].extend(['correctness', 'generator', 'apps', 'performance'])
+    for t, is_simulator in get_gpu_dsp_targets(builder_type):
+        targets[t].extend(['correctness', 'generator', 'apps'])
+        # Don't do performance testing on simulators.
+        if not is_simulator:
+            targets[t].extend(['performance'])
 
     # Handle this special case separately
     if builder_type.has_nvidia():

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -941,18 +941,18 @@ def add_halide_cmake_package_steps(factory, builder_type):
 # Return (target, is_simulator)
 def get_gpu_dsp_targets(builder_type):
     if builder_type.has_nvidia():
-        yield 'host-cuda', false
-        yield 'host-opencl', false
+        yield 'host-cuda', False
+        yield 'host-opencl', False
         if builder_type.os == 'windows':
-            yield 'host-d3d12compute', false
+            yield 'host-d3d12compute', False
 
     if builder_type.os == 'osx':
-        yield 'host-metal', false
+        yield 'host-metal', False
 
     if builder_type.handles_hexagon():
         # All the buildbots use a simulator for HVX, so performance tests
         # won't be useful
-        yield 'host-hvx', true
+        yield 'host-hvx', True
 
 
 # Return a dict with halide-targets as the keys, and a list of test-labels for each value.


### PR DESCRIPTION
With obligatory drive-by code cleanup.

Note that this will likely slow down test throughput by some extent, due to the additional locking used for performance testing. This may or may not be significant, but IMHO we should try it and see, rather than skip the performance testing. See https://github.com/halide/Halide/issues/6451.