### PR TITLE
Upgrade buildbot for LLVM19

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1784,7 +1784,6 @@ def create_llvm_cmake_factory(builder_type):
     if builder_type.llvm_branch == LLVM_RELEASE_18:
         clean_llvm_rebuild = True
 
-
     add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
 
     return factory

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -792,7 +792,9 @@ def get_llvm_cmake_definitions(builder_type):
 
     # We never build LLVM with sanitizers enabled
     if builder_type.has_ccache():
-        definitions['LLVM_CCACHE_BUILD'] = 'ON'
+        # https://discourse.llvm.org/t/llvm-ccache-build-is-deprecated/68431/2
+        definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
+        definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
 
     return definitions
 
@@ -1782,7 +1784,7 @@ def create_llvm_cmake_factory(builder_type):
     add_env_setup_step(factory, builder_type)
     add_get_llvm_source_steps(factory, builder_type)
 
-    clean_llvm_rebuild = False  # TODO (builder_type.llvm_branch == LLVM_MAIN)
+    clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_MAIN)
 
     add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -793,9 +793,6 @@ def get_llvm_cmake_definitions(builder_type):
     # We never build LLVM with sanitizers enabled
     if builder_type.has_ccache():
         definitions['LLVM_CCACHE_BUILD'] = 'ON'
-        # https://discourse.llvm.org/t/llvm-ccache-build-is-deprecated/68431/2
-        # definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
-        # definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
 
     return definitions
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1780,6 +1780,11 @@ def create_llvm_cmake_factory(builder_type):
 
     clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_MAIN)
 
+    # TODO: temporary during transition
+    if builder_type.llvm_branch == LLVM_RELEASE_18:
+        clean_llvm_rebuild = True
+
+
     add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
 
     return factory

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -794,8 +794,8 @@ def get_llvm_cmake_definitions(builder_type):
     if builder_type.has_ccache():
         definitions['LLVM_CCACHE_BUILD'] = 'ON'
         # https://discourse.llvm.org/t/llvm-ccache-build-is-deprecated/68431/2
-        definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
-        definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
+        # definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
+        # definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
 
     return definitions
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -793,6 +793,9 @@ def get_llvm_cmake_definitions(builder_type):
     # We never build LLVM with sanitizers enabled
     if builder_type.has_ccache():
         definitions['LLVM_CCACHE_BUILD'] = 'ON'
+        # https://discourse.llvm.org/t/llvm-ccache-build-is-deprecated/68431/2
+        definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
+        definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
 
     return definitions
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -67,14 +67,14 @@ Version = namedtuple('Version', ['major', 'minor', 'patch'])
 VersionedBranch = namedtuple('VersionedBranch', ['ref', 'version'])
 
 LLVM_MAIN = 'main'
+LLVM_RELEASE_18 = 'release_18'
 LLVM_RELEASE_17 = 'release_17'
 LLVM_RELEASE_16 = 'release_16'
-LLVM_RELEASE_15 = 'release_15'
 
-LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(18, 0, 0)),
+LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(19, 0, 0)),
+                 LLVM_RELEASE_18: VersionedBranch(ref='release/18.x', version=Version(18, 0, 0)),
                  LLVM_RELEASE_17: VersionedBranch(ref='llvmorg-17.0.6', version=Version(17, 0, 6)),
-                 LLVM_RELEASE_16: VersionedBranch(ref='llvmorg-16.0.6', version=Version(16, 0, 6)),
-                 LLVM_RELEASE_15: VersionedBranch(ref='llvmorg-15.0.7', version=Version(15, 0, 7))}
+                 LLVM_RELEASE_16: VersionedBranch(ref='llvmorg-16.0.6', version=Version(16, 0, 6))}
 
 # At any given time, Halide has a main branch, which supports (at least)
 # the LLVM main branch and the most recent release branch (and maybe one older).
