### PR TITLE
Bump version to 13.0.4

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -100,7 +100,7 @@ _HALIDE_RELEASES = [
 
 # TODO: HALIDE_MAIN is currently being built against LLVM main (aka 14), but should switch to LLVM13 soon.
 HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(14, 0, 0)),
-                   HALIDE_RELEASE_13: VersionedBranch(ref='release/13.x', version=Version(13, 0, 1)),
+                   HALIDE_RELEASE_13: VersionedBranch(ref='release/13.x', version=Version(13, 0, 4)),
                    HALIDE_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 1)),
                    HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1))}
 


### PR DESCRIPTION
Depends on https://github.com/halide/Halide/pull/6571. The existing version seems to be stale, so I'm not 100% sure this is the right thing.