### PR TITLE
Enable wasm on OSX machines as well as linux-x64

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -313,6 +313,13 @@ class BuilderType:
         return (self.llvm_branch == LLVM_MAIN
                 and (is_linux_x64 or self.os == 'osx'))
 
+    def handles_wasm_wabt(self):
+        return self.handles_wasm()
+
+    def handles_wasm_v8(self):
+        # OSX machines don't have V8 installed
+        return self.handles_wasm() and self.os == 'linux'
+
     def has_nvidia(self):
         return (self.arch == 'x86'
                 and self.bits == 64
@@ -1032,10 +1039,17 @@ def get_test_labels(builder_type):
         targets['host-cuda-opencl'].extend(['correctness_multi_gpu'])
 
     if builder_type.handles_wasm():
-        # TODO: this is a horrid hack. For now, we want to test JIT with both WABT and V8.
-        # Add as a horrible wart on the target string.
-        for j in ['/v8', '/wabt']:
-            targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int' + j].extend(
+
+        if builder_type.handles_wasm_wabt():
+            # TODO: this is a horrid hack. For now, we want to test JIT with both WABT and V8.
+            # Add as a horrible wart on the target string.
+            targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int/wabt'].extend(
+                ['internal', 'correctness', 'generator', 'error', 'warning'])
+
+        if builder_type.handles_wasm_v8():
+            # TODO: this is a horrid hack. For now, we want to test JIT with both WABT and V8.
+            # Add as a horrible wart on the target string.
+            targets['wasm-32-wasmrt-wasm_simd128-wasm_signext-wasm_sat_float_to_int/v8'].extend(
                 ['internal', 'correctness', 'generator', 'error', 'warning'])
 
         # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -306,12 +306,12 @@ class BuilderType:
                 and self.llvm_branch == LLVM_MAIN)
 
     def handles_wasm(self):
-        # Note that the OSX bots can also 'handle' wasm, but we are going to test
-        # only on Linux for now as they are currently our fastest bots.
-        return (self.arch == 'x86'
+        is_linux_x64 = (self.arch == 'x86'
                 and self.bits == 64
-                and self.os == 'linux'
-                and self.llvm_branch == LLVM_MAIN)
+                and self.os == 'linux')
+
+        return (self.llvm_branch == LLVM_MAIN
+                and (is_linux_x64 or self.os == 'osx'))
 
     def has_nvidia(self):
         return (self.arch == 'x86'

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -307,8 +307,8 @@ class BuilderType:
 
     def handles_wasm(self):
         is_linux_x64 = (self.arch == 'x86'
-                and self.bits == 64
-                and self.os == 'linux')
+                        and self.bits == 64
+                        and self.os == 'linux')
 
         return (self.llvm_branch == LLVM_MAIN
                 and (is_linux_x64 or self.os == 'osx'))


### PR DESCRIPTION
We will need to have at least some wasm testing available in order to run all the WebGPU tests, so let's get the full suite set up on OSX and verify it's working independently first.