### PR TITLE
Enable autoscheduler testing via new labels

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1316,7 +1316,10 @@ def add_halide_cmake_test_steps(factory, builder_type):
                       **get_ctest_options(builder_type, build_dir)))
 
         if exclusive_test_labels:
-            test_set = ', '.join(exclusive_test_labels)
+            if len(exclusive_test_labels) > 2:
+                test_set = ','.join([s.replace('autoschedulers_', 'a_') for s in exclusive_test_labels])
+            else:
+                test_set = ', '.join(exclusive_test_labels)
             factory.addStep(
                 CTest(name='Test %s %s' % (test_set, desc),
                       description='Test %s %s' % (test_set, desc),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1106,7 +1106,7 @@ def get_test_labels(builder_type):
         return targets
 
     targets['host'].extend(['internal', 'correctness', 'generator',
-                            'auto_schedule', 'error', 'warning', 'apps', 'performance', 'tutorial'])
+                            'autoschedulers_cpu', 'error', 'warning', 'apps', 'performance', 'tutorial'])
 
     # For all other sanitizers (eg asan), don't bother with the gpu/etc tests.
     if preset:
@@ -1136,6 +1136,10 @@ def get_test_labels(builder_type):
             targets[t].extend(['correctness', 'generator'])
         else:
             targets[t].extend(['correctness', 'generator', 'apps'])
+        if 'cuda' in t:
+            targets[t].extend(['autoschedulers_cuda'])
+        if 'hvx' not in t:
+            targets[t].extend(['autoschedulers_gpu'])
         # Don't do performance testing on simulators.
         if not is_simulator:
             targets[t].extend(['performance'])
@@ -1170,7 +1174,7 @@ def get_test_labels(builder_type):
 
     if builder_type.handles_webgpu():
         # Most apps can't handle wasm builds yet.
-        targets['wasm-32-wasmrt-webgpu'].extend(['generator'])
+        targets['wasm-32-wasmrt-webgpu'].extend(['generator', 'autoschedulers_gpu'])
 
     return targets
 
@@ -1178,7 +1182,7 @@ def get_test_labels(builder_type):
 def is_time_critical_test(test):
     # Return true if the test label (or single-test name) is 'time critical' and must
     # be run with an exclusive lock on the buildbot (typically, performance tests)
-    return test in ['performance', 'auto_schedule']
+    return test in ['performance', 'autoschedulers_cpu', 'autoschedulers_gpu', 'autoschedulers_cuda']
 
 
 def short_target(halide_target):
@@ -1407,7 +1411,9 @@ def create_halide_make_factory(builder_type):
 
         _labels_to_skip = [
             # auto_schedule and performance requires exclusive machine access and isn't worth it for Make
-            "auto_schedule",
+            "autoschedulers_cpu",
+            "autoschedulers_gpu",
+            "autoschedulers_cuda",
             "performance",
             # Make no longer provides support for building the Python bindings,
             # regardless of builder_type.handles_python()
@@ -1418,7 +1424,7 @@ def create_halide_make_factory(builder_type):
             # Don't test autoschedulers on 32-bit systems via Make;
             # it's not set up 100% correctly for crosscompilation there
             # and the CMake-based coverage is fine.
-            _labels_to_skip.append('auto_schedule')
+            _labels_to_skip.extend(['autoschedulers_cpu', 'autoschedulers_gpu', 'autoschedulers_cuda'])
 
         for label in labels_for_target:
             if label in _labels_to_skip:

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1316,10 +1316,7 @@ def add_halide_cmake_test_steps(factory, builder_type):
                       **get_ctest_options(builder_type, build_dir)))
 
         if exclusive_test_labels:
-            if len(exclusive_test_labels) > 2:
-                test_set = ','.join([s.replace('autoschedulers_', 'a_') for s in exclusive_test_labels])
-            else:
-                test_set = ', '.join(exclusive_test_labels)
+            test_set = ','.join([s.replace('autoschedulers_', 'a_') for s in exclusive_test_labels])
             factory.addStep(
                 CTest(name='Test %s %s' % (test_set, desc),
                       description='Test %s %s' % (test_set, desc),


### PR DESCRIPTION
This enables Anderson2021 on the right systems (hopefully) as a followup to https://github.com/halide/Halide/pull/7732 (and we believe the ASAN failures in Anderson2021 are addressed now)