### PR TITLE
Make changes for cmake based build of hexagon_remote

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -721,7 +721,7 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_INCLUDE_BENCHMARKS': 'OFF',
         'LLVM_INCLUDE_EXAMPLES': 'OFF',
         'LLVM_INCLUDE_TESTS': 'OFF',
-        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Hexagon;PowerPC;WebAssembly',
+        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;PowerPC;WebAssembly',
     }
 
     if builder_type.bits == 32:
@@ -729,6 +729,9 @@ def get_llvm_cmake_definitions(builder_type):
         definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = "ONLY"
         definitions['CMAKE_FIND_ROOT_PATH_MODE_PACKAGE'] = "ONLY"
         definitions['CMAKE_FIND_ROOT_PATH_MODE_PROGRAM'] = "NEVER"
+
+    if builder_type.handles_hexagon():
+        definitions['LLVM_TARGETS_TO_BUILD'] += ";Hexagon"
 
     if builder_type.handles_riscv():
         definitions['LLVM_TARGETS_TO_BUILD'] += ";RISCV"

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -845,6 +845,7 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
             hexagon_remote_bin,
             Interpolate('%(prop:HL_HEXAGON_TOOLS)s/lib/iss'),
         ]
+        env['HEXAGON_SDK_ROOT'] = Interpolate('%(prop:HL_HEXAGON_TOOLS)s/../../../..')
 
     if builder_type.os == 'osx':
         # Environment variable for turning on Metal API validation

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -832,14 +832,14 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
 
     if builder_type.handles_hexagon():
         # Environment variables for testing Hexagon DSP
-        hexagon_remote_bin = get_halide_source_path('src', 'runtime', 'hexagon_remote', 'bin')
-
+        hexagon_remote_bin = get_halide_build_path('src', 'runtime', 'hexagon_remote')
         # Assume that HL_HEXAGON_TOOLS points to the correct directory (it might not be /usr/local/hexagon)
-        env['HL_HEXAGON_SIM_REMOTE'] = Transform(os.path.join, hexagon_remote_bin, 'v65', 'hexagon_sim_remote')
+        env['HL_HEXAGON_SIM_REMOTE'] = Transform(os.path.join, hexagon_remote_bin, 'hexagon', 'bin', 'hexagon_sim_remote')
         env['HL_HEXAGON_SIM_CYCLES'] = '1'
         env['LD_LIBRARY_PATH'] = [Property('LD_LIBRARY_PATH'),
-                                  Transform(os.path.join, hexagon_remote_bin, 'host'),
+                                  hexagon_remote_bin,
                                   Interpolate('%(prop:HL_HEXAGON_TOOLS)s/lib/iss')]
+        env['HEXAGON_SDK_ROOT'] = Interpolate('%(prop:HL_HEXAGON_TOOLS)s/../../../..')
 
     if builder_type.os == 'osx':
         # Environment variable for turning on Metal API validation


### PR DESCRIPTION
- Change HL_HEXAGON_SIM_REMOTE and LD_LIBRARY_PATH to reflect new locations of hexagon_sim_remote and libhalide_hexagon_host.so respectively.
- Add HEXAGON_SDK_ROOT to point to the toplevel of the Hexagon SDK
@steven-johnson PTAL