### PR TITLE
Revert "[Hexagon] - Build LLVM with Hexagon only if the builder handles hexagon"

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -725,7 +725,7 @@ def get_llvm_cmake_definitions(builder_type):
         'LLVM_INCLUDE_BENCHMARKS': 'OFF',
         'LLVM_INCLUDE_EXAMPLES': 'OFF',
         'LLVM_INCLUDE_TESTS': 'OFF',
-        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;PowerPC;WebAssembly',
+        'LLVM_TARGETS_TO_BUILD': 'X86;ARM;NVPTX;AArch64;Hexagon;PowerPC;WebAssembly',
     }
 
     if builder_type.bits == 32:
@@ -733,9 +733,6 @@ def get_llvm_cmake_definitions(builder_type):
         definitions['CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = "ONLY"
         definitions['CMAKE_FIND_ROOT_PATH_MODE_PACKAGE'] = "ONLY"
         definitions['CMAKE_FIND_ROOT_PATH_MODE_PROGRAM'] = "NEVER"
-
-    if builder_type.handles_hexagon():
-        definitions['LLVM_TARGETS_TO_BUILD'] += ";Hexagon"
 
     if builder_type.handles_riscv():
         definitions['LLVM_TARGETS_TO_BUILD'] += ";RISCV"


### PR DESCRIPTION
Reverts halide/build_bot#253