### PR TITLE
Remove macOS workers and workflows from master.cfg

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -146,9 +146,6 @@ class HalideWorker(Worker):
 c["workers"] = [
     HalideWorker("linux-worker-1", max_builds=4, arch="x86", bits=BITS, os="linux"),
     HalideWorker("linux-worker-4", max_builds=4, arch="x86", bits=BITS, os="linux"),
-    HalideWorker("mac-arm-worker-1", max_builds=2, arch="arm", bits=BITS, os="osx"),
-    HalideWorker("mac-x86-worker-2", max_builds=2, arch="x86", bits=BITS, os="osx"),
-    HalideWorker("mac-x86-worker-3", max_builds=2, arch="x86", bits=BITS, os="osx"),
     HalideWorker("win-worker-3", max_builds=1, arch="x86", bits=BITS, os="windows"),
     HalideWorker("win-worker-4", max_builds=1, arch="x86", bits=BITS, os="windows"),
 ]
@@ -194,7 +191,7 @@ class HalideBuilder(BuilderConfig):
     def __init__(self, arch, bits, os, llvm_branch, sanitizer=None):
         assert arch in ["arm", "x86"]
         assert bits == BITS
-        assert os in ["linux", "windows", "osx"]
+        assert os in ["linux", "windows"]
         assert llvm_branch in LLVM_BRANCHES, f"{llvm_branch} not recognized"
 
         self.arch = arch
@@ -238,21 +235,17 @@ class HalideBuilder(BuilderConfig):
     def cmake_preset(self):
         if self.sanitizer:
             return self.sanitizer_preset()
-        os_name = {"linux": "linux", "osx": "macos", "windows": "windows"}[self.os]
+        os_name = {"linux": "linux", "windows": "windows"}[self.os]
         return f"ci-{os_name}-{self.arch}-{self.bits}"
 
     def handles_hexagon(self):
         return self.arch == "x86" and self.os == "linux" and self.llvm_branch == LLVM_MAIN
 
     def handles_wasm(self):
-        return self.llvm_branch == LLVM_MAIN and ((self.arch == "x86" and self.os == "linux") or self.os == "osx")
-
-    def handles_wasm_v8(self):
-        # OSX machines don't have V8 installed
-        return self.handles_wasm() and self.os == "linux"
+        return self.llvm_branch == LLVM_MAIN and self.arch == "x86" and self.os == "linux"
 
     def has_nvidia(self):
-        return self.arch == "x86" and self.os in ["windows", "linux"]
+        return self.arch == "x86"
 
     def handles_d3d12(self):
         return self.arch == "x86" and self.os == "windows"
@@ -261,18 +254,11 @@ class HalideBuilder(BuilderConfig):
         # Stick with Windows on x86-64 for now. Others TBD.
         return self.arch == "x86" and self.os == "windows"
 
-    def handles_webgpu(self):
-        # At the moment, the WebGPU team recommends the OSX versions of Dawn/Node
-        # as the most robust for testing, so that's all we're set up to test with.
-        # (Note that 'Dawn' must be built/installed on the test machines manually;
-        # there are no binaries/prebuilts available at this time.)
-        return self.os == "osx"
-
     def has_tflite(self):
-        return (self.arch == "x86" and self.os == "linux") or (self.arch == "arm" and self.os == "osx")
+        return self.arch == "x86" and self.os == "linux"
 
     def has_ccache(self):
-        return self.os in ["osx", "linux"]
+        return self.os == "linux"
 
     def halide_target(self):
         return f"{self.arch}-{self.bits}-{self.os}"
@@ -534,8 +520,6 @@ def add_env_setup_step(factory, builder_type):
             variables=[
                 "EMSDK",
                 "HL_HEXAGON_TOOLS",
-                "HL_WEBGPU_NATIVE_LIB",
-                "HL_WEBGPU_NODE_BINDINGS",
                 "LD_LIBRARY_PATH",
             ],
         )
@@ -553,11 +537,6 @@ def add_env_setup_step(factory, builder_type):
             Interpolate("%(prop:HL_HEXAGON_TOOLS)s/lib/iss"),
         ]
         env["HEXAGON_SDK_ROOT"] = Interpolate("%(prop:HL_HEXAGON_TOOLS)s/../../../..")
-
-    if builder_type.os == "osx":
-        # Environment variable for turning on Metal API validation
-        # This will have no effect on CPU testing, just Metal testing
-        env["METAL_DEVICE_WRAPPER_TYPE"] = "1"
 
     # Leaving this here (but commented out) in case we need to temporarily
     # disable leak-checking in the future.
@@ -709,12 +688,6 @@ def get_gpu_dsp_targets(builder_type):
     if builder_type.handles_vulkan():
         yield "host-vulkan-vk_int8-vk_int16-vk_int64-vk_float16-vk_float64-vk_v13", False
 
