### PR TITLE
Remove dead arm code path from master.cfg

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -189,7 +189,7 @@ class HalideBuilder(BuilderConfig):
     """
 
     def __init__(self, arch, bits, os, llvm_branch, sanitizer=None):
-        assert arch in ["arm", "x86"]
+        assert arch == "x86"
         assert bits == BITS
         assert os in ["linux", "windows"]
         assert llvm_branch in LLVM_BRANCHES, f"{llvm_branch} not recognized"
@@ -218,10 +218,10 @@ class HalideBuilder(BuilderConfig):
     # Serialization-via-JIT testing could run anywhere, but we limit it
     # to x64-linux to avoid redundancy.
     def handles_serialization_jit_testing(self):
-        return self.arch == "x86" and self.os == "linux" and self.llvm_branch == LLVM_MAIN
+        return self.os == "linux" and self.llvm_branch == LLVM_MAIN
 
     def handles_sanitizers(self):
-        return self.arch == "x86" and self.os == "linux" and self.llvm_branch == LLVM_MAIN
+        return self.os == "linux" and self.llvm_branch == LLVM_MAIN
 
     def sanitizer_preset(self):
         if self.handles_sanitizers():
@@ -239,23 +239,23 @@ class HalideBuilder(BuilderConfig):
         return f"ci-{os_name}-{self.arch}-{self.bits}"
 
     def handles_hexagon(self):
-        return self.arch == "x86" and self.os == "linux" and self.llvm_branch == LLVM_MAIN
+        return self.os == "linux" and self.llvm_branch == LLVM_MAIN
 
     def handles_wasm(self):
-        return self.llvm_branch == LLVM_MAIN and self.arch == "x86" and self.os == "linux"
+        return self.llvm_branch == LLVM_MAIN and self.os == "linux"
 
     def has_nvidia(self):
-        return self.arch == "x86"
+        return True
 
     def handles_d3d12(self):
-        return self.arch == "x86" and self.os == "windows"
+        return self.os == "windows"
 
     def handles_vulkan(self):
         # Stick with Windows on x86-64 for now. Others TBD.
-        return self.arch == "x86" and self.os == "windows"
+        return self.os == "windows"
 
     def has_tflite(self):
-        return self.arch == "x86" and self.os == "linux"
+        return self.os == "linux"
 
     def has_ccache(self):
         return self.os == "linux"
@@ -727,11 +727,10 @@ def get_test_labels(builder_type):
         targets["host"].extend(["python"])
 
     # Test without SSE4.1 on all x86 systems
-    if builder_type.arch == "x86":
-        t = f"x86-{builder_type.bits}-{builder_type.os}"
-        targets[t].extend(["correctness"])
-        # Also test with SSE4.1 (but nothing else that 'host' might sniff).
-        targets[f"{t}-sse41"].extend(["correctness"])
+    t = f"x86-{builder_type.bits}-{builder_type.os}"
+    targets[t].extend(["correctness"])
+    # Also test with SSE4.1 (but nothing else that 'host' might sniff).
+    targets[f"{t}-sse41"].extend(["correctness"])
 
     # Test a subset of things on GPU/DSP targets, as appropriate
     for t, is_simulator in get_gpu_dsp_targets(builder_type):
@@ -927,11 +926,6 @@ def add_test_steps(factory, builder_type):
                 # so just exclude it when doing ASAN
                 exclude_tests.append("tutorial_lesson_19")
 
-            if builder_type.arch == "arm":
-                # TODO: disable lesson_19 on ARM targets
-                # https://github.com/halide/Halide/issues/5224
-                exclude_tests.append("tutorial_lesson_19")
-
             factory.addStep(
                 CTest(
                     name=f"Test {test_set} {desc}",
@@ -1052,15 +1046,9 @@ def create_build_factory(builder_type):
 
 
 def get_interesting_targets():
-    for arch in ["arm", "x86"]:
-        for os in ["linux", "windows"]:
-            if arch == "arm" and os == "windows":
-                # No buildbots for windows-on-arm (yet)
-                continue
-            if arch == "arm" and os == "linux":
-                # ARM Linux builds run on GitHub Actions instead.
-                continue
-            yield arch, BITS, os
+    # ARM builds run on GitHub Actions; only x86 buildbots remain.
+    for os in ["linux", "windows"]:
+        yield "x86", BITS, os
 
 
 def create_builder(arch, bits, os, llvm_branch):


### PR DESCRIPTION
Stack (4/5): based on #349.

## Summary
- Removes dead arm code path from master.cfg.