### PR TITLE
Stop building/testing LLVM13/Halide13

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -70,13 +70,11 @@ LLVM_MAIN = 'main'
 LLVM_RELEASE_16 = 'release_16'
 LLVM_RELEASE_15 = 'release_15'
 LLVM_RELEASE_14 = 'release_14'
-LLVM_RELEASE_13 = 'release_13'
 
 LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(17, 0, 0)),
                  LLVM_RELEASE_16: VersionedBranch(ref='release/16.x', version=Version(16, 0, 0)),
                  LLVM_RELEASE_15: VersionedBranch(ref='llvmorg-15.0.7', version=Version(15, 0, 7)),
-                 LLVM_RELEASE_14: VersionedBranch(ref='llvmorg-14.0.6', version=Version(14, 0, 6)),
-                 LLVM_RELEASE_13: VersionedBranch(ref='llvmorg-13.0.1', version=Version(13, 0, 1))}
+                 LLVM_RELEASE_14: VersionedBranch(ref='llvmorg-14.0.6', version=Version(14, 0, 6))}
 
 # At any given time, Halide has a main branch, which supports (at least)
 # the LLVM main branch and the most recent release branch (and maybe one older).
@@ -92,18 +90,15 @@ LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(17, 0, 0
 HALIDE_MAIN = 'main'
 HALIDE_RELEASE_15 = 'release_15'
 HALIDE_RELEASE_14 = 'release_14'
-HALIDE_RELEASE_13 = 'release_13'
 
 _HALIDE_RELEASES = [
     HALIDE_RELEASE_15,
     HALIDE_RELEASE_14,
-    HALIDE_RELEASE_13,
 ]
 
 HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='main', version=Version(16, 0, 0)),
                    HALIDE_RELEASE_15: VersionedBranch(ref='release/15.x', version=Version(15, 0, 0)),
-                   HALIDE_RELEASE_14: VersionedBranch(ref='release/14.x', version=Version(14, 0, 1)),
-                   HALIDE_RELEASE_13: VersionedBranch(ref='release/13.x', version=Version(13, 0, 4))}
+                   HALIDE_RELEASE_14: VersionedBranch(ref='release/14.x', version=Version(14, 0, 1))}
 
 # Given a halide branch, return the 'native' llvm version we expect to use with it.
 # For halide release branches, this is the corresponding llvm release branch; for
@@ -112,7 +107,6 @@ LLVM_FOR_HALIDE = {
     HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_16],
     HALIDE_RELEASE_15: [LLVM_RELEASE_15],
     HALIDE_RELEASE_14: [LLVM_RELEASE_14],
-    HALIDE_RELEASE_13: [LLVM_RELEASE_13],
 }
 
 # WORKERS
@@ -303,7 +297,7 @@ class BuilderType:
 
     def handles_riscv(self):
         # Only support RISCV on LLVM16 or later.
-        return self.llvm_branch not in [LLVM_RELEASE_13, LLVM_RELEASE_14, LLVM_RELEASE_15]
+        return self.llvm_branch not in [LLVM_RELEASE_14, LLVM_RELEASE_15]
 
     def handles_hexagon(self):
         return (self.arch == 'x86'
@@ -1574,7 +1568,7 @@ def prioritize_builders(buildmaster, builders):
         # releases. We care most about the most recently-released llvm so
         # that we have a full set of builds for releases, then llvm main
         # for bisection, then older llvm versions.
-        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_13]:
+        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_14, HALIDE_RELEASE_15]:
             return 2
         if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_MAIN]:
             return 3


### PR DESCRIPTION
At least one of our arm32 bots is low on storage, and with the soon-to-be-created LLVM16 (and thus Halide 16) branches, we can stop testing Halide 13 now.