### PR TITLE
Remove win-worker-2 and mac-x86-worker-1

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -131,8 +131,6 @@ _NPROC_PLUS_2 = Transform(lambda x: f'{int(x) + 2}', _NPROC)
 _WORKERS = [
     ('linux-worker-1', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
     ('linux-worker-4', WorkerConfig(max_builds=4, j=8, arch='x86', bits=[32, 64], os='linux')),
-    # 2013 Mac Pro running a 6-core Xeon.
-    ('mac-x86-worker-1', WorkerConfig(max_builds=2, j=8, arch='x86', bits=[64], os='osx')),
     # Mac Mini 2018, 3.2 GHz 6-Core Intel Core i7, 16GB memory
     ('mac-x86-worker-2', WorkerConfig(max_builds=2, j=8, arch='x86', bits=[64], os='osx')),
     # Mac Mini 2018, ??? details TBD
@@ -148,8 +146,6 @@ _WORKERS = [
     ('rpi4-linux-worker-1', WorkerConfig(max_builds=1, j=_NPROC, arch='arm', bits=[32], os='linux')),
     # OrangePi5 test bot: 8 cores, can run 32 or 64, experimental -- let's do only 1 build at a time for now
     ('arm64-linux-worker-3', WorkerConfig(max_builds=1, j=_NPROC, arch='arm', bits=[32, 64], os='linux')),
-    # TODO: should normally be offline because every D3D12 test fails
-    ('win-worker-2', WorkerConfig(max_builds=1, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
     ('win-worker-3', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
     ('win-worker-4', WorkerConfig(max_builds=2, j=_NPROC_PLUS_2, arch='x86', bits=[32, 64], os='windows')),
 ]
@@ -700,11 +696,6 @@ def get_halide_cmake_definitions(builder_type, halide_target='host', wasm_jit='w
             cmake_definitions['V8_LIB_PATH'] = ''
         else:
             assert False, "Unknown wasm jit " + str(wasm_jit)
-
-    if builder_type.handles_webgpu() and "webgpu" in halide_target:
-        # TODO(srj): remove these after https://github.com/halide/Halide/pull/7422 lands
-        cmake_definitions['WEBGPU_NODE_BINDINGS'] = Property('HL_WEBGPU_NODE_BINDINGS')
-        cmake_definitions['WEBGPU_NATIVE_LIB'] = Property('HL_WEBGPU_NATIVE_LIB')
 
     if builder_type.handles_hexagon() and 'hvx' in halide_target:
         cmake_definitions['Halide_BUILD_HEXAGON_REMOTE_RUNTIME'] = 'ON'


### PR DESCRIPTION
These are ancient and buggy and inconveniently located, and we now finally have redundancy for them, so let's remove them for good. (The mac bot in particular will never properly support WebGPU)

Also remove code for https://github.com/halide/Halide/pull/7422 lands that has landed already