### PR TITLE
[Hexagon] - Optionally build the hexagon remote runtime

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -685,6 +685,9 @@ def get_halide_cmake_definitions(builder_type, halide_target='host', wasm_jit='w
         cmake_definitions['WEBGPU_NODE_BINDINGS'] = Property('HL_WEBGPU_NODE_BINDINGS')
         cmake_definitions['WEBGPU_NATIVE_LIB'] = Property('HL_WEBGPU_NATIVE_LIB')
 
+    if builder_type.handles_hexagon() and 'hvx' in halide_target:
+        cmake_definitions['Halide_BUILD_HEXAGON_REMOTE_RUNTIME'] = 'ON'
+
     return cmake_definitions
 
 


### PR DESCRIPTION
This PR uses the option added in https://github.com/halide/Halide/pull/7741 to uild the hexagon remote runtime if the builder can handle hexagon and the target string has hvx in it