### PR TITLE
Update nightly tasks to use UTC

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1546,8 +1546,8 @@ def create_halide_scheduler(halide_branch):
     if builders:
         builder_names = [str(b.name) for b in builders]
 
-        # Start the Halide nightlies at 9PM Pacific; our buildbots use PST for
-        # cron, so that's 2100. Note that this is (deliberately) well before
+        # Start the Halide nightlies at 9PM Pacific; our buildbot master uses UTC for
+        # cron, so that's 0400. Note that this is (deliberately) well before
         # the LLVM nightlies get built (currently 11pm start); the idea is
         # that Halide nightlies get built using the previous day's LLVM
         # nightlies, on the assumption that those are more likely to get at
@@ -1557,7 +1557,7 @@ def create_halide_scheduler(halide_branch):
             codebases=['halide'],
             builderNames=builder_names,
             change_filter=ChangeFilter(codebase='halide'),
-            hour=21,
+            hour=4,
             minute=0)
 
         yield ForceScheduler(
@@ -1631,13 +1631,13 @@ def create_llvm_builders():
 def create_llvm_scheduler(llvm_branch):
     builders = [str(b.name) for b in c['builders']
                 if b.builder_type.llvm_branch == llvm_branch and b.builder_type.purpose == Purpose.llvm_nightly]
-    # Start every day at 11PM Pacific; our buildbots use PST for cron, so that's 2300
+    # Start every day at 11PM Pacific; our buildbot use UTC for cron, so that's 0600
     yield Nightly(
         name=f'llvm-nightly-{LLVM_BRANCHES[llvm_branch].version.major}',
         codebases=['llvm'],
         builderNames=builders,
         change_filter=ChangeFilter(codebase='llvm'),
-        hour=23,
+        hour=6,
         minute=0)
 
     for b in builders:


### PR DESCRIPTION
They formerly assumed PST, but the new buildbot-master runs on UTC