### PR TITLE
Take WinBot2 offline to avoid D3D12 test failures

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -142,7 +142,8 @@ _WORKERS = [
     ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC, arch='arm', bits=[32], os='linux')),
     # Taken offline indefinitely, too slow
     # ('win-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
-    ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    # TODO: taken offline because every D3D12 test fails
+    # ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
     ('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
 
@@ -1070,7 +1071,6 @@ def get_gpu_dsp_targets(builder_type):
     if builder_type.has_nvidia():
         yield 'host-cuda', False
         yield 'host-opencl', False
-        # TODO: temporarily disable D3D12 until we have a WinBot running again that won't fail repeatedly
         if builder_type.os == 'windows':
             yield 'host-d3d12compute', False
 


### PR DESCRIPTION
Every D3D12 test fails on this machine, and I'm tired of seeing the false errors.

Also, drive-by removal of stale comment from last time.