### PR TITLE
Revert "Make changes for cmake based build of hexagon_remote (#237)"

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -846,18 +846,15 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
 
     if builder_type.handles_hexagon():
         # Environment variables for testing Hexagon DSP
-        hexagon_remote_bin = get_halide_build_path('src', 'runtime', 'hexagon_remote')
+        hexagon_remote_bin = get_halide_source_path('src', 'runtime', 'hexagon_remote', 'bin')
+
         # Assume that HL_HEXAGON_TOOLS points to the correct directory (it might not be /usr/local/hexagon)
-        env['HL_HEXAGON_SIM_REMOTE'] = Transform(os.path.join,
-                                                 hexagon_remote_bin,
-                                                 'hexagon',
-                                                 'bin',
-                                                 'hexagon_sim_remote')
+        env['HL_HEXAGON_SIM_REMOTE'] = Transform(os.path.join, hexagon_remote_bin, 'v65', 'hexagon_sim_remote')
         env['HL_HEXAGON_SIM_CYCLES'] = '1'
         env['LD_LIBRARY_PATH'] = [
             # no, this will cause a failure at runtime if LD_LIBRARY_PATH is unset (or empty!)
             # Property('LD_LIBRARY_PATH'),
-            hexagon_remote_bin,
+            Transform(os.path.join, hexagon_remote_bin, 'host'),
             Interpolate('%(prop:HL_HEXAGON_TOOLS)s/lib/iss'),
         ]
         env['HEXAGON_SDK_ROOT'] = Interpolate('%(prop:HL_HEXAGON_TOOLS)s/../../../..')


### PR DESCRIPTION
This reverts commit 50e2cb94074cdb3c00942216a73266d5bc559e16.

This is a temporary workaround for https://github.com/halide/Halide/issues/7828 to unblock the Halide bots before I go on vacation.