### PR TITLE
Cancel stale PR builds on new pushes

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -29,6 +29,7 @@ from buildbot.steps.shell import SetPropertyFromCommand, ShellCommand
 from buildbot.steps.source.github import GitHub
 from buildbot.steps.worker import MakeDirectory, RemoveDirectory, SetPropertiesFromEnv
 from buildbot.util import httpclientservice
+from buildbot.util.ssfilter import SourceStampFilter
 from buildbot.worker import Worker
 from buildbot.www.auth import UserPasswordAuth
 from buildbot.www.authz import Authz
@@ -1290,7 +1291,10 @@ c["services"] = [
         ],
         verbose=True,
     ),
-    OldBuildCanceller("build_canceller", []),
+    OldBuildCanceller(
+        "build_canceller",
+        [([b.name for b in c["builders"]], SourceStampFilter(branch_re=r"^refs/pull/"))],
+    ),
 ]
 
 # Disable sending usage data


### PR DESCRIPTION
## Summary
- `OldBuildCanceller` was already imported and instantiated in `master.cfg` but with an empty filter list, making it a no-op.
- Populate the filter to track all builders on any `refs/pull/*` branch, so a new push to a PR cancels older pending/running build requests for that same PR instead of letting them run alongside the new build.
- `main`/`release/*` pushes are untouched (filter is scoped to `refs/pull/`).

## Test plan
- [ ] CI passes
- [ ] After merge/deploy, push a second commit to an open PR and confirm the prior in-flight build for that PR is cancelled (reason: "Build request has been obsoleted by a newer commit") rather than left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)