### PR TITLE
Re-enable some wasm testing, and add some short names

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1068,7 +1068,7 @@ def get_test_labels(builder_type):
         # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
         # so only test Generator here
         targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int-wasm_threads'].extend(
-            ['generator'])
+            ['generator', 'apps'])
 
     return targets
 
@@ -1122,7 +1122,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
             wasm_jit = 'wabt'
 
         factory.addStep(
-            CMake(name='Reconfigure',
+            CMake(name='Reconfigure for %s' % halide_target,
                   description='Reconfigure for %s' % desc,
                   locks=[performance_lock.access('counting')],
                   haltOnFailure=True,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1080,7 +1080,12 @@ def is_time_critical_test(test):
 
 def short_target(halide_target):
     s = halide_target.split('-')
-    return '%s-%s-%s…' % (s[0], s[1], s[3])
+    if len(s) == 1:
+        return s[0]
+    elif len(3) >= 3:
+        return '%s-%s-%s…' % (s[0], s[1], s[2])
+    else:
+        return '<unknown'
 
 def add_halide_cmake_test_steps(factory, builder_type):
     parallelism = Property('WORKER_BUILD_PARALLELISM')

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1083,10 +1083,14 @@ def short_target(halide_target):
     s = halide_target.split('-')
     if len(s) == 1:
         return s[0]
-    elif len(s) >= 3:
+    elif len(s) == 2:
+        return '%s-%s' % (s[0], s[1])
+    elif len(s) == 3:
+        return '%s-%s-%s' % (s[0], s[1], s[2])
+    elif len(s) > 3:
         return '%s-%s-%s…' % (s[0], s[1], s[2])
     else:
-        return '<unknown'
+        return '<unknown>'
 
 
 def add_halide_cmake_test_steps(factory, builder_type):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1082,7 +1082,7 @@ def short_target(halide_target):
     s = halide_target.split('-')
     if len(s) == 1:
         return s[0]
-    elif len(3) >= 3:
+    elif len(s) >= 3:
         return '%s-%s-%s…' % (s[0], s[1], s[2])
     else:
         return '<unknown'

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1078,6 +1078,9 @@ def is_time_critical_test(test):
     # be run with an exclusive lock on the buildbot (typically, performance tests)
     return test in ['performance']
 
+def short_target(halide_target):
+    s = halide_target.split('-')
+    return '%s-%s-%s…' % (s[0], s[1], s[3])
 
 def add_halide_cmake_test_steps(factory, builder_type):
     parallelism = Property('WORKER_BUILD_PARALLELISM')
@@ -1102,7 +1105,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
         # env['HL_TARGET'] = halide_target
         env = extend_property('env', HL_JIT_TARGET=halide_target)
 
-        desc = 'Halide_TARGET=%s' % halide_target
+        desc = 'Halide_TARGET=%s' % short_target(halide_target)
 
         # Do this *before* splitting the horrid wasm-specific target string
         test_labels = labels[halide_target]
@@ -1115,14 +1118,14 @@ def add_halide_cmake_test_steps(factory, builder_type):
             # Re-set HL_JIT_TARGET with the de-warted target string
             env = extend_property('env', HL_JIT_TARGET=halide_target)
             if wasm_jit:
-                desc = '%s + Halide_TARGET=%s' % (wasm_jit, halide_target)
+                desc = '%s + Halide_TARGET=%s' % (wasm_jit, short_target(halide_target))
             env = merge_renderable(env, Property('emsdk_env', default={}))
 
         if not wasm_jit:
             wasm_jit = 'wabt'
 
         factory.addStep(
-            CMake(name='Reconfigure for %s' % halide_target,
+            CMake(name='Reconfigure for %s' % short_target(halide_target),
                   description='Reconfigure for %s' % desc,
                   locks=[performance_lock.access('counting')],
                   haltOnFailure=True,
@@ -1135,7 +1138,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
                   options=get_halide_cmake_options(builder_type, build_dir)))
 
         factory.addStep(
-            ShellCommand(name='Rebuild',
+            ShellCommand(name='Rebuild for %s' % (short_target(halide_target)),
                          description='Rebuild Halide for %s' % desc,
                          locks=[performance_lock.access('counting')],
                          haltOnFailure=True,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1228,7 +1228,8 @@ def add_halide_cmake_test_steps(factory, builder_type):
             apps_cmake_defs['CMAKE_PREFIX_PATH'] = get_halide_install_path(builder_type)
 
             # apps/hannk is expensive to build, and doesn't (yet) build on all systems, so special-case it here
-            apps_cmake_defs['ENABLE_APPS_HANNK'] = 'ON' if builder_type.has_tflite() else 'OFF'
+            want_hannk = (builder_type.has_tflite() and not halide_target.startswith("wasm-"))
+            apps_cmake_defs['ENABLE_APPS_HANNK'] = 'ON' if want_hannk else 'OFF'
 
             factory.addStep(
                 CMake(name='Configure apps for %s' % desc,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1078,6 +1078,7 @@ def is_time_critical_test(test):
     # be run with an exclusive lock on the buildbot (typically, performance tests)
     return test in ['performance']
 
+
 def short_target(halide_target):
     s = halide_target.split('-')
     if len(s) == 1:
@@ -1086,6 +1087,7 @@ def short_target(halide_target):
         return '%s-%s-%s…' % (s[0], s[1], s[2])
     else:
         return '<unknown'
+
 
 def add_halide_cmake_test_steps(factory, builder_type):
     parallelism = Property('WORKER_BUILD_PARALLELISM')


### PR DESCRIPTION
We lost some wasm testing at some point, and didn't notice because we had shortened the test stage names (because buildbot decided some names are too short). Reinstated testing (hopefully) and added a tweak to shorten the target to the first three components so we could have *some* idea what's being tested. This will probably need more tweaking after testing.