### PR TITLE
Build PRs targeting main, recognized GitHub Stacks, or other tracked open PRs

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -16,7 +16,7 @@ from buildbot.changes.filter import ChangeFilter
 from buildbot.config import BuilderConfig
 from buildbot.locks import WorkerLock
 from buildbot.process.factory import BuildFactory
-from buildbot.process.properties import Interpolate, Property, Transform, renderer
+from buildbot.process.properties import Interpolate, Properties, Property, Transform, renderer
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.github import GitHubStatusPush
 from buildbot.reporters.message import MessageFormatterRenderable
@@ -28,6 +28,7 @@ from buildbot.steps.master import SetProperties
 from buildbot.steps.shell import SetPropertyFromCommand, ShellCommand
 from buildbot.steps.source.github import GitHub
 from buildbot.steps.worker import MakeDirectory, SetPropertiesFromEnv, RemoveDirectory
+from buildbot.util import httpclientservice
 from buildbot.worker import Worker
 from buildbot.www.auth import UserPasswordAuth
 from buildbot.www.authz import Authz
@@ -1083,7 +1084,6 @@ c["schedulers"] = [
         change_filter=ChangeFilter(
             category="pull",
             branch_fn=lambda br: br != "main",
-            filter_fn=lambda ch: ch.properties.getProperty("basename") == "main",
         ),
         builderNames=[b1.name for b1 in c["builders"]],
     ),
@@ -1110,6 +1110,72 @@ class SafeGitHubEventHandler(GitHubEventHandler):
             self._log(f"ignoring push event for ref: {ref}")
             return self.skip()
 
+    @staticmethod
+    def _is_release_branch(basename):
+        # Matches the branches accepted by handle_push, above.
+        return bool(re.match(r"^release/\d+\.x$", basename or ""))
+
+    @inlineCallbacks
+    def _base_is_open_pr_head(self, base_repo_full_name, basename):
+        # Fallback for PRs based on another branch that GitHub hasn't
+        # registered as a formal Stack (see _base_branch_is_buildable):
+        # true if `basename` is itself the head of another open PR in the
+        # same repo, i.e. it's an informally-stacked/tracked branch rather
+        # than an untracked one that could vanish without warning.
+        owner = base_repo_full_name.split("/")[0]
+        headers = {"User-Agent": "Buildbot"}
+        if self._token:
+            p = Properties()
+            p.master = self.master
+            p.setProperty("full_name", base_repo_full_name, "change_hook")
+            token = yield p.render(self._token)
+            headers["Authorization"] = "token " + token
+
+        http = yield httpclientservice.HTTPSession(
+            self.master.httpservice,  # ty: ignore[possibly-missing-attribute]
+            self.github_api_endpoint,
+            headers=headers,
+            debug=self.debug,
+            verify=self.verify,
+        )
+        res = yield http.get(
+            f"/repos/{base_repo_full_name}/pulls",
+            params={"head": f"{owner}:{basename}", "state": "open"},
+        )
+        if 200 <= res.code < 300:
+            data = yield res.json()
+            return len(data) > 0
+
+        self._log(f"Failed checking open PRs based on '{basename}': response code {res.code}")
+        return False
+
+    @inlineCallbacks
+    def _base_branch_is_buildable(self, pr):
+        # Buildbot builds refs/pull/<N>/merge, which GitHub computes against
+        # the PR's immediate base branch. For a PR that is part of a
+        # recognized GitHub Stack (the `stack` payload field), that merge
+        # ref is chained through every lower PR's own merge ref, so building
+        # it already transitively tests against `stack.base.ref` (typically
+        # "main") -- confirmed by walking the actual parent commits of
+        # halide/Halide#9249-#9253's refs/pull/*/merge. For a PR based on
+        # some other, untracked branch, the merge ref is just base-tip vs.
+        # head-tip with no relation to main, and that base branch may be
+        # force-pushed or deleted at any time, wasting the build. Only
+        # build PRs against main, recognized stacks, or (as a fallback for
+        # informal/pre-Stacks-feature chains) a base that is itself the
+        # head of another open PR.
+        basename = pr["base"]["ref"]
+        if basename == "main":
+            return True
+        if self._is_release_branch(basename):
+            return False
+        if pr.get("stack"):
+            return True
+
+        buildable = yield self._base_is_open_pr_head(pr["base"]["repo"]["full_name"], basename)
+        return buildable
+
+    @inlineCallbacks
     def handle_pull_request(self, payload, event):
         pr = payload["pull_request"]
         try:
@@ -1125,7 +1191,8 @@ class SafeGitHubEventHandler(GitHubEventHandler):
                     # Pretend it's a 'synchronize' event instead since private buildbot code
                     # rejects review_requested for no clear reason.
                     payload["action"] = "synchronize"
-                return super().handle_pull_request(payload, event)
+                result = yield super().handle_pull_request(payload, event)
+                return result
 
             # Skip external pull requests that originate from untrusted forks
             trusted_repos = (
@@ -1137,8 +1204,15 @@ class SafeGitHubEventHandler(GitHubEventHandler):
                 self._log(f"PR {pr['head']['repo']['full_name']} was skipped due to being external:")
                 return self.skip()
 
+            # Skip PRs targeting a branch that isn't main, a recognized
+            # stack targeting main, or another actively-tracked open PR.
+            if not (yield self._base_branch_is_buildable(pr)):
+                self._log(f"PR {pr['html_url']} was skipped: base '{pr['base']['ref']}' isn't buildable")
+                return self.skip()
+
             self._log(f"PR {pr['html_url']} is being handled normally")
-            return super().handle_pull_request(payload, event)
+            result = yield super().handle_pull_request(payload, event)
+            return result
 
         except KeyError as e:
             self._log(f'missing key "{e}" in malformed payload: {payload}')


### PR DESCRIPTION
## Summary
- Previously, the scheduler only built PRs whose base branch was literally `main`, so a PR whose base is another PR's branch (a stacked PR, e.g. halide/Halide#9253 based on #9251) was silently never scheduled.
- Gating moves into `SafeGitHubEventHandler.handle_pull_request`, where the full PR payload is available. A PR is now built if:
  - its base is `main` (unchanged), or
  - it's part of a recognized GitHub Stack (the `stack` payload field) — confirmed by inspecting the actual `refs/pull/*/merge` commit parents on halide/Halide#9249-#9253 that this ref is chained through every lower PR's own merge ref, so building it already transitively tests against `stack.base.ref` (`main`), or
  - its base is otherwise the head of another open PR in the same repo (an informal/pre-Stacks-feature chain, e.g. a long-lived shared integration branch).
- PRs against `release/N.x` branches are still skipped (unchanged), and anything else (an untracked, possibly short-lived branch) is now explicitly skipped to avoid wasting CI on builds that can be invalidated without warning.

Fixes #148

## Test plan
- [x] `ruff check`, `ty check` pass (also verified via pre-commit hooks on commit)
- [ ] Manually verify via webhook redelivery that a real stacked PR (e.g. halide/Halide#9253) now triggers a build
- [ ] Manually verify a PR based on an untracked scratch branch is still skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)