### PR TITLE
Temporarily disable WinBot3 and Vulkan testing

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -337,11 +337,14 @@ class BuilderType:
                 and self.os in ['windows', 'linux'])
 
     def handles_vulkan(self):
+        # TODO: disabled temporarily pending fixes to the Vulkan runtime
+        return False
+
         # Stick with Linux on x86-64 for now. Others TBD.
-        return (self.arch == 'x86'
-                and self.bits == 64
-                and self.os == 'linux'
-                and self.halide_branch in [HALIDE_MAIN, HALIDE_RELEASE_16])
+        # return (self.arch == 'x86'
+        #         and self.bits == 64
+        #         and self.os == 'linux'
+        #         and self.halide_branch in [HALIDE_MAIN, HALIDE_RELEASE_16])
 
     def handles_webgpu(self):
         # At the moment, the WebGPU team recommends the OSX versions of Dawn/Node

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -141,7 +141,8 @@ _WORKERS = [
     # Taken offline indefinitely, too slow
     # ('win-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
     ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
-    ('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    # TODO: temporarily offline pending repair
+    #('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
 
 # The 'workers' list defines the set of recognized buildworkers. Each element is

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -142,7 +142,7 @@ _WORKERS = [
     # ('win-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
     ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
     # TODO: temporarily offline pending repair
-    #('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    # ('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
 
 # The 'workers' list defines the set of recognized buildworkers. Each element is


### PR DESCRIPTION
- WinBot3 is offline and will be for a few days, don't bother scheduling it
- Vulkan currently has known failures that make otherwise-clean tests fail, so disable it until @derek-gerstmann can land his fixes