### PR TITLE
Constrain the halide-nightly builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -848,7 +848,11 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
         # Environment variables for testing Hexagon DSP
         hexagon_remote_bin = get_halide_build_path('src', 'runtime', 'hexagon_remote')
         # Assume that HL_HEXAGON_TOOLS points to the correct directory (it might not be /usr/local/hexagon)
-        env['HL_HEXAGON_SIM_REMOTE'] = Transform(os.path.join, hexagon_remote_bin, 'hexagon', 'bin', 'hexagon_sim_remote')
+        env['HL_HEXAGON_SIM_REMOTE'] = Transform(os.path.join,
+                                                 hexagon_remote_bin,
+                                                 'hexagon',
+                                                 'bin',
+                                                 'hexagon_sim_remote')
         env['HL_HEXAGON_SIM_CYCLES'] = '1'
         env['LD_LIBRARY_PATH'] = [
             # no, this will cause a failure at runtime if LD_LIBRARY_PATH is unset (or empty!)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -100,6 +100,12 @@ HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='main', version=Version(17, 
                    HALIDE_RELEASE_16: VersionedBranch(ref='release/16.x', version=Version(16, 0, 6)),
                    HALIDE_RELEASE_15: VersionedBranch(ref='release/15.x', version=Version(15, 0, 1))}
 
+# This lists the Halide branch(es) for which we want to build nightlies;
+# it's usually desirable to constrain these to save buildbot time (esp on the slower bots)
+# and avoid branches that aren't changing much (i.e. -- recent releases that aren't
+# likely to need new updates soon).
+HALIDE_NIGHTLIES = [HALIDE_MAIN]
+
 # Given a halide branch, return the 'native' llvm version we expect to use with it.
 # For halide release branches, this is the corresponding llvm release branch; for
 # halide main, it's llvm main.
@@ -1534,7 +1540,7 @@ def create_halide_builders():
     for arch, bits, os in get_interesting_halide_targets():
         # Create builders for build + package of Halide master + release branches
         # (but only against their 'native' LLVM versions)
-        for halide_branch in HALIDE_BRANCHES:
+        for halide_branch in HALIDE_NIGHTLIES:
             for llvm_branch in LLVM_FOR_HALIDE[halide_branch]:
                 yield from create_halide_builder(arch, bits, os, halide_branch, llvm_branch, Purpose.halide_nightly)
 


### PR DESCRIPTION
We currently default to building 'nightlies' from all the HALIDE_BRANCHES; in practice, this is overkill, as (eg) neither the halide-15 nor halide-16 branch are getting daily changes. This becomes problematic for our slower buildbots (esp. the armbots) as they now often don't finish the 'nightlies' until mid-morning the next day. This change makes a separate list of branches to build nightlies for, defaulting to just the main branch. (If/when we need new nightlies for other branches, eg for a dot-release, we can edit them back in; this isn't optimal, but until/unless we get better buildbot performance, it's probably the best option.)