### PR TITLE
Always enable clang-tools-extra when building LLVM

### DIFF
--- a/master/custom_steps.py
+++ b/master/custom_steps.py
@@ -227,7 +227,7 @@ class CTest(ShellMixin, CompositeStepMixin, BuildStep):
         if skipped:
             log = yield self.addLog("skipped")
             for test in skipped:
-                log.addStdout(f'{test.findtext("Name")}\n')
+                log.addStdout(f"{test.findtext('Name')}\n")
                 self.write_xml(
                     test,
                     ("./Results/NamedMeasurement[@name='Environment']/Value", log.addHeader),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -891,6 +891,7 @@ def get_llvm_cmake_definitions(builder_type):
         "LLVM_ENABLE_RTTI": "ON",
         "LLVM_ENABLE_ZLIB": "ON",
         "LLVM_TARGETS_TO_BUILD": "X86;ARM;NVPTX;AArch64;Hexagon;PowerPC;WebAssembly;RISCV",
+        "LLVM_ENABLE_PROJECTS": "clang;lld;clang-tools-extra",
     }
 
     for off in _LLVM_OFF_OPTS:
@@ -904,11 +905,6 @@ def get_llvm_cmake_definitions(builder_type):
 
     if builder_type.handles_sanitizers():
         definitions["LLVM_ENABLE_RUNTIMES"] = "compiler-rt;libcxx;libcxxabi;libunwind"
-        # We only need clang-tools-extra if building for sanitizers -- skip them
-        # if the builder will never do this, to save time & space.
-        definitions["LLVM_ENABLE_PROJECTS"] = "clang;lld;clang-tools-extra"
-    else:
-        definitions["LLVM_ENABLE_PROJECTS"] = "clang;lld"
 
     # Some versions of GCC will flood the output with useless warnings about
     # "parameter passing for argument of type foo changed in GCC 7.1" unless

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ cryptography==43.0.0
 pywin32==301; sys_platform == 'win32'
 
 # Development tools
-ruff==0.8.6
+ruff==0.9.1


### PR DESCRIPTION
What it says on the tin.

Fixes halide/Halide#8554