### PR TITLE
temporarily disable D3D12 until we have a WinBot running again that won't fail repeatedly

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1069,8 +1069,9 @@ def get_gpu_dsp_targets(builder_type):
     if builder_type.has_nvidia():
         yield 'host-cuda', False
         yield 'host-opencl', False
-        if builder_type.os == 'windows':
-            yield 'host-d3d12compute', False
+        # TODO: temporarily disable D3D12 until we have a WinBot running again that won't fail repeatedly
+        # if builder_type.os == 'windows':
+        #     yield 'host-d3d12compute', False
 
         # If we're running on a capable GPU, add all optional feature flags to the vulkan target
         # which are required to get all the correctness tests to pass


### PR DESCRIPTION
attn @slomp @shoaibkamil 