### PR TITLE
Avoid unnecessary uploads of LLVM packages

### DIFF
--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -138,7 +138,7 @@ class CleanOldFiles(BuildStep):
 class FileUploadIfNotExist(FileUpload):
     name = 'file-upload-if-not-exist'
 
-    def __init__(self, *, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # This is a hack to show some sort of progress-like output when uploading
         self.debug = True

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -146,7 +146,7 @@ class FileUploadIfNotExist(FileUpload):
             stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
             return SUCCESS
 
-        return super().run();
+        return super().run()
 
 
 class CTest(ShellMixin, CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -141,12 +141,15 @@ class FileUploadIfNotExist(FileUpload):
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
-            stdio = yield self.addLog('stdio')
-            stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
-            yield stdio.finish()
+            # TODO: this requires @defer.inlineCallbacks, but adding that
+            # will make the non-skip-upload path fail because we have no callbacks.
+            # How to resolve? Not sure. Oh well.
+            #
+            # stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
+            # yield stdio.finish()
             return SUCCESS
 
-        yield from super().run()
+        return super().run()
 
 
 class CTest(ShellMixin, CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -140,12 +140,15 @@ class FileUploadIfNotExist(FileUpload):
 
     @defer.inlineCallbacks
     def run(self):
+        stdio = yield self.addLog('stdio')
+
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
-            stdio = yield self.addLog('stdio')
             stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
+            yield stdio.finish()
             return SUCCESS
 
+        yield stdio.finish()
         return super().run()
 
 

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -147,8 +147,8 @@ class FileUploadIfNotExist(FileUpload):
             yield stdio.finish()
             return SUCCESS
 
-        yield from super().run()
-        return SUCCESS
+        res = yield super().run()
+        return res
 
 
 class CTest(ShellMixin, CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -138,18 +138,22 @@ class CleanOldFiles(BuildStep):
 class FileUploadIfNotExist(FileUpload):
     name = 'file-upload-if-not-exist'
 
-    @defer.inlineCallbacks
-    def run(self):
-        stdio = yield self.addLog('stdio')
+    def __init__(self, *, deletefn, workdir, **kwargs):
+        super().__init__(**kwargs)
+        # This is a hack to show some sort of progress-like output when uploading
+        self.debug = True
 
+    def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
-            stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
-            yield stdio.finish()
+            # TODO: this requires @defer.inlineCallbacks, but adding that
+            # will make the non-skip-upload path fail because we have no callbacks.
+            # How to resolve? Not sure. Oh well.
+            #
+            # stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
+            # yield stdio.finish()
             return SUCCESS
 
-        stdio.addStdout(f"Preparing to upload to {repr(masterdest)}...")
-        yield stdio.finish()
         return super().run()
 
 

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -12,7 +12,7 @@ from buildbot.steps.worker import CompositeStepMixin
 from twisted.internet import defer
 from twisted.python import log
 
-__all__ = ['CleanOldFiles', 'CTest', 'SetPropertiesFromCMakeCache']
+__all__ = ['CleanOldFiles', 'CTest', 'FileUploadIfNotExist', 'SetPropertiesFromCMakeCache']
 
 
 class SetPropertiesFromCMakeCache(CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -142,7 +142,8 @@ class FileUploadIfNotExist(FileUpload):
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
-            log.msg(f"File {repr(masterdest)} already exists on dest, skipping upload!")
+            stdio = yield self.addLog('stdio')
+            stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
             return SUCCESS
 
         return super().run();

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -10,7 +10,6 @@ from buildbot.process.results import SUCCESS, FAILURE, WARNINGS
 from buildbot.steps.transfer import FileUpload
 from buildbot.steps.worker import CompositeStepMixin
 from twisted.internet import defer
-from twisted.python import log
 
 __all__ = ['CleanOldFiles', 'CTest', 'FileUploadIfNotExist', 'SetPropertiesFromCMakeCache']
 

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -143,9 +143,6 @@ class FileUploadIfNotExist(FileUpload):
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
-            # TODO: this doesn't show up in the worker status webpage --
-            # is there a way to send a status message to the worker log?
-            # (Using twisted.python.log() doesn't work either)
             stdio = yield self.addLog('stdio')
             stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
             return SUCCESS

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -139,7 +139,6 @@ class CleanOldFiles(BuildStep):
 class FileUploadIfNotExist(FileUpload):
     name = 'file-upload-if-not-exist'
 
-    @defer.inlineCallbacks
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -138,7 +138,7 @@ class CleanOldFiles(BuildStep):
 class FileUploadIfNotExist(FileUpload):
     name = 'file-upload-if-not-exist'
 
-    def __init__(self, *, deletefn, workdir, **kwargs):
+    def __init__(self, *, **kwargs):
         super().__init__(**kwargs)
         # This is a hack to show some sort of progress-like output when uploading
         self.debug = True

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -148,6 +148,7 @@ class FileUploadIfNotExist(FileUpload):
             return SUCCESS
 
         yield from super().run()
+        return SUCCESS
 
 
 class CTest(ShellMixin, CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -139,6 +139,7 @@ class CleanOldFiles(BuildStep):
 class FileUploadIfNotExist(FileUpload):
     name = 'file-upload-if-not-exist'
 
+    @defer.inlineCallbacks
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -145,7 +145,7 @@ class FileUploadIfNotExist(FileUpload):
             log.msg(f"File {repr(masterdest)} already exists on dest, skipping upload!")
             return SUCCESS
 
-        return super.run(self);
+        return super().run();
 
 
 class CTest(ShellMixin, CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -148,6 +148,7 @@ class FileUploadIfNotExist(FileUpload):
             yield stdio.finish()
             return SUCCESS
 
+        stdio.addStdout(f"Preparing to upload to {repr(masterdest)}...")
         yield stdio.finish()
         return super().run()
 

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -7,8 +7,10 @@ from typing import Dict, List
 
 from buildbot.process.buildstep import BuildStepFailed, BuildStep, ShellMixin
 from buildbot.process.results import SUCCESS, FAILURE, WARNINGS
+from buildbot.steps.transfer import FileUpload
 from buildbot.steps.worker import CompositeStepMixin
 from twisted.internet import defer
+from twisted.python import log
 
 __all__ = ['CleanOldFiles', 'CTest', 'SetPropertiesFromCMakeCache']
 
@@ -128,6 +130,23 @@ class CleanOldFiles(BuildStep):
 
         yield stdio.finish()
         return status
+
+
+# Like FileUpload, but if the dest file already exists,
+# just log that to stdio and do nothing. Useful when the
+# filename contains (eg) a git commit or SHA that uniquely
+# identifies the file version.
+class FileUploadIfNotExist(FileUpload):
+    name = 'file-upload-if-not-exist'
+
+    @defer.inlineCallbacks
+    def run(self):
+        masterdest = os.path.expanduser(self.masterdest)
+        if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
+            log.msg(f"File {repr(masterdest)} already exists on dest, skipping upload!")
+            return SUCCESS
+
+        return super.run(self);
 
 
 class CTest(ShellMixin, CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -141,15 +141,12 @@ class FileUploadIfNotExist(FileUpload):
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
-            # TODO: this requires @defer.inlineCallbacks, but adding that
-            # will make the non-skip-upload path fail because we have no callbacks.
-            # How to resolve? Not sure. Oh well.
-            #
-            # stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
-            # yield stdio.finish()
+            stdio = yield self.addLog('stdio')
+            stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
+            yield stdio.finish()
             return SUCCESS
 
-        return super().run()
+        yield from super().run()
 
 
 class CTest(ShellMixin, CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -142,6 +142,9 @@ class FileUploadIfNotExist(FileUpload):
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
+            # TODO: this doesn't show up in the worker status webpage --
+            # is there a way to send a status message to the worker log?
+            # (Using twisted.python.log() doesn't work either)
             stdio = yield self.addLog('stdio')
             stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
             return SUCCESS

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -138,18 +138,16 @@ class CleanOldFiles(BuildStep):
 class FileUploadIfNotExist(FileUpload):
     name = 'file-upload-if-not-exist'
 
+    @defer.inlineCallbacks
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:
-            # TODO: this requires @defer.inlineCallbacks, but adding that
-            # will make the non-skip-upload path fail because we have no callbacks.
-            # How to resolve? Not sure. Oh well.
-            #
-            # stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
-            # yield stdio.finish()
+            stdio = yield self.addLog('stdio')
+            stdio.addStdout(f"File {repr(masterdest)} already exists on dest, skipping upload!")
+            yield stdio.finish()
             return SUCCESS
 
-        return super().run()
+        yield from super().run()
 
 
 class CTest(ShellMixin, CompositeStepMixin, BuildStep):

--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -138,11 +138,6 @@ class CleanOldFiles(BuildStep):
 class FileUploadIfNotExist(FileUpload):
     name = 'file-upload-if-not-exist'
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        # This is a hack to show some sort of progress-like output when uploading
-        self.debug = True
-
     def run(self):
         masterdest = os.path.expanduser(self.masterdest)
         if os.path.isfile(masterdest) and os.path.getsize(masterdest) > 0:

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -34,7 +34,7 @@ from buildbot.www.authz.roles import RolesFromUsername
 from buildbot.www.hooks.github import GitHubEventHandler
 from twisted.internet import defer
 
-from custom_steps import CTest, CleanOldFiles, SetPropertiesFromCMakeCache
+from custom_steps import CTest, CleanOldFiles, FileUploadIfNotExist, SetPropertiesFromCMakeCache
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -1039,13 +1039,13 @@ def add_llvm_steps(factory, builder_type, clean_rebuild):
         return render
 
     factory.addStep(
-        FileUpload(name='Upload LLVM package',
-                   workersrc=get_local_packaged_path_r(builder_type),
-                   locks=[performance_lock.access('counting')],
-                   haltOnFailure=True,
-                   workdir=build_dir,
-                   mode=0o644,
-                   masterdest=get_upload_dest_path(builder_type)))
+        FileUploadIfNotExist(name='Upload LLVM package',
+                             workersrc=get_local_packaged_path_r(builder_type),
+                             locks=[performance_lock.access('counting')],
+                             haltOnFailure=True,
+                             workdir=build_dir,
+                             mode=0o644,
+                             masterdest=get_upload_dest_path(builder_type)))
 
     def pkg_version_and_target(path: Path):
         # Archives names are formatted like: llvm-[version]-[arch]-[commit].[ext]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1046,6 +1046,7 @@ def add_llvm_steps(factory, builder_type, clean_rebuild):
                              haltOnFailure=True,
                              workdir=build_dir,
                              mode=0o644,
+                             blocksize=1024 * 1024,
                              masterdest=get_upload_dest_path(builder_type)))
 
     def pkg_version_and_target(path: Path):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1046,7 +1046,6 @@ def add_llvm_steps(factory, builder_type, clean_rebuild):
                              haltOnFailure=True,
                              workdir=build_dir,
                              mode=0o644,
-                             blocksize=1024 * 1024,
                              masterdest=get_upload_dest_path(builder_type)))
 
     def pkg_version_and_target(path: Path):


### PR DESCRIPTION
This saves a lot of time and bandwidth (~10 mins per, ~1.2GB per)