### PR TITLE
[Hexagon] - Add HEXAGON_SDK_ROOT to the env on builders that handle_hexagon

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -720,7 +720,7 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_INCLUDE_BENCHMARKS': 'OFF',
         'LLVM_INCLUDE_EXAMPLES': 'OFF',
         'LLVM_INCLUDE_TESTS': 'OFF',
-        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;PowerPC;WebAssembly',
+        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Hexagon;PowerPC;WebAssembly',
     }
 
     if builder_type.bits == 32:
@@ -728,9 +728,6 @@ def get_llvm_cmake_definitions(builder_type):
         definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = "ONLY"
         definitions['CMAKE_FIND_ROOT_PATH_MODE_PACKAGE'] = "ONLY"
         definitions['CMAKE_FIND_ROOT_PATH_MODE_PROGRAM'] = "NEVER"
-
-    if builder_type.handles_hexagon():
-        definitions['LLVM_TARGETS_TO_BUILD'] += ";Hexagon"
 
     if builder_type.handles_riscv():
         definitions['LLVM_TARGETS_TO_BUILD'] += ";RISCV"

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -720,7 +720,7 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_INCLUDE_BENCHMARKS': 'OFF',
         'LLVM_INCLUDE_EXAMPLES': 'OFF',
         'LLVM_INCLUDE_TESTS': 'OFF',
-        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Hexagon;PowerPC;WebAssembly',
+        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;PowerPC;WebAssembly',
     }
 
     if builder_type.bits == 32:
@@ -728,6 +728,9 @@ def get_llvm_cmake_definitions(builder_type):
         definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = "ONLY"
         definitions['CMAKE_FIND_ROOT_PATH_MODE_PACKAGE'] = "ONLY"
         definitions['CMAKE_FIND_ROOT_PATH_MODE_PROGRAM'] = "NEVER"
+
+    if builder_type.handles_hexagon():
+        definitions['LLVM_TARGETS_TO_BUILD'] += ";Hexagon"
 
     if builder_type.handles_riscv():
         definitions['LLVM_TARGETS_TO_BUILD'] += ";RISCV"
@@ -843,6 +846,7 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
             Transform(os.path.join, hexagon_remote_bin, 'host'),
             Interpolate('%(prop:HL_HEXAGON_TOOLS)s/lib/iss'),
         ]
+        env['HEXAGON_SDK_ROOT'] = Interpolate('%(prop:HL_HEXAGON_TOOLS)s/../../../..')
 
     if builder_type.os == 'osx':
         # Environment variable for turning on Metal API validation


### PR DESCRIPTION
This PR is a subset of #237 but is required to break a circular dependency between https://github.com/halide/Halide/pull/7741 and #237 . The order that PRs should go in is
This PR -> https://github.com/halide/Halide/pull/7741 -> #237 

**NOTE** - Once this PR is merged, I'll update #237 with master merged in.

This PR is needed to fix the clang-tidy problem in https://github.com/halide/Halide/pull/7741