### PR TITLE
Mark the auto_schedule tests as performance-critical

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1076,7 +1076,7 @@ def get_test_labels(builder_type):
 def is_time_critical_test(test):
     # Return true if the test label (or single-test name) is 'time critical' and must
     # be run with an exclusive lock on the buildbot (typically, performance tests)
-    return test in ['performance']
+    return test in ['performance', 'auto_schedule']
 
 
 def short_target(halide_target):
@@ -1301,7 +1301,8 @@ def create_halide_make_factory(builder_type):
             continue
 
         _labels_to_skip = [
-            # performance requires exclusive machine access and isn't worth it for Make
+            # auto_schedule and performance requires exclusive machine access and isn't worth it for Make
+            "auto_schedule",
             "performance",
             # Make no longer provides support for building the Python bindings,
             # regardless of builder_type.handles_python()


### PR DESCRIPTION
Some of the autoscheduler tests run before-and-after benchmarks, so they need exclusive access to the machine to avoid false-positive failures.