### PR TITLE
Fix formatting for line that is searched by buildbot

### DIFF
--- a/master/buildbot.tac
+++ b/master/buildbot.tac
@@ -20,7 +20,7 @@ logfile = LogFile.fromFullPath(
 
 # note: this line is matched against to check that this is a buildmaster
 # directory; do not edit it.
-application = service.Application("buildmaster")
+application = service.Application('buildmaster')  # fmt: skip
 application.setComponent(ILogObserver, FileLogObserver(logfile).emit)
 
 m = BuildMaster(basedir, configfile, umask)


### PR DESCRIPTION
Lo and behold there was a comment saying not to edit this line. Adding `# fmt: skip` will prevent issues with ruff going forward.

Very annoying that this doesn't trip `buildbot checkconfig`.