### PR TITLE
Truncate step names that are too long

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1064,7 +1064,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
             wasm_jit = 'wabt'
 
         factory.addStep(
-            CMake(name='Reconfigure for %s' % desc,
+            CMake(name='Reconfigure',
                   description='Reconfigure for %s' % desc,
                   locks=[performance_lock.access('counting')],
                   haltOnFailure=True,
@@ -1077,7 +1077,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
                   options=get_cmake_options(builder_type)))
 
         factory.addStep(
-            ShellCommand(name='Rebuild for %s' % desc,
+            ShellCommand(name='Rebuild',
                          description='Rebuild Halide for %s' % desc,
                          locks=[performance_lock.access('counting')],
                          haltOnFailure=True,
@@ -1124,7 +1124,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
                 exclude_tests.append('tutorial_lesson_19')
 
             factory.addStep(
-                CTest(name='Test %s %s' % (test_set, desc),
+                CTest(name='Test',
                       description='Test %s %s' % (test_set, desc),
                       locks=[performance_lock.access('counting')],
                       workdir=build_dir,


### PR DESCRIPTION
Apparently this can cause database corruption (!!)

See: https://github.com/buildbot/buildbot/pull/6443