### PR TITLE
Disable CCache for all Sanitizer builds; Re-Enable ASAN

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -158,7 +158,7 @@ c['workers'] = [Worker(n,
                        properties={'WORKER_BUILD_PARALLELISM': cfg.j}) for n, cfg in _WORKERS]
 
 _SANITIZERS = [
-    # 'asan',  # TODO: weird error about precompiled header file
+    'asan',
     'fuzzer',  # this isn't *technically* a sanitizer, but is close enough that it's a good fit
 ]
 
@@ -640,7 +640,9 @@ def get_halide_cmake_definitions(builder_type, halide_target='host', wasm_jit='w
     else:
         cmake_definitions['CMAKE_BUILD_TYPE'] = 'Release'
 
-    if builder_type.has_ccache():
+    # Sanitizer builds intermittently fail when using CCache for reasons that aren't
+    # clear ("precompiled header modified") -- for now, just ignore CCache for them
+    if builder_type.has_ccache() and not builder_type.sanitizer_preset():
         cmake_definitions['Halide_CCACHE_BUILD'] = 'ON'
 
     if builder_type.arch == 'arm' and builder_type.bits == 32 and builder_type.os == 'linux':
@@ -767,6 +769,7 @@ def get_llvm_cmake_definitions(builder_type):
     if builder_type.os == 'osx':
         definitions['LLVM_ENABLE_SUPPORT_XCODE_SIGNPOSTS'] = 'FORCE_OFF'
 
+    # We never build LLVM with sanitizers enabled
     if builder_type.has_ccache():
         definitions['LLVM_CCACHE_BUILD'] = 'ON'
 
@@ -1356,6 +1359,7 @@ def create_halide_make_factory(builder_type):
     build_dir = get_halide_build_path()
 
     factory = BuildFactory()
+    # We never enable sanitizers for Make builds here (only for CMake)
     add_env_setup_step(factory, builder_type, enable_ccache=True)
 
     # It's never necessary to use get_msvc_config_steps() for Make,


### PR DESCRIPTION
Hack workaround for the intermiittent Precompiled Header failures that we can't seem to get to work reliably with sanitizer builds.