### PR TITLE
Disable some unnecessary features in LLVM

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -693,6 +693,7 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_ENABLE_OCAMLDOC': 'OFF',
         'LLVM_ENABLE_RTTI': 'ON',
         'LLVM_ENABLE_TERMINFO': 'OFF',
+        'LLVM_ENABLE_WARNINGS': 'ON',  # silence them, it's not like we're gonna fix them
         'LLVM_ENABLE_ZLIB': 'OFF',
         'LLVM_ENABLE_ZSTD': 'OFF',
         'LLVM_INCLUDE_BENCHMARKS': 'OFF',

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -678,18 +678,26 @@ def get_cmake_build_command(builder_type, build_dir, targets=None):
 
 
 def get_llvm_cmake_definitions(builder_type):
+    # Keep sorted!
     definitions = {
         'CMAKE_BUILD_TYPE': 'Release',
         'CMAKE_INSTALL_PREFIX': get_llvm_install_path(builder_type),
         'LLVM_BUILD_32_BITS': ('ON' if builder_type.bits == 32 else 'OFF'),
         'LLVM_ENABLE_ASSERTIONS': 'ON',
+        'LLVM_ENABLE_BINDINGS': 'OFF',
+        'LLVM_ENABLE_CURL': 'OFF',
+        'LLVM_ENABLE_DIA_SDK': 'OFF',
+        'LLVM_ENABLE_HTTPLIB': 'OFF',
+        'LLVM_ENABLE_IDE': 'OFF',
         'LLVM_ENABLE_LIBXML2': 'OFF',
+        'LLVM_ENABLE_OCAMLDOC': 'OFF',
         'LLVM_ENABLE_RTTI': 'ON',
         'LLVM_ENABLE_TERMINFO': 'OFF',
+        'LLVM_ENABLE_ZLIB': 'OFF',
         'LLVM_ENABLE_ZSTD': 'OFF',
-        'LLVM_ENABLE_OCAMLDOC': 'OFF',
-        'LLVM_ENABLE_BINDINGS': 'OFF',
-        'LLVM_ENABLE_IDE': 'OFF',
+        'LLVM_INCLUDE_BENCHMARKS': 'OFF',
+        'LLVM_INCLUDE_EXAMPLES': 'OFF',
+        'LLVM_INCLUDE_TESTS': 'OFF',
         'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Hexagon;PowerPC;WebAssembly',
     }
 


### PR DESCRIPTION
Minor cleanup, just disable things that I'm pretty sure we don't need on the buildbots to save a bit of build time