### PR TITLE
disable winbot3, enable winbot2, disable d3d12 tests

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -140,11 +140,10 @@ _WORKERS = [
     ('arm64-linux-worker-2', WorkerConfig(max_builds=1, j=2, arch='arm', bits=[64], os='linux')),
     # The rpi4 has 8GB ram, so apparently it's OK with -j=nproc for now.
     ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC, arch='arm', bits=[32], os='linux')),
-    # Taken offline indefinitely, too slow
-    # ('win-worker-1', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
-    # TODO: taken offline because every D3D12 test fails
-    # ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
-    ('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    # TODO: should normally be offline because every D3D12 test fails
+    ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
+    # TODO: broken, pending repair till Monday
+    # ('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
 
 # The 'workers' list defines the set of recognized buildworkers. Each element is
@@ -1074,8 +1073,10 @@ def get_gpu_dsp_targets(builder_type):
     if builder_type.has_nvidia():
         yield 'host-cuda', False
         yield 'host-opencl', False
-        if builder_type.os == 'windows':
-            yield 'host-d3d12compute', False
+
+        # TODO: temporarily disabled because our only windows bot doesn't support it...
+        # if builder_type.os == 'windows':
+        #     yield 'host-d3d12compute', False
 
         # If we're running on a capable GPU, add all optional feature flags to the vulkan target
         # which are required to get all the correctness tests to pass


### PR DESCRIPTION
WinBot3 is offline till ~Monday, so let's re-enable WinBot2 to get at least some Windows coverage till then. (Disable D3D12 testing since those will all fail on WinBot2)

cc @shoaibkamil 