### PR TITLE
Upgrade WinBots to use VC2022

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -468,7 +468,8 @@ def get_msvc_config_steps(factory, builder_type):
     vcvarsall = 'vcvarsall.bat %s && set' % arch_for_bits[builder_type.bits]
 
     # TODO: surely there is a better way of locating vcvarsall
-    vcvarsdir = "c:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build"
+    # vcvarsdir = "c:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build"
+    vcvarsdir = "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build"
 
     # `vsvarsall && set` dumps all the settings to stdout;
     # we'll extract & save just the subset we think are likely to be relevant.


### PR DESCRIPTION
VC2019 Free Edition is no longer downloadable, and WinBot3 had to be reimaged, so we're upgrading everyone!