### PR TITLE
Fix Vulkan target to use all feature flags 

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -326,14 +326,11 @@ class BuilderType:
                 and self.os in ['windows', 'linux'])
 
     def handles_vulkan(self):
-        # Disabled for now, TODO
-        return False
-
         # Stick with Linux on x86-64 for now. Others TBD.
-        # return (self.arch == 'x86'
-        #         and self.bits == 64
-        #         and self.os == 'linux'
-        #         and self.halide_branch not in [HALIDE_RELEASE_14, HALIDE_RELEASE_15])
+        return (self.arch == 'x86'
+                and self.bits == 64
+                and self.os == 'linux'
+                and self.halide_branch not in [HALIDE_RELEASE_14, HALIDE_RELEASE_15])
 
     def handles_webgpu(self):
         # At the moment, the WebGPU team recommends the OSX versions of Dawn/Node
@@ -1023,8 +1020,10 @@ def get_gpu_dsp_targets(builder_type):
         if builder_type.os == 'windows':
             yield 'host-d3d12compute', False
 
-    if builder_type.handles_vulkan():
-        yield 'host-vulkan', False
+        # If we're running on a capable GPU, add all optional feature flags to the vulkan target
+        # which are required to get all the correctness tests to pass
+        if builder_type.handles_vulkan():
+            yield 'host-vulkan-vk_int8-vk_int16-vk_int64-vk_float16-vk_float64-vk_v13', False
 
     if builder_type.handles_webgpu():
         yield 'host-webgpu', False

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -330,7 +330,7 @@ class BuilderType:
         return (self.arch == 'x86'
                 and self.bits == 64
                 and self.os == 'linux'
-                and self.halide_branch not in [HALIDE_RELEASE_14, HALIDE_RELEASE_15])
+                and self.halide_branch == HALIDE_MAIN)
 
     def handles_webgpu(self):
         # At the moment, the WebGPU team recommends the OSX versions of Dawn/Node


### PR DESCRIPTION
Re-enable Vulkan testing on Linux x86-64 for NVIDIA GPUs with all feature flags enabled.

Testing on a Linux Ubuntu 20.04 AMD-64 box with NVIDIA GeForce RTX 3070 Ti works as expected when build is configured with -DHalide_TARGET=host-vulkan-vk_int8-vk_int16-vk_int64-vk_float16-vk_float64-vk_v13  