### PR TITLE
Update LLVM builds/versions

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -67,21 +67,21 @@ Version = namedtuple('Version', ['major', 'minor', 'patch'])
 VersionedBranch = namedtuple('VersionedBranch', ['ref', 'version'])
 
 LLVM_MAIN = 'main'
+LLVM_RELEASE_14 = 'release_14'
 LLVM_RELEASE_13 = 'release_13'
 LLVM_RELEASE_12 = 'release_12'
-LLVM_RELEASE_11 = 'release_11'
 
-LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(14, 0, 0)),
+LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(15, 0, 0)),
+                 LLVM_RELEASE_14: VersionedBranch(ref='release/14.x', version=Version(14, 0, 0)),
                  LLVM_RELEASE_13: VersionedBranch(ref='release/13.x', version=Version(13, 0, 0)),
-                 LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 1)),
-                 LLVM_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1))}
+                 LLVM_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 1))}
 
 # At any given time, Halide has a main branch, which supports (at least)
 # the LLVM main branch and the most recent release branch (and maybe one older).
 #
 # We also support previous release branches; a release branch tracks *only* the
-# corresponding version of LLVM (i.e., Halide 11 is 'release/11.x' and is only
-# built/tested against LLVM11, even though it might still work with other LLVM versions).
+# corresponding version of LLVM (i.e., Halide 13 is 'release/13.x' and is only
+# built/tested against LLVM13, even though it might still work with other LLVM versions).
 #
 # Note that we deliberately chose branch names that match LLVM's conventions.
 #
@@ -90,29 +90,28 @@ LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(14, 0, 0
 HALIDE_MAIN = 'main'
 HALIDE_RELEASE_13 = 'release_13'
 HALIDE_RELEASE_12 = 'release_12'
-HALIDE_RELEASE_11 = 'release_11'
 
 _HALIDE_RELEASES = [
     HALIDE_RELEASE_13,
     HALIDE_RELEASE_12,
-    HALIDE_RELEASE_11,
 ]
 
-# TODO: HALIDE_MAIN is currently being built against LLVM main (aka 14), but should switch to LLVM13 soon.
+# TODO: Halide main is still v14 for now
 HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='master', version=Version(14, 0, 0)),
+                   # TODO: enable soon
+                   # HALIDE_RELEASE_14: VersionedBranch(ref='release/14.x', version=Version(14, 0, 0)),
                    HALIDE_RELEASE_13: VersionedBranch(ref='release/13.x', version=Version(13, 0, 4)),
-                   HALIDE_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 1)),
-                   HALIDE_RELEASE_11: VersionedBranch(ref='release/11.x', version=Version(11, 0, 1))}
+                   HALIDE_RELEASE_12: VersionedBranch(ref='release/12.x', version=Version(12, 0, 1))}
 
 # Given a halide branch, return the 'native' llvm version we expect to use with it.
 # For halide release branches, this is the corresponding llvm release branch; for
 # halide main, it's llvm main.
-# TODO: HALIDE_MAIN needs to test against LLVM_MAIN and also LLVM_RELEASE_13 + LLVM_RELEASE_12, for now anyway
 LLVM_FOR_HALIDE = {
-    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_13, LLVM_RELEASE_12],
+    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_14],
+    # TODO: enable soon
+    # HALIDE_RELEASE_14: [LLVM_RELEASE_14],
     HALIDE_RELEASE_13: [LLVM_RELEASE_13],
     HALIDE_RELEASE_12: [LLVM_RELEASE_12],
-    HALIDE_RELEASE_11: [LLVM_RELEASE_11],
 }
 
 # WORKERS
@@ -1505,7 +1504,7 @@ def prioritize_builders(buildmaster, builders):
         # releases. We care most about the most recently-released llvm so
         # that we have a full set of builds for releases, then llvm main
         # for bisection, then older llvm versions.
-        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_11]:
+        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_13]:
             return 2
         if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_MAIN]:
             return 3


### PR DESCRIPTION
LLVM top-of-tree is now 15, with 14rc1 under a new branch. So:
- Drop building of LLVM11 (and Halide 11) entirely
- Add LLVM 14 (main is now "15")
- Added placeholders for Halide 14 branch, to be enabled once we create said branch

Do we need to continue building/testing either LLVM12 or Halide 12? We don't have a firm policy on this.