### PR TITLE
Disable leak-checking in ASAN testing

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -861,6 +861,14 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
         # We don't ever want an Abort, Retry, Ignore dialog in our tests
         env['HL_DISABLE_WINDOWS_ABORT_DIALOG'] = '1'
 
+    if builder_type.handles_sanitizers():
+        # Disable leak-checking (for now) for ASAN builds;
+        # this appears to mainly be some refcount cycles that we
+        # don't currently find a way to free on exit, and while we
+        # should really fix these, we don't want to ignore more serious
+        # ASAN failures that may occur (see https://github.com/halide/Halide/issues/7689)
+        env['ASAN_OPTIONS'] = 'detect_leaks=0'
+
     factory.addStep(SetProperties(
         name='Initialize environment',
         properties=dict(


### PR DESCRIPTION
We have a number of leaks in tests, ~all of which appear to be in situations where IntrusivePtr objects have cycles (eg various constraints, SpirV code); let's disable these pending investigation of https://github.com/halide/Halide/issues/7689 so that we don't risk missing actual access violations.