-    if builder_type.handles_webgpu():
-        yield "host-webgpu", False
-
-    if builder_type.os == "osx":
-        yield "host-metal", False
-
     if builder_type.handles_hexagon():
         # All the buildbots use a simulator for HVX, so performance tests
         # won't be useful
@@ -762,11 +735,7 @@ def get_test_labels(builder_type):
 
     # Test a subset of things on GPU/DSP targets, as appropriate
     for t, is_simulator in get_gpu_dsp_targets(builder_type):
-        # TODO(https://github.com/halide/Halide/issues/7420): disable apps for host-gpu until the errors are resolved
-        if t == "host-webgpu":
-            targets[t].extend(["correctness", "generator"])
-        else:
-            targets[t].extend(["correctness", "generator", "apps"])
+        targets[t].extend(["correctness", "generator", "apps"])
         if "cuda" in t:
             targets[t].extend(["autoschedulers_cuda"])
         if "hvx" not in t:
@@ -787,28 +756,18 @@ def get_test_labels(builder_type):
             )
 
     if builder_type.handles_wasm():
-        # TODO: this is a horrid hack. For now, we want to test JIT with both WABT and V8.
+        # TODO: this is a horrid hack. For now, we want to test JIT with WABT, WAMR, and V8.
         # Add as a horrible wart on the target string.
         targets["wasm-32-wasmrt-wasm_simd128/wabt"].extend(["internal", "correctness", "generator", "error", "warning"])
         targets["wasm-32-wasmrt-wasm_simd128/wamr"].extend(["internal", "correctness", "generator", "error", "warning"])
+        targets["wasm-32-wasmrt-wasm_simd128/v8"].extend(["internal", "correctness", "generator", "error", "warning"])
 
         # Do at least some testing with "baseline-only" wasm
         targets["wasm-32-wasmrt-wasm_mvponly/wabt"].extend(["internal", "correctness", "generator", "error", "warning"])
 
-        if builder_type.handles_wasm_v8():
-            # TODO: this is a horrid hack. For now, we want to test JIT with both WABT and V8.
-            # Add as a horrible wart on the target string.
-            targets["wasm-32-wasmrt-wasm_simd128/v8"].extend(
-                ["internal", "correctness", "generator", "error", "warning"]
-            )
-
         # WABT (and thus WASM JIT) can't handle code build with wasm_threads yet,
         # so only test Generator here
         targets["wasm-32-wasmrt-wasm_simd128-wasm_threads"].extend(["generator", "apps"])
-
-    if builder_type.handles_webgpu():
-        # Most apps can't handle wasm builds yet.
-        targets["wasm-32-wasmrt-webgpu"].extend(["generator"])
 
     return targets
 
@@ -953,15 +912,11 @@ def add_test_steps(factory, builder_type):
                 test_set = ", ".join(parallel_test_labels)
 
             # Build up some special cases to exclude
-            exclude_tests = []
-            if builder_type.os == "windows" or builder_type.os == "linux":
-                # TODO: disable lens_blur on windows for now due to
-                #   https://bugs.llvm.org/show_bug.cgi?id=46176
-                #   and also due to Windows testbots having inadequate GPU RAM
-                #   and also due to Linux testbots having inadequate GPU RAM
-                exclude_tests.append("interpolate")
-                exclude_tests.append("lens_blur")
-                exclude_tests.append("unsharp")
+            # TODO: disable lens_blur on windows for now due to
+            #   https://bugs.llvm.org/show_bug.cgi?id=46176
+            #   and also due to Windows testbots having inadequate GPU RAM
+            #   and also due to Linux testbots having inadequate GPU RAM
+            exclude_tests = ["interpolate", "lens_blur", "unsharp"]
 
             if builder_type.os == "linux":
                 # TODO: disable tutorial_lesson_12_using_the_gpu (both C++ and python) on linux
@@ -1069,10 +1024,6 @@ def add_test_steps(factory, builder_type):
                 # https://github.com/halide/Halide/issues/5552
                 exclude_tests.append("lens_blur_filter")
 
-            retry_flags = []
-            if "metal" in halide_target and builder_type.arch == "x86":
-                retry_flags = ["--repeat", "until-pass:5"]
-
             factory.addStep(
                 CTest(
                     name=f"Test apps for {desc}",
@@ -1084,7 +1035,6 @@ def add_test_steps(factory, builder_type):
                     exclude_tests=exclude_tests,
                     exclude_labels=["slow_tests"],
                     verbose=True,
-                    extra_flags=retry_flags,
                     **get_ctest_options(builder_type),
                 )
             )
@@ -1103,7 +1053,7 @@ def create_build_factory(builder_type):
 
 def get_interesting_targets():
     for arch in ["arm", "x86"]:
-        for os in ["linux", "osx", "windows"]:
+        for os in ["linux", "windows"]:
             if arch == "arm" and os == "windows":
                 # No buildbots for windows-on-arm (yet)
                 continue


### PR DESCRIPTION
Stack (2/5): based on #347.

## Summary
- Removes macOS workers and workflows from master.cfg.