### PR TITLE
Bump twisted to 26.4.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "twisted"
-version = "25.5.0"
+version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1070,9 +1070,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/0f/82716ed849bf7ea4984c21385597c949944f0f9b428b5710f79d0afc084d/twisted-25.5.0.tar.gz", hash = "sha256:1deb272358cb6be1e3e8fc6f9c8b36f78eb0fa7c2233d2dbe11ec6fee04ea316", size = 3545725, upload-time = "2025-06-07T09:52:24.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/66/ab7efd8941f0bc7b2bd555b0f0471bff77df4c88e0cc31120c82737fec77/twisted-25.5.0-py3-none-any.whl", hash = "sha256:8559f654d01a54a8c3efe66d533d43f383531ebf8d81d9f9ab4769d91ca15df7", size = 3204767, upload-time = "2025-06-07T09:52:21.428Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Supersedes #346 (dependabot's `twisted` bump to `26.4.0rc2`), which pinned the `pyproject.toml` floor to a pre-release version.
- Stable `twisted` 26.4.0 has since shipped and resolves cleanly now that #359 bumped `pyopenssl`/`cryptography` (previously the TLS extra's requirements blocked resolution, which is why #346's `uv-lock` check was failing).
- Also fixes **CVE-2026-42304** (high severity): DoS in `twisted.names` via crafted DNS compression pointer chains, present in twisted <= 25.5.0.

Closes #346 once merged (dependabot should recognize it's superseded).

## Test plan
- [x] `uv lock --upgrade-package twisted` — resolves to stable 26.4.0
- [x] `ruff check .` / `ty check` — pass
- [ ] CI (uv-lock, bandit, codespell, vulture, buildbot checkconfig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)