### PR TITLE
Re-enable CCache for LLVM builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -793,6 +793,9 @@ def get_llvm_cmake_definitions(builder_type):
     # We never build LLVM with sanitizers enabled
     if builder_type.has_ccache():
         definitions['LLVM_CCACHE_BUILD'] = 'ON'
+        # https://discourse.llvm.org/t/llvm-ccache-build-is-deprecated/68431/2
+        definitions['CMAKE_C_COMPILER_LAUNCHER'] = 'ccache'
+        definitions['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
 
     return definitions
 


### PR DESCRIPTION
As of Feb 2023, LLVM_CCACHE_BUILD was quietly deprecated; see https://discourse.llvm.org/t/llvm-ccache-build-is-deprecated/68431/2