### PR TITLE
Revise halide-main builders to be halide-nightly builders

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1444,7 +1444,7 @@ def create_halide_scheduler(halide_branch):
         yield Nightly(
             name='halide-package-' + halide_branch,
             codebases=['halide'],
-            builderNames=builders,
+            builderNames=builder_names,
             change_filter=ChangeFilter(codebase='halide'),
             hour=21,
             minute=0)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -212,7 +212,7 @@ c['codebaseGenerator'] = codebase_generator
 
 
 class Purpose(Enum):
-    halide_main = 1
+    halide_nightly = 1
     halide_testbranch = 2
     llvm_nightly = 3
 
@@ -1331,7 +1331,7 @@ def create_halide_cmake_factory(builder_type):
     add_halide_cmake_test_steps(factory, builder_type)
 
     # If everything else looks ok, build a distrib.
-    if builder_type.purpose == Purpose.halide_main:
+    if builder_type.purpose == Purpose.halide_nightly:
         add_halide_cmake_package_steps(factory, builder_type)
 
     return factory
@@ -1390,7 +1390,7 @@ def create_halide_builders():
         # (but only against their 'native' LLVM versions)
         for halide_branch in HALIDE_BRANCHES:
             for llvm_branch in LLVM_FOR_HALIDE[halide_branch]:
-                yield from create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_main)
+                yield from create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_nightly)
 
         # Create the builders for testing pull requests to releases.
         for halide_branch in _HALIDE_RELEASES:
@@ -1429,20 +1429,28 @@ def create_halide_scheduler(halide_branch):
         ref = change.properties.getProperty('basename')
         return ref == HALIDE_BRANCHES[halide_branch].ref
 
-    # ----- main
+    # ----- nightlies
     builders = [b for b in c['builders']
-                if b.builder_type.halide_branch == halide_branch and b.builder_type.purpose == Purpose.halide_main]
+                if b.builder_type.halide_branch == halide_branch and b.builder_type.purpose == Purpose.halide_nightly]
     if builders:
         builder_names = [str(b.name) for b in builders]
-        yield AnyBranchScheduler(
+
+        # Start the Halide nightlies at 9PM Pacific; our buildbots use PST for
+        # cron, so that's 2100. Note that this is (deliberately) well before
+        # the LLVM nightlies get built (currently 11pm start); the idea is
+        # that Halide nightlies get built using the previous day's LLVM
+        # nightlies, on the assumption that those are more likely to get at
+        # least some test coverage (via testbranch) to minimize breakage.
+        yield Nightly(
             name='halide-package-' + halide_branch,
             codebases=['halide'],
-            change_filter=ChangeFilter(category=None, codebase='halide', branch=HALIDE_BRANCHES[halide_branch].ref),
-            treeStableTimer=60 * 5,  # seconds
-            builderNames=builder_names)
+            builderNames=builders,
+            change_filter=ChangeFilter(codebase='halide'),
+            hour=21,
+            minute=0)
 
         yield ForceScheduler(
-            name='force-halide-package-' + halide_branch,
+            name='force-halide-nightly-' + halide_branch,
             builderNames=builder_names,
             codebases=['halide'])
 


### PR DESCRIPTION
For a long time, our buildbot system has treated changes to Halide `main` the same way as changes to PR testbranches: any commit should trigger a rebuild right away (well, within a ~5 minute threshold).

This PR proposes to change this to build Halide `main` distributions on a nightly basis instead, much as we do for LLVM, for a few reasons:
- We don't really need to rebuild the distributions right away; it's incredibly rare for them to detect a breakage that wasn't already known.
- It's rare that we need distrib builds at all except when producing releases (at least as of right now, since we don't really offer the interim distrib binaries to the public)
- It's common for the current 'main' builders to grab a bunch of buildbots during the middle of the workday, even if there are a bunch of pending testbranch PRs that really should get priority

So, instead, this proposes a nightly approach. This PR proposes to start the nightlies builds at 9PM PST (sorry, rest-of-world). Note that the LLVM nightlies currently start at 11pm, so this means that (1) the Halide nightlies will deliberately use the LLVM nightlies from the previous day (on the assumption that build breakages will be more likely to have been ironed out), and (2) it should be rare that this doesn't give enough time for the Halide nightlies to complete before the LLVM nightlies start (since the 'nightlies' builds don't run the full test suite).