### PR TITLE
Take max-x86-1 and win-1 offline

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -124,7 +124,8 @@ _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
     ('linux-worker-4', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
     # 2013 Mac Pro running a 6-core Xeon.
-    ('mac-x86-worker-1', WorkerConfig(max_builds=2, j=8, arch='x86', bits=[64], os='osx')),
+    # TODO: temporary offline due to network issues
+    # ('mac-x86-worker-1', WorkerConfig(max_builds=2, j=8, arch='x86', bits=[64], os='osx')),
     # Mac Mini 2018, 3.2 GHz 6-Core Intel Core i7, 16GB memory
     ('mac-x86-worker-2', WorkerConfig(max_builds=2, j=8, arch='x86', bits=[64], os='osx')),
     ('mac-arm-worker-1', WorkerConfig(max_builds=2, j=8, arch='arm', bits=[64], os='osx')),
@@ -138,7 +139,8 @@ _WORKERS = [
     ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC, arch='arm', bits=[32], os='linux')),
     # Taken offline indefinitely, too slow
     # ('win-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
-    ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    # TODO: temporary offline due to network issues
+    # ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
     ('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
 


### PR DESCRIPTION
These two are on a lab network that is too flaky (it will crap out during an LLVM build) and so far we can't get anyone to diagnose it (they demand logs from the machine and we can't get those without someone going there in person and no one is in that bldg anymore) -- taking them offline entirely rather than have them fail lots of builds

