### PR TITLE
Enable Vulkan testing for windows on x86-64 w/NVIDIA GPUs.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -349,14 +349,8 @@ class BuilderType:
         return self.arch == "x86" and self.bits == 64 and self.os in ["windows", "linux"]
 
     def handles_vulkan(self):
-        # TODO: https://github.com/halide/Halide/issues/8497
-        return False
-
-        # Stick with Linux on x86-64 for now. Others TBD.
-        # return (self.arch == 'x86'
-        #         and self.bits == 64
-        #         and self.os == 'linux'
-        #         and self.halide_branch in [HALIDE_MAIN, HALIDE_RELEASE_18])
+        # Stick with Windows on x86-64 for now. Others TBD.
+        return self.arch == "x86" and self.bits == 64 and self.os == "windows"
 
     def handles_webgpu(self):
         # At the moment, the WebGPU team recommends the OSX versions of Dawn/Node
@@ -1020,19 +1014,6 @@ def add_env_setup_step(factory, builder_type, enable_ccache=False):
             Interpolate("%(prop:HL_HEXAGON_TOOLS)s/lib/iss"),
         ]
         env["HEXAGON_SDK_ROOT"] = Interpolate("%(prop:HL_HEXAGON_TOOLS)s/../../../..")
-
-    # Force Vulkan validation layer on to catch any driver related errors
-    # ... this enables a suite of diagnostic checks implemented in the Vulkan SDK
-    # that verifies the driver and application conform to the Vulkan runtime
-    # specification. This should not be enabled in production due to the overhead,
-    # but we want to catch any changes in driver behaviour and/or spurious errors that
-    # may be hard to find (but easy to fix if the right error messages are present)
-    #
-    # Nov 7 2024: this validation layer is not resilient to running tests in parallel,
-    # which we do, so we're not going to enable it for now
-    #
-    # if builder_type.has_nvidia() and builder_type.handles_vulkan():
-    #     env['VK_INSTANCE_LAYERS'] = "VK_LAYER_KHRONOS_validation"
 
     if builder_type.os == "osx":
         # Environment variable for turning on Metal API validation


### PR DESCRIPTION
Remove unused validation layer environment setting.