### PR TITLE
Drop builder support for Halide 14 / LLVM14

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -69,12 +69,10 @@ VersionedBranch = namedtuple('VersionedBranch', ['ref', 'version'])
 LLVM_MAIN = 'main'
 LLVM_RELEASE_16 = 'release_16'
 LLVM_RELEASE_15 = 'release_15'
-LLVM_RELEASE_14 = 'release_14'
 
 LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(17, 0, 0)),
                  LLVM_RELEASE_16: VersionedBranch(ref='llvmorg-16.0.6', version=Version(16, 0, 6)),
-                 LLVM_RELEASE_15: VersionedBranch(ref='llvmorg-15.0.7', version=Version(15, 0, 7)),
-                 LLVM_RELEASE_14: VersionedBranch(ref='llvmorg-14.0.6', version=Version(14, 0, 6))}
+                 LLVM_RELEASE_15: VersionedBranch(ref='llvmorg-15.0.7', version=Version(15, 0, 7))}
 
 # At any given time, Halide has a main branch, which supports (at least)
 # the LLVM main branch and the most recent release branch (and maybe one older).
@@ -90,18 +88,15 @@ LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(17, 0, 0
 HALIDE_MAIN = 'main'
 HALIDE_RELEASE_16 = 'release_16'
 HALIDE_RELEASE_15 = 'release_15'
-HALIDE_RELEASE_14 = 'release_14'
 
 _HALIDE_RELEASES = [
     HALIDE_RELEASE_16,
     HALIDE_RELEASE_15,
-    HALIDE_RELEASE_14,
 ]
 
 HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='main', version=Version(17, 0, 0)),
                    HALIDE_RELEASE_16: VersionedBranch(ref='release/16.x', version=Version(16, 0, 6)),
-                   HALIDE_RELEASE_15: VersionedBranch(ref='release/15.x', version=Version(15, 0, 1)),
-                   HALIDE_RELEASE_14: VersionedBranch(ref='release/14.x', version=Version(14, 0, 1))}
+                   HALIDE_RELEASE_15: VersionedBranch(ref='release/15.x', version=Version(15, 0, 1))}
 
 # Given a halide branch, return the 'native' llvm version we expect to use with it.
 # For halide release branches, this is the corresponding llvm release branch; for
@@ -110,7 +105,6 @@ LLVM_FOR_HALIDE = {
     HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_16],
     HALIDE_RELEASE_16: [LLVM_RELEASE_16],
     HALIDE_RELEASE_15: [LLVM_RELEASE_15],
-    HALIDE_RELEASE_14: [LLVM_RELEASE_14],
 }
 
 # WORKERS
@@ -311,7 +305,7 @@ class BuilderType:
 
     def handles_riscv(self):
         # Only support RISCV on LLVM16 or later.
-        return self.llvm_branch not in [LLVM_RELEASE_14, LLVM_RELEASE_15]
+        return self.llvm_branch not in [LLVM_RELEASE_15]
 
     def handles_hexagon(self):
         return (self.arch == 'x86'
@@ -351,7 +345,7 @@ class BuilderType:
         # as the most robust for testing, so that's all we're set up to test with.
         # (Note that 'Dawn' must be built/installed on the test machines manually;
         # there are no binaries/prebuilts available at this time.)
-        return self.os == 'osx' and self.halide_branch not in [HALIDE_RELEASE_14, HALIDE_RELEASE_15]
+        return self.os == 'osx' and self.halide_branch not in [HALIDE_RELEASE_15]
 
     def has_tflite(self):
         if self.arch == 'x86' and self.bits == 64 and self.os == 'linux':
@@ -1685,8 +1679,6 @@ def prioritize_builders(buildmaster, builders):
         # releases. We care most about the most recently-released llvm so
         # that we have a full set of builds for releases, then llvm main
         # for bisection, then older llvm versions.
-        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_14]:
-            return 2
         if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_15]:
             return 2
         if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_16]:


### PR DESCRIPTION
It's unlikely we'll be doing any more dot releases for Halide 14 anytime soon, so let's drop the buildbot support for it, which will allow us to skip builds and updates to LLVM14. (We can always resurrect this from the git history if we do need it later.)