### PR TITLE
Revise the buildbots to use the CMake toolchain file for wasm/emscripten

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -8,12 +8,13 @@ on:
 jobs:
   lint:
     name: flake8
-    runs-on: ubuntu-latest
+    # TODO: should be ubuntu-latest, but actions/setup-python doesn't work with ubuntu 22 just yet
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2.3.3
+      - uses: actions/setup-python@v4.3.0
         with:
-          python-version: 3.8.14
+          python-version: 3.8
       - name: Set up flake8 annotations
         uses: rbialon/flake8-annotations@v1
       - name: Run flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
       - name: Set up flake8 annotations
         uses: rbialon/flake8-annotations@v1
       - name: Run flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/setup-python@v2.3.3
         with:
           python-version: 3.8.14
       - name: Set up flake8 annotations

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -10,8 +10,8 @@ jobs:
     name: flake8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.5
-      - uses: actions/setup-python@v4.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: 3.8
       - name: Set up flake8 annotations

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -10,8 +10,8 @@ jobs:
     name: flake8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v2.5
+      - uses: actions/setup-python@v4.3
         with:
           python-version: 3.8
       - name: Set up flake8 annotations

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4.3.0
         with:
-          python-version: 3.8
+          python-version: 3.8.14
       - name: Set up flake8 annotations
         uses: rbialon/flake8-annotations@v1
       - name: Run flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - name: Set up flake8 annotations
         uses: rbialon/flake8-annotations@v1
       - name: Run flake8

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v2.3.3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -10,9 +10,9 @@ jobs:
         python-version: [ 3.6, 3.8, 3.9 ]
 
     steps:
-      - uses: actions/checkout@v2.5
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.3
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -10,9 +10,9 @@ jobs:
         python-version: [ 3.6, 3.8, 3.9 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -3,16 +3,17 @@ on: [ push, pull_request ]
 jobs:
   test:
     name: Check buildbot config on Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    # TODO: should be ubuntu-latest, but actions/setup-python doesn't work with ubuntu 22 just yet
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        python-version: [ 3.6.15, 3.8.14, 3.9.15 ]
+        python-version: [ 3.6, 3.8, 3.9 ]
 
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2.3.3
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.6, 3.8, 3.9 ]
+        python-version: [ 3.6.15, 3.8.14, 3.9.15 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -529,44 +529,6 @@ def get_msvc_config_steps(factory, builder_type):
                                extract_fn=save_interesting_env_vars))
 
 
-EMSDK_ENV_VARS = [
-    "EM_CACHE",
-    "EM_CONFIG",
-    "EMSDK",
-    "EMSDK_NODE",
-    "EMSDK_PYTHON",
-    "PATH",
-]
-
-
-def get_emsdk_config_steps(factory, builder_type):
-    if not builder_type.handles_wasm():
-        print("WARNING: should not call get_emsdk_config_steps() for builds that cannot handle WASM")
-        return
-
-    def save_interesting_env_vars(rc, stdout, stderr):
-        d = {}
-        output = stdout + '\n' + stderr
-        for line in output.split('\n'):
-            match = re.match("^([a-zA-Z0-9_-]+) = (.*)$", line.strip())
-            if match:
-                key = match.group(1).upper()
-                value = match.group(2)
-                if key in EMSDK_ENV_VARS:
-                    d[key] = value
-        print("emsdk env: ", d)
-        return {'emsdk_env': d}
-
-    factory.addStep(
-        SetPropertyFromCommand(name='Run emsdk_env',
-                               description='Run emsdk_env',
-                               locks=[performance_lock.access('counting')],
-                               haltOnFailure=True,
-                               env=Property('env', default={}),
-                               command=["/bin/bash", "-c", "source ${EMSDK}/emsdk_env.sh"],
-                               extract_fn=save_interesting_env_vars))
-
-
 def merge_renderable(_base, _extn):
     @renderer
     @defer.inlineCallbacks
@@ -649,7 +611,8 @@ def get_halide_cmake_definitions(builder_type, halide_target='host', wasm_jit='w
 
     # TODO: HALIDE_NODE_JS_PATH is only necessary until EMSDK updates their built-in version of Node
     # to v16.13+; when that is done, remove this definition.
-    if builder_type.handles_wasm():
+    if builder_type.handles_wasm() and halide_target.startswith("wasm-"):
+        cmake_definitions['CMAKE_TOOLCHAIN_FILE'] = Interpolate('%(prop:EMSDK)s/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake')
         cmake_definitions['NODE_JS_EXECUTABLE'] = Property('HALIDE_NODE_JS_PATH')
         if wasm_jit == 'v8':
             cmake_definitions['WITH_WABT'] = 'OFF'
@@ -744,10 +707,6 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
     if builder_type.os == 'windows':
         # do this first because the SetPropertyFromCommand step isn't smart enough to merge
         get_msvc_config_steps(factory, builder_type)
-
-    # Snag the env vars for the EMSDK. (Note that these are saved in 'emsdk_env' rather than 'env').
-    if builder_type.handles_wasm():
-        get_emsdk_config_steps(factory, builder_type)
 
     cxx = 'c++'
     cc = 'cc'
@@ -1128,7 +1087,6 @@ def add_halide_cmake_test_steps(factory, builder_type):
             env = extend_property('env', HL_JIT_TARGET=halide_target)
             if wasm_jit:
                 desc = '%s + T=%s' % (wasm_jit, short_target(halide_target))
-            env = merge_renderable(env, Property('emsdk_env', default={}))
 
         if not wasm_jit:
             wasm_jit = 'wabt'


### PR DESCRIPTION
This should be a lot cleaner than we did before (slurping and setting env vars), and allows a cleaner and well-defined to detect Emscripten usage inside CMake (specifically, the EMSCRIPTEN var is defined).

Also, drive-by fix to validation and flake8 Actions to fix recent upstream breakage