### PR TITLE
Don't build nightlies for sanitizers

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -717,7 +717,7 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_ENABLE_OCAMLDOC': 'OFF',
         'LLVM_ENABLE_RTTI': 'ON',
         'LLVM_ENABLE_TERMINFO': 'OFF',
-        'LLVM_ENABLE_WARNINGS': 'ON',  # silence them, it's not like we're gonna fix them
+        'LLVM_ENABLE_WARNINGS': 'OFF',  # silence them, it's not like we're gonna fix them
         'LLVM_ENABLE_ZLIB': 'ON',
         'LLVM_ENABLE_ZSTD': 'OFF',
         'LLVM_INCLUDE_BENCHMARKS': 'OFF',
@@ -1464,7 +1464,14 @@ def get_interesting_halide_targets():
 
 
 def create_halide_builder(arch, bits, os, halide_branch, llvm_branch, purpose, buildsystem=BuildSystem.cmake):
-    for san in _SANITIZERS + [None]:
+    # Always do a build with no sanitizers
+    sanitizers = [None]
+
+    # Also build with sanitizers (but not if we are doing nightlies)
+    if builder_type.purpose != Purpose.halide_nightly:
+        sanitizers.extend(_SANITIZERS)
+
+    for san in sanitizers:
         builder_type = BuilderType(arch, bits, os, halide_branch, llvm_branch, purpose, san, buildsystem)
         if san and purpose == Purpose.llvm_nightly:
             continue

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1468,7 +1468,7 @@ def create_halide_builder(arch, bits, os, halide_branch, llvm_branch, purpose, b
     sanitizers = [None]
 
     # Also build with sanitizers (but not if we are doing nightlies)
-    if builder_type.purpose != Purpose.halide_nightly:
+    if purpose != Purpose.halide_nightly:
         sanitizers.extend(_SANITIZERS)
 
     for san in sanitizers:


### PR DESCRIPTION
Also, drive-by to turn off warnings for LLVM builds, which somehow got re-enabled