### PR TITLE
Rework BuilderType as HalideBuilder, a BuilderConfig subtype

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -156,7 +156,7 @@ performance_lock = WorkerLock("performance_lock", maxCount=9999)
 # only take place on one worker.
 
 
-class BuilderType:
+class HalideBuilder(BuilderConfig):
     """
     A class to encapsulate the settings for a specific Builder.
     (Do not confuse with CMake's 'BUILD_TYPE', which is something else.)
@@ -188,6 +188,15 @@ class BuilderType:
 
         if self.sanitizer:
             assert self.sanitizer in _SANITIZERS
+
+        compatible_workers = filter(self.is_compatible_with, c["workers"])
+        super().__init__(
+            name=self.builder_label(),
+            workernames=[worker.name for worker in compatible_workers],
+            factory=create_build_factory(self),
+            collapseRequests=True,
+            tags=self.builder_tags(),
+        )
 
     # The armbots aren't configured with Python at all.
     # We don't support the Python bindings on 32-bit at all.
@@ -431,7 +440,6 @@ def get_cmake_options(builder_type, build_dir):
 
 
 def get_ctest_options(builder_type):
-
     if builder_type.sanitizer:
         assert builder_type.handles_sanitizers()
         # No, this won't work, see https://gitlab.kitware.com/cmake/cmake/-/issues/23982 --
@@ -1219,19 +1227,9 @@ def create_builder(arch, bits, os, llvm_branch):
     # sanitizers.extend(_SANITIZERS)
 
     for san in sanitizers:
-        builder_type = BuilderType(arch, bits, os, llvm_branch, san)
-        if san and not builder_type.handles_sanitizers():
+        builder = HalideBuilder(arch, bits, os, llvm_branch, san)
+        if san and not builder.handles_sanitizers():
             continue
-
-        compatible_workers = filter(builder_type.is_compatible_with, c["workers"])
-        builder = BuilderConfig(
-            name=builder_type.builder_label(),
-            workernames=[worker.name for worker in compatible_workers],
-            factory=create_build_factory(builder_type),
-            collapseRequests=True,
-            tags=builder_type.builder_tags(),
-        )
-        builder.builder_type = builder_type
         yield builder
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,6 @@ extra-paths = ["master"]
 [tool.ty.src]
 include = ["master/custom_steps.py"]
 
-[tool.ty.rules]
-# BuilderConfig gets a dynamic `builder_type` attribute attached
-unresolved-attribute = "warn"
-
 [tool.bandit]
 targets = ["master/master.cfg", "master/custom_steps.py", "master/buildbot.tac", "worker/buildbot.tac"]
 skips = [


### PR DESCRIPTION
Removes a workaround we needed for ty