### PR TITLE
Fix ty-check pre-commit hook to resolve buildbot/twisted imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     hooks:
       - id: ty-check
         name: ty
-        entry: uv run ty check master/master.cfg master/custom_steps.py
+        entry: uv run --package master ty check --error-on-warning master/master.cfg master/custom_steps.py
         language: system
         pass_filenames: false
         files: ^master/(master\.cfg|custom_steps\.py)$


### PR DESCRIPTION
Stack (1/5): see subsequent PRs for the rest of the arch/bits cleanup.

## Summary
- Fixes the ty-check pre-commit hook so it can resolve buildbot/twisted imports.