### PR TITLE
Add LLVM18 to buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -67,10 +67,12 @@ Version = namedtuple('Version', ['major', 'minor', 'patch'])
 VersionedBranch = namedtuple('VersionedBranch', ['ref', 'version'])
 
 LLVM_MAIN = 'main'
+LLVM_RELEASE_17 = 'release_17'
 LLVM_RELEASE_16 = 'release_16'
 LLVM_RELEASE_15 = 'release_15'
 
-LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(17, 0, 0)),
+LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(18, 0, 0)),
+                 LLVM_RELEASE_17: VersionedBranch(ref='release/17.x', version=Version(17, 0, 0)),
                  LLVM_RELEASE_16: VersionedBranch(ref='llvmorg-16.0.6', version=Version(16, 0, 6)),
                  LLVM_RELEASE_15: VersionedBranch(ref='llvmorg-15.0.7', version=Version(15, 0, 7))}
 
@@ -102,7 +104,7 @@ HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='main', version=Version(17, 
 # For halide release branches, this is the corresponding llvm release branch; for
 # halide main, it's llvm main.
 LLVM_FOR_HALIDE = {
-    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_16],
+    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_17, LLVM_RELEASE_16],
     HALIDE_RELEASE_16: [LLVM_RELEASE_16],
     HALIDE_RELEASE_15: [LLVM_RELEASE_15],
 }


### PR DESCRIPTION
Looks like LLVM just did a `release/17.x` branch and now trunk is 18.