### PR TITLE
Add --remove-orphans to the deploy step

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -109,4 +109,4 @@ jobs:
             if git diff --name-only "$BEFORE" "$AFTER" | grep -qE '^(master/|master\.sh|pyproject\.toml|uv\.lock)'; then
               BUILD_FLAG="--build"
             fi
-            docker compose up -d $BUILD_FLAG
+            docker compose up -d --remove-orphans $BUILD_FLAG


### PR DESCRIPTION
## Summary
Adds `--remove-orphans` to the deploy script's `docker compose up -d` call.

## Why
\`docker compose up -d\` alone only reconciles services still defined in `docker-compose.yml` -- it leaves containers running for services that were *removed* from the file untouched. This is exactly what happened with #367 (dropping the `pypi`/`netmon` services): both containers kept running unnoticed after that PR merged and deployed successfully, since the deploy step never actually told Docker to remove them. Only surfaced today when a VM reboot restarted them via their own `restart: unless-stopped` policy (`netmon` came back crash-looping, since its image/volumes are gone).

Cleaned up the currently-running orphans manually via `docker compose up -d --remove-orphans` on the host; this PR makes sure the deploy step does that automatically going forward for any future service removals.

## Test plan
- [x] Manually ran `docker compose up -d --remove-orphans` on `buildbot-master` -- confirmed `pypi` and `netmon` containers stopped and removed, `db`/`caddy`/`buildbot` unaffected.