### PR TITLE
Skip clang-tools-extra on most buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -648,7 +648,6 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_BUILD_32_BITS': ('ON' if builder_type.bits == 32 else 'OFF'),
         'LLVM_ENABLE_ASSERTIONS': 'ON',
         'LLVM_ENABLE_LIBXML2': 'OFF',
-        'LLVM_ENABLE_PROJECTS': 'clang;lld;clang-tools-extra',
         'LLVM_ENABLE_RTTI': 'ON',
         'LLVM_ENABLE_TERMINFO': 'OFF',
         'LLVM_ENABLE_ZSTD': 'OFF',
@@ -660,6 +659,11 @@ def get_llvm_cmake_definitions(builder_type):
 
     if builder_type.handles_sanitizers():
         definitions['LLVM_ENABLE_RUNTIMES'] = "compiler-rt;libcxx;libcxxabi;libunwind"
+        # We only need clang-tools-extra if building for sanitizers -- skip them
+        # if the builder will never do this, to save time & space.
+        definitions['LLVM_ENABLE_PROJECTS'] = "clang;lld;clang-tools-extra"
+    else:
+        definitions['LLVM_ENABLE_PROJECTS'] = "clang;lld"
 
     # Some versions of GCC will flood the output with useless warnings about
     # "parameter passing for argument of type foo changed in GCC 7.1" unless


### PR DESCRIPTION
We need some of these tools when building for ASAN, but (1) that's currently disabled because the work was put on hold in favor of higher-priority work, and (2) even when enabled, would only be done on linux-x86-64. So skip it on the slower systems (e.g. arm32, which currently take > 12 hours to build LLVM16 from scratch...)