### PR TITLE
Allows Windows machines to find pip-installed PyBind11

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -594,6 +594,8 @@ def get_halide_cmake_definitions(builder_type, halide_target='host', wasm_jit='w
 
     if builder_type.os == 'windows':
         cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = Interpolate('%(prop:VCPKG_ROOT)s/scripts/buildsystems/vcpkg.cmake')
+        # CMake on Windows can't reliably find our pip-installed PyBind11 unless we set CMAKE_PREFIX_PATH to point to is
+        cmake_definitions['pybind11_DIR'] = Interpolate('%(prop:VIRTUAL_ENV)s/share/cmake/pybind11')
 
     # TODO: HALIDE_NODE_JS_PATH is only necessary until EMSDK updates their built-in version of Node
     # to v16.13+; when that is done, remove this definition.
@@ -736,7 +738,8 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
                                          variables=['VCPKG_ROOT',
                                                     'LD_LIBRARY_PATH',
                                                     'HL_HEXAGON_TOOLS',
-                                                    'HALIDE_NODE_JS_PATH']))
+                                                    'HALIDE_NODE_JS_PATH'
+                                                    'VIRTUAL_ENV']))
 
     vcpkg_root = Property('VCPKG_ROOT', default=None)
 


### PR DESCRIPTION
This sets pybind11_DIR to $VIRTUAL_ENV/share/cmake/pybind11; in local testing this seems to heal the inability of Windows to find this reliably.