### PR TITLE
Use LLVM 16.0.0 tag

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -72,7 +72,7 @@ LLVM_RELEASE_15 = 'release_15'
 LLVM_RELEASE_14 = 'release_14'
 
 LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(17, 0, 0)),
-                 LLVM_RELEASE_16: VersionedBranch(ref='release/16.x', version=Version(16, 0, 0)),
+                 LLVM_RELEASE_16: VersionedBranch(ref='llvmorg-16.0.0', version=Version(16, 0, 0)),
                  LLVM_RELEASE_15: VersionedBranch(ref='llvmorg-15.0.7', version=Version(15, 0, 7)),
                  LLVM_RELEASE_14: VersionedBranch(ref='llvmorg-14.0.6', version=Version(14, 0, 6))}
 


### PR DESCRIPTION
LLVM 16 has been officially released, so start using a release tag for it on buildbots, rather than "top-of-tree LLVM16".