### PR TITLE
Skip CI builds for PRs that only touch build/test-irrelevant files

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -2,6 +2,7 @@
 # ex: set syntax=python:
 # vim: set syntax=python:
 # comment
+import fnmatch
 import logging
 import operator
 import os
@@ -1078,6 +1079,77 @@ def create_builders():
 
 c["builders"] = list(create_builders())
 
+
+# Paths that cannot affect the outcome of this buildbot's CMake configure/build/ctest
+# pipeline (it never invokes the legacy Makefile, builds docs, runs pip packaging, or
+# runs clang-tidy/pre-commit). fnmatch's `*` already matches across `/`, so these behave
+# like `**` globs without needing separate syntax.
+_IGNORABLE_PATH_GLOBS = [
+    # GitHub Actions / GitHub metadata -- this buildbot doesn't use GH Actions at all
+    ".github/*",
+    # Root-level and nested docs
+    "*.md",
+    "doc/*",  # Doxygen docs; WITH_DOCS is OFF by default
+    "LICENSE.txt",
+    # Repo/editor/tooling metadata that never reaches CMake or ctest
+    ".gitignore",
+    ".gitattributes",
+    ".gitmodules",
+    ".gdbinit",
+    ".lldbinit",
+    ".clang-format",
+    ".clang-format-ignore",
+    ".clang-tidy",
+    ".git-blame-ignore-revs",
+    ".devcontainer/*",
+    ".claude/*",
+    ".idea/*",
+    # Coverage / pre-commit / lint configs and scripts (not run by this buildbot)
+    "codecov.yml",
+    ".pre-commit-config.yaml",
+    "run-clang-format.sh",
+    "run-clang-tidy.sh",
+    # pip packaging -- buildbot builds python bindings via CMake+uv directly,
+    # never via packaging/pip's sdist/wheel path
+    "packaging/*",
+    # Legacy `make`-based build -- this buildbot only builds via CMake
+    "Makefile",
+    "Makefile.inc",
+    "*/Makefile",
+    "*/Makefile.inc",
+    "apps/support/*",  # legacy-make helpers only (Makefile.inc, viz_auto.sh)
+    # Apps that apps/CMakeLists.txt never builds
+    "apps/HelloAndroid/*",
+    "apps/HelloAndroidCamera2/*",
+    "apps/HelloiOS/*",
+    "apps/HelloWasm/*",
+    # Dev-only tools/ scripts not wired into tools/CMakeLists.txt or any test target
+    "tools/find_inverse.cpp",
+    "tools/check_cmake_file_lists.py",
+    "tools/check_cmake_style.py",
+    "tools/clang-tidy-filter.sh",
+    "tools/gdbhalide.py",
+    "tools/lldbhalide.py",
+    "tools/Halide.natvis",
+    "tools/halide_config.make.tpl",
+    "tools/makelib.sh",
+    "tools/run-coverage.sh",
+]
+
+
+def _is_ignorable_path(path):
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in _IGNORABLE_PATH_GLOBS)
+
+
+def is_change_important(change):
+    files = change.files
+    if not files:
+        # Fail open: an empty/missing file list (e.g. a rate-limited or
+        # unauthenticated GitHub API call) must never cause a build to be skipped.
+        return True
+    return any(not _is_ignorable_path(f) for f in files)
+
+
 c["schedulers"] = [
     AnyBranchScheduler(
         name="halide-main",
@@ -1085,6 +1157,8 @@ c["schedulers"] = [
             category="pull",
             branch_fn=lambda br: br != "main",
         ),
+        fileIsImportant=is_change_important,
+        onlyImportant=True,
         builderNames=[b1.name for b1 in c["builders"]],
     ),
     ForceScheduler(
@@ -1247,6 +1321,7 @@ c["www"] = {
             "secret": WEBHOOK_TOKEN,
             "skips": [],
             "class": SafeGitHubEventHandler,
+            "token": GITHUB_TOKEN,
         },
     },
 }


### PR DESCRIPTION
## Summary
- Adds a `fileIsImportant` predicate to the `halide-main` scheduler that skips scheduling builds when a PR's changed files are all drawn from a known-safe set that can't affect this buildbot's CMake configure/build/ctest outcome: docs (`*.md`, `doc/**`), `.github/**`, the legacy `Makefile`-based build (never invoked by this buildbot), unreachable demo apps (`apps/Hello*`), and dev-only `tools/` lint/debugger scripts. Full list and rationale in the diff comments.
- Deliberately does **not** exclude `apps/images/**`, `apps/vcpkg/**`, `tools/launch_wasm_test.js`, or `python_bindings/**`/`pyproject.toml` — verified these are load-bearing for this pipeline (sample images read by CMake-built apps, vcpkg overlay ports for `apps/hannk`, wasm generator test launcher, and python bindings actually built/tested here).
- Fails open: an empty/missing changed-files list (e.g. a rate-limited GitHub API call) is always treated as important, so it never silently skips a real change.
- Adds `token=GITHUB_TOKEN` to the GitHub webhook's `change_hook_dialects` config so the PR-files API lookup buildbot already performs is authenticated, reducing the chance of hitting the unauthenticated rate limit.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` — config parses cleanly
- [x] `buildbot checkconfig .` — full config loads successfully
- [x] Standalone assertions against `_is_ignorable_path`/`is_change_important` covering ignorable paths (README.md, `.github/workflows/*.yml`, legacy Makefiles, `apps/HelloWasm/*`), non-ignorable paths (`src/*.cpp`, `apps/images/*`, `apps/vcpkg/*`, `tools/launch_wasm_test.js`, `python_bindings/*`, `CMakeLists.txt`), mixed-file PRs, and the empty-file-list fail-open case — all passed
- [ ] Observe a real PR touching only docs/`.github` to confirm no build is scheduled, and a real PR touching source to confirm builds still run as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)