### PR TITLE
Update LLVM17 branch to first release branch (17.0.1)

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -72,7 +72,7 @@ LLVM_RELEASE_16 = 'release_16'
 LLVM_RELEASE_15 = 'release_15'
 
 LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(18, 0, 0)),
-                 LLVM_RELEASE_17: VersionedBranch(ref='release/17.x', version=Version(17, 0, 0)),
+                 LLVM_RELEASE_17: VersionedBranch(ref='llvmorg-17.0.1', version=Version(17, 0, 1)),
                  LLVM_RELEASE_16: VersionedBranch(ref='llvmorg-16.0.6', version=Version(16, 0, 6)),
                  LLVM_RELEASE_15: VersionedBranch(ref='llvmorg-15.0.7', version=Version(15, 0, 7))}
 


### PR DESCRIPTION
LLVM17 was finally released, so switch to first release branch (which, note, was 17.0.1 and not 17.0.0)