@@ -88,17 +88,17 @@ LLVM_BRANCHES = {LLVM_MAIN: VersionedBranch(ref='main', version=Version(18, 0, 0
 # (Note that there are older releases of Halide that we no longer bother to build/test regularly.)
 
 HALIDE_MAIN = 'main'
+HALIDE_RELEASE_17 = 'release_17'
 HALIDE_RELEASE_16 = 'release_16'
-HALIDE_RELEASE_15 = 'release_15'
 
 _HALIDE_RELEASES = [
+    HALIDE_RELEASE_17,
     HALIDE_RELEASE_16,
-    HALIDE_RELEASE_15,
 ]
 
-HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='main', version=Version(17, 0, 0)),
-                   HALIDE_RELEASE_16: VersionedBranch(ref='release/16.x', version=Version(16, 0, 6)),
-                   HALIDE_RELEASE_15: VersionedBranch(ref='release/15.x', version=Version(15, 0, 1))}
+HALIDE_BRANCHES = {HALIDE_MAIN: VersionedBranch(ref='main', version=Version(18, 0, 0)),
+                   HALIDE_RELEASE_17: VersionedBranch(ref='release/17.x', version=Version(17, 0, 0)),
+                   HALIDE_RELEASE_16: VersionedBranch(ref='release/16.x', version=Version(16, 0, 6))}
 
 # This lists the Halide branch(es) for which we want to build nightlies;
 # it's usually desirable to constrain these to save buildbot time (esp on the slower bots)
@@ -110,9 +110,9 @@ HALIDE_NIGHTLIES = [HALIDE_MAIN]
 # For halide release branches, this is the corresponding llvm release branch; for
 # halide main, it's llvm main.
 LLVM_FOR_HALIDE = {
-    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_17, LLVM_RELEASE_16],
+    HALIDE_MAIN: [LLVM_MAIN, LLVM_RELEASE_18, LLVM_RELEASE_17],
+    HALIDE_RELEASE_17: [LLVM_RELEASE_17],
     HALIDE_RELEASE_16: [LLVM_RELEASE_16],
-    HALIDE_RELEASE_15: [LLVM_RELEASE_15],
 }
 
 # WORKERS
@@ -325,7 +325,7 @@ class BuilderType:
 
     def handles_riscv(self):
         # Only support RISCV on LLVM16 or later.
-        return self.llvm_branch not in [LLVM_RELEASE_15]
+        return True
 
     def handles_hexagon(self):
         return (self.arch == 'x86'
@@ -368,7 +368,7 @@ class BuilderType:
         # as the most robust for testing, so that's all we're set up to test with.
         # (Note that 'Dawn' must be built/installed on the test machines manually;
         # there are no binaries/prebuilts available at this time.)
-        return self.os == 'osx' and self.halide_branch not in [HALIDE_RELEASE_15]
+        return self.os == 'osx'
 
     def has_tflite(self):
         if self.arch == 'x86' and self.bits == 64 and self.os == 'linux':
@@ -1873,13 +1873,13 @@ def prioritize_builders(buildmaster, builders):
         # releases. We care most about the most recently-released llvm so
         # that we have a full set of builds for releases, then llvm main
         # for bisection, then older llvm versions.
-        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_15]:
-            return 2
         if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_16]:
             return 2
-        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_MAIN]:
+        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_RELEASE_17]:
             return 3
-        return 4
+        if builder_type.llvm_branch in LLVM_FOR_HALIDE[HALIDE_MAIN]:
+            return 4
+        return 5
 
     return list(sorted(builders, key=importance))
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1785,11 +1785,7 @@ def create_llvm_cmake_factory(builder_type):
     add_env_setup_step(factory, builder_type)
     add_get_llvm_source_steps(factory, builder_type)
 
-    clean_llvm_rebuild = (builder_type.llvm_branch == LLVM_MAIN)
-
-    # TODO: temporary during transition
-    if builder_type.llvm_branch == LLVM_RELEASE_18:
-        clean_llvm_rebuild = True
+    clean_llvm_rebuild = False  # TODO (builder_type.llvm_branch == LLVM_MAIN)
 
     add_llvm_steps(factory, builder_type, clean_llvm_rebuild)
 


### PR DESCRIPTION
LLVM main is now v19 and a v18 branch has been cut, so:
- Migrate LLVM_MAIN -> 19
- add LLVM_RELEASE_18
- add HALIDE_RELEASE_17
- drop LLVM15 and Halide15 entirely